### PR TITLE
[#187] Make WAL streaming follow timeline change

### DIFF
--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -235,7 +235,7 @@ pgmoneta_extract_message(char type, struct message* msg, struct message** extrac
 int
 pgmoneta_extract_error_fields(char type, struct message* msg, char** extracted)
 {
-   size_t offset = 0;
+   size_t offset = 1 + 4;
    char* result = NULL;
    *extracted = NULL;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1873,6 +1873,8 @@ init_replication_slots(void)
 
       if (usr != -1)
       {
+         create_slot = config->servers[srv].create_slot == CREATE_SLOT_YES ||
+                       (config->create_slot == CREATE_SLOT_YES && config->servers[srv].create_slot != CREATE_SLOT_NO);
          socket = 0;
          auth = pgmoneta_server_authenticate(srv, "postgres", config->users[usr].username, config->users[usr].password, false, &ssl, &socket);
 
@@ -1935,9 +1937,6 @@ init_replication_slots(void)
 
          if (create_slot && slot_status == SLOT_NOT_FOUND && strlen(config->servers[srv].wal_slot) > 0)
          {
-            create_slot = config->servers[srv].create_slot == CREATE_SLOT_YES ||
-                          (config->create_slot == CREATE_SLOT_YES && config->servers[srv].create_slot != CREATE_SLOT_NO);
-
             auth = pgmoneta_server_authenticate(srv, "postgres", config->users[usr].username, config->users[usr].password, true, &ssl, &socket);
 
             if (auth == AUTH_SUCCESS)


### PR DESCRIPTION
Hi,

This is a big improvement on our WAL functionality. Previously we get our WAL streaming starting position using IDENTIFY_SYSTEM. However in postgres this is actually the last resort. The reason is that, consider the case when server goes into recovery mode and bumps its timeline from 1 to 2. When pgmoneta connects to server again, it will start streaming segments on timeline 2 directly, instead of what's remaining on timeline 1. This is because IDENTIFY_SYSTEM always gives us the current timeline and xlog position. And the server is currently on timeline 2. 

In the new design, on streaming starts, pgmoneta will go into WAL archive directory and starts looking for the latest segment, which it will use as the starting position, disregarding which timeline it's on. And when server finished streaming WAL segments on an old timeline, it will send command complete and indicate the next xlogpos on the next timeline. We also added support to read that info and automatically start the next WAL streaming process on the next timeline:
![23113e1cfecc2c69c78e28017d17025](https://github.com/pgmoneta/pgmoneta/assets/89931362/37783952-178e-49ac-a631-20e9dad6b80c)


Some minor bugs are also fixed along the way, including our error response logging, sometimes the error response message's payload does not include type and length header, causing parsing error. As well as our create_slot functionality, create_slot flag was permanently set to false. More config->running checkings are added to prevent the child process not terminated properly.

Note that pgmoneta restore currently doesn't support having the server going into recovery mode. To make the server jump to the next timeline, I need to manually add recovery.signal, and change restore_command in postgresql.conf.