### PR TITLE
set message buffer payload to NULL before freeing

### DIFF
--- a/src/libpgmoneta/wal.c
+++ b/src/libpgmoneta/wal.c
@@ -392,6 +392,9 @@ pgmoneta_wal(int srv, char** argv)
 
    pgmoneta_free_copy_message(identify_system_msg);
    pgmoneta_free_copy_message(start_replication_msg);
+   if (msg != NULL) {
+       msg->data = NULL;
+   }
    pgmoneta_free_copy_message(msg);
    pgmoneta_free_query_response(identify_system_response);
    pgmoneta_memory_stream_buffer_free(buffer);
@@ -416,6 +419,9 @@ error:
    }
    pgmoneta_free_copy_message(identify_system_msg);
    pgmoneta_free_copy_message(start_replication_msg);
+   if (msg != NULL) {
+       msg->data = NULL;
+   }
    pgmoneta_free_copy_message(msg);
    pgmoneta_free_query_response(identify_system_response);
    pgmoneta_memory_stream_buffer_free(buffer);


### PR DESCRIPTION
Since our message buffer is just pointing to the middle of some malloced space, there's no point of freeing the payload. We need to set it to NULL or it'll cause invalid free.