### PR TITLE
[#123] Receive and extract base backup archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       run: sudo apt install -y liblz4-dev
     - name: Install libssh
       run: sudo apt install -y libssh-dev
+    - name: Install libarchive
+      run: sudo apt install -y libarchive-dev
     - name: Install libcurl
       run: sudo apt install -y libcurl4-nss-dev
     - name: Install clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,13 @@ else ()
   message(FATAL_ERROR "OpenSSL needed")
 endif()
 
+find_package(LibArchive)
+if (LibArchive_FOUND)
+  message(STATUS "libarchive found")
+else ()
+  message(FATAL_ERROR "libarchive needed")
+endif()
+
 find_package(Rst2man)
 if (RST2MAN_FOUND)
   message(STATUS "rst2man found")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Don't forget to indicate your pgmoneta version.
 You can use the follow command, if you are using a [Fedora](https://getfedora.org/) based platform:
 
 ```
-dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic libcurl libcurl-devel bzip2 bzip2-devel
+dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic libcurl libcurl-devel bzip2 bzip2-devel libarchive libarchive-devel
 ```
 
 in order to get the necessary dependencies.

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ See [Architecture](./doc/ARCHITECTURE.md) for the architecture of `pgmoneta`.
 * [rst2man](https://docutils.sourceforge.io/)
 * [libssh](https://www.libssh.org/)
 * [libcurl](https://curl.se/libcurl/)
+* [libarchive](http://www.libarchive.org/)
 
 ```sh
-dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel libcurl libcurl-devel python3-docutils libatomic bzip2 bzip2-devel
+dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel libcurl libcurl-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel
 ```
 
 Alternative [clang 8+](https://clang.llvm.org/) can be used.

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Backup is handled in [backup.h](../src/include/backup.h) ([backup.c](../src/libp
 Restore is handled in [restore.h](../src/include/restore.h) ([restore.c](../src/libpgmoneta/restore.c)) with linking
 handled in [link.h](../src/include/link.h) ([link.c](../src/libpgmoneta/link.c)).
 
-Archive is handled in [archive.h](../src/include/archive.h) ([archive.c](../src/libpgmoneta/archive.c)) backed by
+Archive is handled in [achv.h](../src/include/achv.h) ([archive.c](../src/libpgmoneta/archive.c)) backed by
 restore.
 
 Write-Ahead Log is handled in [wal.h](../src/include/wal.h) ([wal.c](../src/libpgmoneta/wal.c)).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     ${SYSTEMD_INCLUDE_DIRS}
     ${LIBSSH_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}
+    ${LibArchive_INCLUDE_DIRS}
   )
 
   #
@@ -45,6 +46,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     ${LIBSSH_LIBRARIES}
     ${CURL_LIBRARIES}
     ${LIBATOMIC_LIBRARY}
+    ${LibArchive_LIBRARY}
   )
 
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
@@ -69,6 +71,7 @@ else()
     ${OPENSSL_INCLUDE_DIR}
     ${LIBSSH_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}
+    ${LibArchive_INCLUDE_DIRS}
   )
 
   #
@@ -84,6 +87,7 @@ else()
     ${OPENSSL_SSL_LIBRARY}
     ${LIBSSH_LIBRARIES}
     ${CURL_LIBRARIES}
+    ${LibArchive_LIBRARIES}
   )
 
   if (${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")

--- a/src/include/achv.h
+++ b/src/include/achv.h
@@ -48,6 +48,15 @@ extern "C" {
 void
 pgmoneta_archive(int client_fd, int server, char* backup_id, char* position, char* directory, char** argv);
 
+/**
+ * Extract from a tar file to a given directory
+ * @param file_path The tar file path
+ * @param destination The destination to extract to
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_extract_tar_file(char* file_path, char* destination);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -33,8 +33,9 @@
 extern "C" {
 #endif
 
-#include <pgmoneta.h>
 #include <memory.h>
+#include <pgmoneta.h>
+#include <tablespace.h>
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -416,6 +417,42 @@ pgmoneta_consume_copy_stream(int socket, struct stream_buffer* buffer, struct me
  */
 int
 pgmoneta_consume_data_row_messages(int socket, struct stream_buffer* buffer, struct query_response** response);
+
+/**
+ * Receive backup tar files from the copy stream and write to disk
+ * This functionality is for server version < 15
+ * @param socket The socket
+ * @param buffer The stream buffer
+ * @param basedir The base directory for the backup data
+ * @param tablespaces The user level tablespaces
+ * @param version The server version
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_receive_archive_files(int socket, struct stream_buffer* buffer, char* basedir, struct tablespace* tablespaces, int version);
+
+/**
+ * Receive backup tar files from the copy stream and write to disk
+ * This functionality is for server version >= 15
+ * @param socket The socket
+ * @param buffer The stream buffer
+ * @param basedir The base directory for the backup data
+ * @param tablespaces The user level tablespaces
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_receive_archive_stream(int socket, struct stream_buffer* buffer, char* basedir, struct tablespace* tablespaces);
+
+/**
+ * Receive mainfest file from the copy stream and write to disk
+ * This functionality is for server version >= 13,
+ * @param socket The socket
+ * @param buffer The stream buffer
+ * @param basedir The base directory for the manifest
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_receive_manifest_file(int socket, struct stream_buffer* buffer, char* basedir);
 
 #ifdef __cplusplus
 }

--- a/src/include/tablespace.h
+++ b/src/include/tablespace.h
@@ -38,9 +38,10 @@ extern "C" {
 
 struct tablespace
 {
-   char* name;
-   char* path;
-   struct tablespace* next;
+   char* name;              /**< The name of the table space */
+   char* path;              /**< The path of the table space in the original server */
+   unsigned int oid;        /**< [[maybe_unused]] The oid of the table space */
+   struct tablespace* next; /**< The pointer to the next table space */
 };
 
 /**

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -175,6 +175,15 @@ void
 pgmoneta_write_string(void* data, char* s);
 
 /**
+ * Compare two strings
+ * @param str1 The first string
+ * @param str2 The second string
+ * @return true if the strings are the same, otherwise false
+ */
+bool
+pgmoneta_compare_string(const char* str1, const char* str2);
+
+/**
  * Is the machine big endian ?
  * @return True if big, otherwise false for little
  */

--- a/src/libpgmoneta/server.c
+++ b/src/libpgmoneta/server.c
@@ -282,7 +282,7 @@ pgmoneta_server_get_version(int socket, int server)
    config->servers[server].version = atoi(response->tuples->data[0]);
 
    pgmoneta_free_query_response(response);
-   pgmoneta_free_message(query_msg);
+   pgmoneta_free_copy_message(query_msg);
 
    return 0;
 error:

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -70,7 +70,6 @@ static char* get_server_basepath(int server);
 
 static int copy_tablespaces(char* from, char* to, char* base, char* server, char* id, struct backup* backup);
 
-
 int32_t
 pgmoneta_get_request(struct message* msg)
 {
@@ -401,6 +400,20 @@ void
 pgmoneta_write_string(void* data, char* s)
 {
    memcpy(data, s, strlen(s));
+}
+
+bool
+pgmoneta_compare_string(const char* str1, const char* str2)
+{
+   if (str1 == NULL && str2 == NULL)
+   {
+      return true;
+   }
+   if ((str1 == NULL && str2 != NULL) || (str1 != NULL && str2 == NULL))
+   {
+      return false;
+   }
+   return strcmp(str1, str2) == 0;
 }
 
 bool

--- a/src/main.c
+++ b/src/main.c
@@ -29,7 +29,7 @@
 /* pgmoneta */
 #include <pgmoneta.h>
 #include <aes.h>
-#include <archive.h>
+#include <achv.h>
 #include <backup.h>
 #include <bzip2_compression.h>
 #include <configuration.h>


### PR DESCRIPTION
Finally! This is our native implementation of receiving and extracting the basebackup and the mainfest postgres server sends us. It uses libarchive to do the tar file extraction. We also support tablespaces now, for convenience I had to add the oid feild to the tablespace struct. So that I can keep track of and update the symbolic link easily. Let me know if you find it not ok. 

This implementation only works for server with version < 15, which sends tar file for each tablespaces separately. For server whose version >= 15, everything is sent in one backup stream so it's slightly different. 

I also have hesitations on whether to extract some parts into functions or if I'm putting the functionality in the right file. Feel free to give suggestions.

The correctness has be manually verified. But I couldn't really put it to test until in the end I also implement the xlog streaming.