### PR TITLE
A new function to retrieve file's permissions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,5 @@ Jichen Xu <kyokitisin@gmail.com>
 Saurav Pal <resyfer.dev@gmail.com>
 Bokket <bokkett@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
+Hazem Alrawi <hazemalrawi7@gmail.com>
+


### PR DESCRIPTION
Hi,
In utils.c the function named pgmoneta_copy_file()  always creates a new file with specified permissions

`   fd_to = open(to, O_WRONLY | O_CREAT | O_EXCL, 0664);`

0664 are the permissions in octal this is not correct so we have to make sure that the newly created file **to** inherits the same permissions of the parent file **from**

`    *permissions = from_stat.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);`
Here I only take care of permissions given to:
-owner (S_IRWXU)
-group (S_IRWXG)
-other (S_IRWXO)
that's why I bitmask the value of .st_mode

Errors related to **from** file can be handled in pgmoneta_copy_file() function but when it comes to stat failure I preferred to delegate the task of logging the error to the caller function because -till now- the newly created function is nested into pgmoneta_copy_file()

Waiting for your feedback!