### PR TITLE
[#157] verify replication slot upon startup if it is configured

### DIFF
--- a/src/include/message.h
+++ b/src/include/message.h
@@ -369,6 +369,15 @@ int
 pgmoneta_create_replication_slot_message(char* create_slot_name, struct message** msg);
 
 /**
+ * Create a message to search if a replication slot exists
+ * @param slot_name The name of the slot
+ * @param msg The resulting message
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_create_search_replication_slot_message(char* slot_name, struct message** msg);
+
+/**
  * Send a CopyDone message
  * @param socket The socket
  * @return 0 upon success, otherwise 1

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -109,6 +109,10 @@ extern "C" {
 #define CREATE_SLOT_YES       1
 #define CREATE_SLOT_NO        2
 
+#define VALID_SLOT            0
+#define SLOT_NOT_FOUND        1
+#define INCORRECT_SLOT_TYPE       2
+
 #define likely(x)    __builtin_expect (!!(x), 1)
 #define unlikely(x)  __builtin_expect (!!(x), 0)
 

--- a/src/libpgmoneta/message.c
+++ b/src/libpgmoneta/message.c
@@ -913,6 +913,36 @@ pgmoneta_create_replication_slot_message(char* create_slot_name, struct message*
 }
 
 int
+pgmoneta_create_search_replication_slot_message(char* slot_name, struct message** msg)
+{
+   char cmd[1024];
+   struct message* m = NULL;
+   size_t size;
+
+   memset(&cmd[0], 0, sizeof(cmd));
+
+   snprintf(cmd, sizeof(cmd), "SELECT slot_name, slot_type FROM pg_replication_slots WHERE slot_name = '%s';", slot_name);
+
+   size = 1 + 4 + strlen(cmd) + 1;
+
+   m = (struct message*)malloc(sizeof(struct message));
+   m->data = malloc(size);
+
+   memset(m->data, 0, size);
+
+   m->kind = 'Q';
+   m->length = size;
+
+   pgmoneta_write_byte(m->data, 'Q');
+   pgmoneta_write_int32(m->data + 1, size - 1);
+   memcpy(m->data + 5, &cmd[0], strlen(cmd));
+
+   *msg = m;
+
+   return MESSAGE_STATUS_OK;
+}
+
+int
 pgmoneta_send_copy_done_message(int socket)
 {
    struct message* msg = NULL;


### PR DESCRIPTION
Hi @jesperpedersen , please note that this is still a draft because there's tiny problem there. pgmoneta is able to verify the replication slot and exit(1) if it's wrong. But it seems that the pid file is not removed. As a result, the next time it cannot startup even when the config is correct. Here's the log:
```
2023-12-11 19:44:09 FATAL main.c:1954 PID file [/tmp//pgmoneta.all.pid] exists, is there another instance running ?
```
I checked the pid inside /tmp/pgmoneta.all.pid, and seems that there's no corresponding process. Should I manually remove the file before exit, or is there anything I'm doing not quite right?