### PR TITLE
[#42] Automatic PID file path definition

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ pgmoneta was created by the following authors:
 Jesper Pedersen <jesper.pedersen@redhat.com>
 David Fetter <david@fetter.org>
 Will Leinweber <will@bitfission.com>
+Luca Ferrari <fluca1978@gmail.com>

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -48,7 +48,7 @@ See a [sample](./etc/pgmoneta.conf) configuration for running `pgmoneta` on `loc
 | non_blocking | on | Bool | No | Have `O_NONBLOCK` on sockets |
 | backlog | 16 | Int | No | The backlog for `listen()`. Minimum `16` |
 | hugepage | `try` | String | No | Huge page support (`off`, `try`, `on`) |
-| pidfile | | String | No | Path to the PID file |
+| pidfile | | String | No | Path to the PID file. If not specified, it will be automatically set to `unix_socket_dir`/pgmoneta.<host>.pid` where `<host>` is the value of the `host` parameter or `all` if `host = *`.|
 
 ## Server section
 

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -166,7 +166,7 @@ struct configuration
 
    int blocking_timeout;       /**< The blocking timeout in seconds */
    int authentication_timeout; /**< The authentication timeout in seconds */
-   char pidfile[MISC_LENGTH];  /**< File containing the PID */
+   char pidfile[MAX_PATH];     /**< File containing the PID */
 
    char libev[MISC_LENGTH]; /**< Name of libev mode */
    int buffer_size;         /**< Socket buffer size */

--- a/src/main.c
+++ b/src/main.c
@@ -90,8 +90,6 @@ static void reload_configuration(void);
 static void init_receivewals(void);
 static int  create_pidfile(void);
 static void remove_pidfile(void);
-static int  create_lockfile(void);
-static void remove_lockfile(void);
 static void shutdown_ports(void);
 
 struct accept_io
@@ -491,11 +489,6 @@ main(int argc, char **argv)
       exit(1);
    }
 
-   if (create_lockfile())
-   {
-      exit(1);
-   }
-
    pgmoneta_set_proc_title(argc, argv, "main", NULL);
 
    /* Bind Unix Domain Socket */
@@ -663,7 +656,6 @@ main(int argc, char **argv)
    free(management_fds);
 
    remove_pidfile();
-   remove_lockfile();
 
    pgmoneta_stop_logging();
    pgmoneta_destroy_shared_memory(shmem, shmem_size);
@@ -1773,46 +1765,6 @@ remove_pidfile(void)
    {
       unlink(config->pidfile);
    }
-}
-
-static int
-create_lockfile(void)
-{
-   char* f = NULL;
-   int fd;
-
-   f = pgmoneta_append(f, "/tmp/pgmoneta.lock");
-
-   fd = open(f, O_WRONLY | O_CREAT | O_EXCL, 0644);
-   if (fd < 0)
-   {
-      printf("Could not create lock file '%s' due to %s\n", f, strerror(errno));
-      goto error;
-   }
-
-   close(fd);
-
-   free(f);
-
-   return 0;
-
-error:
-
-   free(f);
-
-   return 1;
-}
-
-static void
-remove_lockfile(void)
-{
-   char* f = NULL;
-
-   f = pgmoneta_append(f, "/tmp/pgmoneta.lock");
-
-   unlink(f);
-
-   free(f);
 }
 
 static void


### PR DESCRIPTION
In the case the user does not set the `pidfile` configuration
parameter, the software should define one path itself.
In particular the change makes the `pidfile` equal to the concatenation
of the `unix_socket_dir` (mandatory) and the string `pgmoneta.<host>.pid`
where `<host>` is the value of the `host` configuration parameter
or `all` if `host = *`.

Changed the `pidfile` variable size.

Updated the documentation and the AUTHORS file.

Close #42.