### PR TITLE
[#44] Handle configuration file with no newline at the end.

### DIFF
--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -1279,7 +1279,7 @@ extract_key_value(char* str, char** key, char** value)
       while (str[c] != ' ' && str[c] != '\r' && str[c] != '\n' && c < length)
          c++;
 
-      if (c < length)
+      if (c <= length)
       {
          v = malloc((c - offset) + 1);
          memset(v, 0, (c - offset) + 1);


### PR DESCRIPTION
In the case the last line of the configuration file does not have
a new line, such line is not parsed at all. This means the
key/value pair is not extracted at all.
This could cause misleading errors.

Close #44