### PR TITLE
[#158] extract and log CopyFail/ErrorResponse message

### DIFF
--- a/src/include/message.h
+++ b/src/include/message.h
@@ -138,6 +138,20 @@ void
 pgmoneta_log_message(struct message* msg);
 
 /**
+ * Log a COPY-failure message
+ * @param msg The copyfail message
+ */
+void
+pgmoneta_log_copyfail_message(struct message* msg);
+
+/**
+ * Log an Error Response message
+ * @param msg The Error Response message
+ */
+void
+pgmoneta_log_error_response_message(struct message* msg);
+
+/**
  * Write a notice message
  * @param ssl The SSL struct
  * @param socket The socket descriptor

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -82,6 +82,16 @@ int
 pgmoneta_extract_message(char type, struct message* msg, struct message** extracted);
 
 /**
+ * Extract a error message field from a message
+ * @param type The error message field type to be extracted
+ * @param msg The error message
+ * @param extracted The resulting error message field
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_extract_error_fields(char type, struct message* msg, char** extracted);
+
+/**
  * Extract a message based on an offset
  * @param offset The offset
  * @param data The data segment

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -221,6 +221,49 @@ pgmoneta_extract_message(char type, struct message* msg, struct message** extrac
    return 1;
 }
 
+int
+pgmoneta_extract_error_fields(char type, struct message* msg, char** extracted)
+{
+   size_t offset = 0;
+   char* result = NULL;
+   *extracted = NULL;
+
+   if (msg == NULL || msg->kind != 'E')
+   {
+      return 1;
+   }
+
+   while (result == NULL && offset < msg->length)
+   {
+      char t = (char)pgmoneta_read_byte(msg->data + offset);
+
+      if (t == '\0')
+      {
+         return 1;
+      }
+
+      size_t field_len = strlen(msg->data + offset + 1) + 1;
+
+      if (type == t)
+      {
+         result = (char*) malloc(field_len);
+         memset(result, 0, field_len);
+         strcpy(result, msg->data + offset + 1);
+
+         *extracted = result;
+
+         return 0;
+      }
+      else
+      {
+         offset += 1;
+         offset += strlen(msg->data + offset) + 1;
+      }
+   }
+
+   return 1;
+}
+
 size_t
 pgmoneta_extract_message_offset(size_t offset, void* data, struct message** extracted)
 {

--- a/src/libpgmoneta/wal.c
+++ b/src/libpgmoneta/wal.c
@@ -197,9 +197,16 @@ pgmoneta_wal(int srv, char** argv)
          goto error;
       }
 
-      if (msg == NULL || msg->kind == 'E' || msg->kind == 'f')
+      if (msg == NULL)
       {
-         pgmoneta_log_message(msg);
+         pgmoneta_log_error("wal: received NULL message");
+         goto error;
+      }
+
+      if (msg->kind == 'E' || msg->kind == 'f')
+      {
+         pgmoneta_log_copyfail_message(msg);
+         pgmoneta_log_error_response_message(msg);
          goto error;
       }
       if (msg->kind == 'd')


### PR DESCRIPTION
ErrorResponse message usually consists of multiple fields, each with a type and a string, referring to https://www.postgresql.org/docs/current/protocol-error-fields.html.

Aside from the fields that tell you what the error is, postgres also tells you things like where in the source code the error was reported. It would be useful for debugging but messy and confusing for users. So I only log the "always present" fields (message, severity and error code) in ERROR level and leave the rest to DEBUG level.

At INFO level above, we shall see:
![9dfdd20e2013c62f85ab87e7250e62a](https://github.com/pgmoneta/pgmoneta/assets/89931362/37d368ef-65b4-41ee-a267-c88d54fa7bbd)

At DEBUG level, we'll see:
![a17373aad779e86e42c6266312cd848](https://github.com/pgmoneta/pgmoneta/assets/89931362/00a9a137-b711-48a5-9f65-3865ce65fa07)
