### PR TITLE
Expose ongoing backup lock to prometheus as pgmoneta_active_backup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,4 +11,4 @@ Saurav Pal <resyfer.dev@gmail.com>
 Bokket <bokkett@gmail.com>
 Haoran Zhang <andrewzhr9911@gmail.com>
 Hazem Alrawi <hazemalrawi7@gmail.com>
-
+Shahryar Soltanpour <shahryar.soltanpour@gmail.com>

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -488,6 +488,16 @@ home_page(int client_fd)
    data = pgmoneta_append(data, "      </tr>\n");
    data = pgmoneta_append(data, "    </tbody>\n");
    data = pgmoneta_append(data, "  </table>\n");
+   data = pgmoneta_append(data, "  <h2>pgmoneta_active_backup</h2>\n");
+   data = pgmoneta_append(data, "  Is there an active backup for a server\n");
+   data = pgmoneta_append(data, "  <table border=\"1\">\n");
+   data = pgmoneta_append(data, "    <tbody>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>name</td>\n");
+   data = pgmoneta_append(data, "        <td>The identifier for the server</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "    </tbody>\n");
+   data = pgmoneta_append(data, "  </table>\n");
    data = pgmoneta_append(data, "  <p>\n");
    data = pgmoneta_append(data, "  <a href=\"https://pgmoneta.github.io/\">pgmoneta.github.io/</a>\n");
    data = pgmoneta_append(data, "</body>\n");
@@ -1923,6 +1933,22 @@ size_information(int client_fd)
       data = pgmoneta_append(data, "\n");
 
       free(d);
+   }
+   data = pgmoneta_append(data, "\n");
+
+   data = pgmoneta_append(data, "#HELP pgmoneta_active_backup Is there an active backup for a server\n");
+   data = pgmoneta_append(data, "#TYPE pgmoneta_active_backup gauge\n");
+
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      data = pgmoneta_append(data, "pgmoneta_active_backup{");
+      data = pgmoneta_append(data, "name=\"");
+      data = pgmoneta_append(data, config->servers[i].name);
+      data = pgmoneta_append(data, "\"} ");
+
+      data = pgmoneta_append_bool(data, atomic_load(&config->servers[i].backup));
+
+      data = pgmoneta_append(data, "\n");
    }
    data = pgmoneta_append(data, "\n");
 


### PR DESCRIPTION
Hi, 

In this PR, I have added the `atomic_bool backup` variable to the list of the variables exposed to Prometheus. 

With this addition, `pgmoneta_active_backup(name="XYZ") 1` in Prometheus metrics shows that a backup is currently ongoing on the "XYZ" instance. 

I could not find a testing mechanism in the repository to write tests for this functionality, but I have manually verified that the value is set to `1` correctly when a backup is in progress and otherwise, it's `0`. 

Would be happy to know your thoughts and comments on this :)
