### PR TITLE
refactor: move aes features to aes.h(c)

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -30,6 +30,7 @@
 #include <pgmoneta.h>
 #include <logging.h>
 #include <security.h>
+#include <aes.h>
 #include <utils.h>
 
 /* system */

--- a/src/include/aes.h
+++ b/src/include/aes.h
@@ -26,69 +26,26 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PGMONETA_SECURITY_H
-#define PGMONETA_SECURITY_H
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <pgmoneta.h>
-
-#include <stdlib.h>
-
 #include <openssl/ssl.h>
 
 /**
- * Authenticate a user
- * @param server The server
- * @param database The database
- * @param username The username
- * @param password The password
- * @param fd The resulting socket
- * @return AUTH_SUCCESS, AUTH_BAD_PASSWORD or AUTH_ERROR
- */
-int
-pgmoneta_server_authenticate(int server, char* database, char* username, char* password, int* fd);
-
-/**
- * Authenticate a remote management user
- * @param client_fd The descriptor
- * @param address The client address
- * @param client_ssl The client SSL context
+ * Encrypt a string
+ * @param plaintext The string
+ * @param password The master password
+ * @param ciphertext The ciphertext output
+ * @param ciphertext_length The length of the ciphertext
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_remote_management_auth(int client_fd, char* address, SSL** client_ssl);
+pgmoneta_encrypt(char* plaintext, char* password, char** ciphertext, int* ciphertext_length);
 
 /**
- * Connect using SCRAM-SHA256
- * @param username The user name
- * @param password The password
- * @param server_fd The descriptor
- * @param s_ssl The SSL context
+ * Decrypt a string
+ * @param ciphertext The string
+ * @param ciphertext_length The length of the ciphertext
+ * @param password The master password
+ * @param plaintext The plaintext output
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_remote_management_scram_sha256(char* username, char* password, int server_fd, SSL** s_ssl);
-
-/**
- * Get the master key
- * @param masterkey The master key
- * @return 0 upon success, otherwise 1
- */
-int
-pgmoneta_get_master_key(char** masterkey);
-
-/**
- * Is the TLS configuration valid
- * @return 0 upon success, otherwise 1
- */
-int
-pgmoneta_tls_valid(void);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif
+pgmoneta_decrypt(char* ciphertext, int ciphertext_length, char* password, char** plaintext);

--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2022 Red Hat
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <aes.h>
+
+static int derive_key_iv(char* password, unsigned char* key, unsigned char* iv);
+static int aes_encrypt(char* plaintext, unsigned char* key, unsigned char* iv, char** ciphertext, int* ciphertext_length);
+static int aes_decrypt(char* ciphertext, int ciphertext_length, unsigned char* key, unsigned char* iv, char** plaintext);
+
+// [public]
+int
+pgmoneta_encrypt(char* plaintext, char* password, char** ciphertext, int* ciphertext_length)
+{
+   unsigned char key[EVP_MAX_KEY_LENGTH];
+   unsigned char iv[EVP_MAX_IV_LENGTH];
+
+   memset(&key, 0, sizeof(key));
+   memset(&iv, 0, sizeof(iv));
+
+   if (derive_key_iv(password, key, iv) != 0)
+   {
+      return 1;
+   }
+
+   return aes_encrypt(plaintext, key, iv, ciphertext, ciphertext_length);
+}
+
+// [public]
+int
+pgmoneta_decrypt(char* ciphertext, int ciphertext_length, char* password, char** plaintext)
+{
+   unsigned char key[EVP_MAX_KEY_LENGTH];
+   unsigned char iv[EVP_MAX_IV_LENGTH];
+
+   memset(&key, 0, sizeof(key));
+   memset(&iv, 0, sizeof(iv));
+
+   if (derive_key_iv(password, key, iv) != 0)
+   {
+      return 1;
+   }
+
+   return aes_decrypt(ciphertext, ciphertext_length, key, iv, plaintext);
+}
+
+// [private]
+static int
+derive_key_iv(char* password, unsigned char* key, unsigned char* iv)
+{
+
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+   OpenSSL_add_all_algorithms();
+#endif
+
+   if (!EVP_BytesToKey(EVP_aes_256_cbc(), EVP_sha1(), NULL,
+                       (unsigned char*) password, strlen(password), 1,
+                       key, iv))
+   {
+      return 1;
+   }
+
+   return 0;
+}
+
+// [private]
+static int
+aes_encrypt(char* plaintext, unsigned char* key, unsigned char* iv, char** ciphertext, int* ciphertext_length)
+{
+   EVP_CIPHER_CTX* ctx = NULL;
+   int length;
+   size_t size;
+   unsigned char* ct = NULL;
+   int ct_length;
+
+   if (!(ctx = EVP_CIPHER_CTX_new()))
+   {
+      goto error;
+   }
+
+   if (EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv) != 1)
+   {
+      goto error;
+   }
+
+   size = strlen(plaintext) + EVP_CIPHER_block_size(EVP_aes_256_cbc());
+   ct = malloc(size);
+   memset(ct, 0, size);
+
+   if (EVP_EncryptUpdate(ctx,
+                         ct, &length,
+                         (unsigned char*)plaintext, strlen((char*)plaintext)) != 1)
+   {
+      goto error;
+   }
+
+   ct_length = length;
+
+   if (EVP_EncryptFinal_ex(ctx, ct + length, &length) != 1)
+   {
+      goto error;
+   }
+
+   ct_length += length;
+
+   EVP_CIPHER_CTX_free(ctx);
+
+   *ciphertext = (char*)ct;
+   *ciphertext_length = ct_length;
+
+   return 0;
+
+error:
+   if (ctx)
+   {
+      EVP_CIPHER_CTX_free(ctx);
+   }
+
+   free(ct);
+
+   return 1;
+}
+
+// [private]
+static int
+aes_decrypt(char* ciphertext, int ciphertext_length, unsigned char* key, unsigned char* iv, char** plaintext)
+{
+   EVP_CIPHER_CTX* ctx = NULL;
+   int plaintext_length;
+   int length;
+   size_t size;
+   char* pt = NULL;
+
+   if (!(ctx = EVP_CIPHER_CTX_new()))
+   {
+      goto error;
+   }
+
+   if (EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv) != 1)
+   {
+      goto error;
+   }
+
+   size = ciphertext_length + EVP_CIPHER_block_size(EVP_aes_256_cbc());
+   pt = malloc(size);
+   memset(pt, 0, size);
+
+   if (EVP_DecryptUpdate(ctx,
+                         (unsigned char*)pt, &length,
+                         (unsigned char*)ciphertext, ciphertext_length) != 1)
+   {
+      goto error;
+   }
+
+   plaintext_length = length;
+
+   if (EVP_DecryptFinal_ex(ctx, (unsigned char*)pt + length, &length) != 1)
+   {
+      goto error;
+   }
+
+   plaintext_length += length;
+
+   EVP_CIPHER_CTX_free(ctx);
+
+   pt[plaintext_length] = 0;
+   *plaintext = pt;
+
+   return 0;
+
+error:
+   if (ctx)
+   {
+      EVP_CIPHER_CTX_free(ctx);
+   }
+
+   free(pt);
+
+   return 1;
+}

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -33,6 +33,7 @@
 #include <security.h>
 #include <shmem.h>
 #include <utils.h>
+#include <aes.h>
 
 /* system */
 #include <errno.h>


### PR DESCRIPTION
Move aes features from security.h(c) to aes.h(c), fix correlated includes.
This commit bring no new feature to the codebase.

Refs: #56 #78