### PR TITLE
[#123] Receive and consume copy stream messages

### DIFF
--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -37,6 +37,18 @@ extern "C" {
 
 #include <stdlib.h>
 
+/** @struct
+ * Defines a streaming buffer
+ */
+struct stream_buffer
+{
+   char* buffer;  /**< allocated buffer holding streaming data */
+   int size;      /**< allocated buffer size */
+   int start;     /**< offset to the first unconsumed data in buffer */
+   int end;       /**< offset to the first position after available data */
+   int cursor;    /**< next byte to consume */
+} __attribute__ ((aligned (64)));
+
 /**
  * Initialize a memory segment for the process local message structure
  */
@@ -95,6 +107,29 @@ pgmoneta_memory_dynamic_destroy(void* data);
  */
 void*
 pgmoneta_memory_dynamic_append(void* orig, size_t orig_size, void* append, size_t append_size, size_t* new_size);
+
+/**
+ * Initialize a stream buffer
+ * @param buffer The stream buffer to be initialized
+ */
+void
+pgmoneta_memory_stream_buffer_init(struct stream_buffer** buffer);
+
+/**
+ * Enlarge the buffer, doesn't guarantee success
+ * @param buffer The stream buffer
+ * @param bytes_needed The number of bytes needed
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_memory_stream_buffer_enlarge(struct stream_buffer* buffer, int bytes_needed);
+
+/**
+ * Free a stream buffer
+ * @param buffer The stream buffer to be freed
+ */
+void
+pgmoneta_memory_stream_buffer_free(struct stream_buffer* buffer);
 
 #ifdef __cplusplus
 }

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 #include <pgmoneta.h>
+#include <memory.h>
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -384,6 +385,27 @@ pgmoneta_free_query_response(struct query_response* response);
  */
 void
 pgmoneta_query_response_debug(struct query_response* response);
+
+/**
+ * Read the copy stream into the streaming buffer in blocking mode
+ * @param socket The socket
+ * @param buffer The streaming buffer
+ * @return 1 upon success, 0 if no data received, otherwise 2
+ */
+int
+pgmoneta_read_copy_stream(int socket, struct stream_buffer* buffer);
+
+/**
+ * Consume the data in copy stream buffer, get the next valid message in the copy stream buffer
+ * Recognized message types are DataRow, CopyOutResponse, CopyInResponse, CopyData, CopyDone, CopyFail and ErrorResponse
+ * Other message will be ignored
+ * @param socket The socket
+ * @param buffer The stream buffer
+ * @param message [out] The message
+ * @return 1 upon success, 0 if no data to consume, otherwise 2
+ */
+int
+pgmoneta_consume_copy_stream(int socket, struct stream_buffer* buffer, struct message** message);
 
 #ifdef __cplusplus
 }

--- a/src/libpgmoneta/memory.c
+++ b/src/libpgmoneta/memory.c
@@ -159,3 +159,44 @@ pgmoneta_memory_dynamic_append(void* orig, size_t orig_size, void* append, size_
 
    return d;
 }
+
+void
+pgmoneta_memory_stream_buffer_init(struct stream_buffer** buffer)
+{
+   struct stream_buffer* b = malloc(sizeof(struct stream_buffer));
+   b->size = DEFAULT_BUFFER_SIZE;
+   b->start = b->end = b->cursor = 0;
+   b->buffer = malloc(DEFAULT_BUFFER_SIZE);
+   *buffer = b;
+}
+
+int
+pgmoneta_memory_stream_buffer_enlarge(struct stream_buffer* buffer, int bytes_needed)
+{
+   char* new_buf = NULL;
+   // subtract the space we have left to avoid wasting space
+   bytes_needed -= (buffer->size - buffer->end);
+   buffer->size += bytes_needed;
+   new_buf = realloc(buffer->buffer, buffer->size);
+   if (new_buf == NULL)
+   {
+      return 1;
+   }
+   buffer->buffer = new_buf;
+   return 0;
+}
+
+void
+pgmoneta_memory_stream_buffer_free(struct stream_buffer* buffer)
+{
+   if (buffer == NULL)
+   {
+      return;
+   }
+   if (buffer->buffer != NULL)
+   {
+      free(buffer->buffer);
+      buffer->buffer = NULL;
+   }
+   free(buffer);
+}


### PR DESCRIPTION
Finally, I resolved the bug (that was a stupid mistake)! This PR cosists of two functionalities:

One to read data from server into a buffer, it will left shift consumed data to reuse space, I tested locally and it was perfect, did not once exceed its original buffer size. For the sake of simplicity I just use the default buffer size (65535B), in the future we could have some configuration for the user to specify how big they want the stream buffer to be.

Another one is to parse data in the buffer, consume data into messages. It will block and return one message by another, and it will filter out those messages we are not interested in the stream replication process. And it will automatically read new data if current message is not complete.

I tested locally and it works perfectly, just as the protocal says, two DataRow messages, one CopyOutResponse then a bunch of CopyData, then finishes by a CopyDone message.

Let me know if you have questions.