### PR TITLE
[#187] Parse .history and expose to prometheus

### DIFF
--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <ev.h>
 #include <stdatomic.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
 #if HAVE_OPENBSD
@@ -211,6 +212,7 @@ struct server
    int version;                        /**< The major version of the server*/
    int operation_count;                /**< Operation count of the server */
    int failed_operation_count;         /**< Failed operation count of the server */
+   uint32_t cur_timeline;              /**< Current timeline the server is on*/
    char last_operation_time[MISC_LENGTH];         /**< Last operation time of the server */
    char last_failed_operation_time[MISC_LENGTH];  /**< Last failed operation time of the server */
    char wal_shipping[MAX_PATH];                   /**< The WAL shipping directory */

--- a/src/include/wal.h
+++ b/src/include/wal.h
@@ -34,7 +34,16 @@ extern "C" {
 #endif
 
 #include <ev.h>
+#include <stdint.h>
 #include <stdlib.h>
+
+struct timeline_history
+{
+   uint32_t parent_tli;           /**< the previous timeline current timeline switched off from */
+   uint32_t switchpos_hi;         /**< the high 32 bit in decimal of xlog pos where the switch happened */
+   uint32_t switchpos_lo;         /**< the low 32 bit in decimal of xlog pos where the switch happened */
+   struct timeline_history* next; /**< the next history entry */
+};
 
 /**
  * Receive WAL
@@ -43,6 +52,23 @@ extern "C" {
  */
 void
 pgmoneta_wal(int srv, char** argv);
+
+/**
+ * Find and extract the history info from .history file of given server and timeline
+ * @param srv The server index
+ * @param tli The timeline
+ * @param history [out] the history info
+ * @return 0 on success, otherwise 1
+ */
+int
+pgmoneta_get_timeline_history(int srv, uint32_t tli, struct timeline_history** history);
+
+/**
+ * Free the history
+ * @param history The history
+ */
+void
+pgmoneta_free_timeline_history(struct timeline_history* history);
 
 #ifdef __cplusplus
 }

--- a/src/libpgmoneta/bzip2_compression.c
+++ b/src/libpgmoneta/bzip2_compression.c
@@ -193,7 +193,8 @@ pgmoneta_bzip2_wal(char* directory)
       if (entry->d_type == DT_REG)
       {
          if (pgmoneta_is_file_archive(entry->d_name) ||
-             pgmoneta_ends_with(entry->d_name, ".partial"))
+             pgmoneta_ends_with(entry->d_name, ".partial") ||
+             pgmoneta_ends_with(entry->d_name, ".history"))
          {
             continue;
          }

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -191,6 +191,7 @@ pgmoneta_read_configuration(void* shm, char* filename)
                   atomic_init(&srv.wal, false);
                   srv.wal_streaming = false;
                   srv.valid = false;
+                  srv.cur_timeline = 1; // by default current timeline is 1
                   memset(srv.wal_shipping, 0, MAX_PATH);
 
                   idx_server++;

--- a/src/libpgmoneta/gzip_compression.c
+++ b/src/libpgmoneta/gzip_compression.c
@@ -189,7 +189,8 @@ pgmoneta_gzip_wal(char* directory)
       if (entry->d_type == DT_REG)
       {
          if (pgmoneta_is_file_archive(entry->d_name) ||
-             pgmoneta_ends_with(entry->d_name, ".partial"))
+             pgmoneta_ends_with(entry->d_name, ".partial") ||
+             pgmoneta_ends_with(entry->d_name, ".history"))
          {
             continue;
          }

--- a/src/libpgmoneta/lz4_compression.c
+++ b/src/libpgmoneta/lz4_compression.c
@@ -120,7 +120,8 @@ pgmoneta_lz4c_wal(char* directory)
       if (entry->d_type == DT_REG)
       {
          if (pgmoneta_is_file_archive(entry->d_name) ||
-             pgmoneta_ends_with(entry->d_name, ".partial"))
+             pgmoneta_ends_with(entry->d_name, ".partial") ||
+             pgmoneta_ends_with(entry->d_name, ".history"))
          {
             continue;
          }

--- a/src/libpgmoneta/zstandard_compression.c
+++ b/src/libpgmoneta/zstandard_compression.c
@@ -247,7 +247,8 @@ pgmoneta_zstandardc_wal(char* directory)
       if (entry->d_type == DT_REG)
       {
          if (pgmoneta_is_file_archive(entry->d_name) ||
-             pgmoneta_ends_with(entry->d_name, ".partial"))
+             pgmoneta_ends_with(entry->d_name, ".partial") ||
+             pgmoneta_ends_with(entry->d_name, ".history"))
          {
             continue;
          }


### PR DESCRIPTION
Hi,

Sorry about the delay. This has been a crazy week 😩 

This patch provides us the ability to parse the history file. To make my life a little easier, I excluded .history file from being compressed - they are tiny anyway.

Prometheus is not making my life easy either, I cannot display hex string, nor put high and low 32 bits together, because it's A STRING!! So I display them separately in decimal for now. By default timeline 1 will have an invalid parent timeline of 0 and a switch point of 0/0.

Also spent great deal of time trying to connect local prometheus client to pgmoneta on Azure server. Turns out there's a firewall that overwrote Azure's inbound rules :(

Let me know if there's problem~