### PR TITLE
[#164] Reuse message buffer to hold consumed messages

### DIFF
--- a/src/include/message.h
+++ b/src/include/message.h
@@ -461,6 +461,26 @@ int
 pgmoneta_consume_copy_stream(int socket, struct stream_buffer* buffer, struct message** message);
 
 /**
+ * Consume the data in copy stream buffer similar to pgmoneta_consume_copy_stream.
+ * Instead of creating a new message each time, reuse the same message buffer each time
+ * Must be used with pgmoneta_consume_copy_stream_end
+ * @param socket The socket
+ * @param buffer The stream buffer
+ * @param message The message buffer
+ * @return 1 upon success, 0 if no data to consume, otherwise 2
+ */
+int
+pgmoneta_consume_copy_stream_start(int socket, struct stream_buffer* buffer, struct message* message);
+
+/**
+ * Finish consuming the buffer, prepare for the next message to be consumed
+ * @param buffer The stream buffer
+ * @param message The message buffer
+ */
+void
+pgmoneta_consume_copy_stream_end(struct stream_buffer* buffer, struct message* message);
+
+/**
  * Receive and parse the DataRow messages into tuples
  * @param socket The socket
  * @param buffer The stream buffer holding the messages

--- a/src/libpgmoneta/backup.c
+++ b/src/libpgmoneta/backup.c
@@ -38,6 +38,7 @@
 
 /* system */
 #include <stdatomic.h>
+#include <unistd.h>
 #include <stdlib.h>
 #include <time.h>
 


### PR DESCRIPTION
Sorry for the delay.. I tested it out and seems that after replacing the old pgmoneta_cosume_copy_stream, both wal and base backup are working fine. And we reduced a lot of mallocs:

![62cf36c3f2c15a61a5aaf07745e37c1](https://github.com/pgmoneta/pgmoneta/assets/89931362/f1081372-29cc-4791-aeac-2191f9fa4f5f)
