### PR TITLE
[#187] Extract WAL info from backup_label

### DIFF
--- a/src/include/info.h
+++ b/src/include/info.h
@@ -39,15 +39,18 @@ extern "C" {
 /* system */
 #include <stdlib.h>
 
-#define INFO_STATUS      "STATUS"
-#define INFO_LABEL       "LABEL"
-#define INFO_WAL         "WAL"
-#define INFO_ELAPSED     "ELAPSED"
-#define INFO_VERSION     "VERSION"
-#define INFO_KEEP        "KEEP"
-#define INFO_BACKUP      "BACKUP"
-#define INFO_RESTORE     "RESTORE"
-#define INFO_TABLESPACES "TABLESPACES"
+#define INFO_STATUS         "STATUS"
+#define INFO_LABEL          "LABEL"
+#define INFO_WAL            "WAL"
+#define INFO_ELAPSED        "ELAPSED"
+#define INFO_VERSION        "VERSION"
+#define INFO_KEEP           "KEEP"
+#define INFO_BACKUP         "BACKUP"
+#define INFO_RESTORE        "RESTORE"
+#define INFO_TABLESPACES    "TABLESPACES"
+#define INFO_START_WALPOS   "START_WALPOS"
+#define INFO_CHKPT_WALPOS   "CHKPT_WALPOS"
+#define INFO_START_TIMELINE "START_TIMELINE"
 
 #define VALID_UNKNOWN -1
 #define VALID_FALSE    0
@@ -68,6 +71,11 @@ struct backup
    char valid;                                               /**< Is the backup valid */
    unsigned long number_of_tablespaces;                      /**< The number of tablespaces */
    char tablespaces[MAX_NUMBER_OF_TABLESPACES][MISC_LENGTH]; /**< The names of the tablespaces */
+   uint32_t start_lsn_hi32;                                  /**< The high 32 bits of WAL starting position of the backup */
+   uint32_t start_lsn_lo32;                                  /**< The low 32 bits of WAL starting position of the backup */
+   uint32_t checkpoint_lsn_hi32;                             /**< The high 32 bits of WAL checkpoint position of the backup */
+   uint32_t checkpoint_lsn_lo32;                             /**< The low 32 bits of WAL checkpoint position of the backup */
+   uint32_t start_timeline;                                  /**< The starting timeline of the backup */
 } __attribute__ ((aligned (64)));
 
 /**

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -628,6 +628,17 @@ int
 pgmoneta_read_wal(char* directory, char** wal);
 
 /**
+ * Read the start WAL location and checkpoint WAL location from a backup_label file
+ * @param directory The base directory
+ * @param startpos [out] The start WAL position
+ * @param chkptpos [out] The checkpoint WAL position
+ * @param start_timeline [out] The timeline this backup starts with
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_read_wal_info(char* directory, char** startpos, char** chkptpos, uint32_t* start_timeline);
+
+/**
  * Get the directory for a server
  * @param server The server
  * @return The directory

--- a/src/libpgmoneta/info.c
+++ b/src/libpgmoneta/info.c
@@ -391,6 +391,18 @@ pgmoneta_get_backup(char* directory, char* label, struct backup** backup)
             memcpy(&bck->tablespaces[tbl_idx], &value[0], strlen(&value[0]));
             tbl_idx++;
          }
+         else if (pgmoneta_starts_with(&key[0], INFO_START_WALPOS))
+         {
+            sscanf(&value[0], "%X/%X", &bck->start_lsn_hi32, &bck->start_lsn_lo32);
+         }
+         else if (pgmoneta_starts_with(&key[0], INFO_CHKPT_WALPOS))
+         {
+            sscanf(&value[0], "%X/%X", &bck->checkpoint_lsn_hi32, &bck->checkpoint_lsn_lo32);
+         }
+         else if (pgmoneta_starts_with(&key[0], INFO_START_TIMELINE))
+         {
+            bck->start_timeline = atoi(&value[0]);
+         }
       }
    }
 

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -436,6 +436,59 @@ home_page(int client_fd)
    data = pgmoneta_append(data, "    </tbody>\n");
    data = pgmoneta_append(data, "  </table>\n");
    data = pgmoneta_append(data, "  <p>\n");
+   data = pgmoneta_append(data, "  <h2>pgmoneta_backup_start_timeline</h2>\n");
+   data = pgmoneta_append(data, "  The starting timeline of a backup for a server\n");
+   data = pgmoneta_append(data, "  <table border=\"1\">\n");
+   data = pgmoneta_append(data, "    <tbody>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>name</td>\n");
+   data = pgmoneta_append(data, "        <td>The identifier for the server</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>label</td>\n");
+   data = pgmoneta_append(data, "        <td>The backup label</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "    </tbody>\n");
+   data = pgmoneta_append(data, "  </table>\n");
+   data = pgmoneta_append(data, "  <p>\n");
+   data = pgmoneta_append(data, "  <h2>pgmoneta_backup_start_walpos</h2>\n");
+   data = pgmoneta_append(data, "  The starting WAL position of a backup for a server\n");
+   data = pgmoneta_append(data, "  <table border=\"1\">\n");
+   data = pgmoneta_append(data, "    <tbody>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>name</td>\n");
+   data = pgmoneta_append(data, "        <td>The identifier for the server</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>label</td>\n");
+   data = pgmoneta_append(data, "        <td>The backup label</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>walpos</td>\n");
+   data = pgmoneta_append(data, "        <td>The backup starting WAL position</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "    </tbody>\n");
+   data = pgmoneta_append(data, "  </table>\n");
+   data = pgmoneta_append(data, "  <p>\n");
+   data = pgmoneta_append(data, "  <h2>pgmoneta_backup_checkpoint_walpos</h2>\n");
+   data = pgmoneta_append(data, "  The checkpoint WAL pos for a server\n");
+   data = pgmoneta_append(data, "  <table border=\"1\">\n");
+   data = pgmoneta_append(data, "    <tbody>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>name</td>\n");
+   data = pgmoneta_append(data, "        <td>The identifier for the server</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>label</td>\n");
+   data = pgmoneta_append(data, "        <td>The backup label</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>walpos</td>\n");
+   data = pgmoneta_append(data, "        <td>The backup checkpoint WAL position</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "    </tbody>\n");
+   data = pgmoneta_append(data, "  </table>\n");
+   data = pgmoneta_append(data, "  <p>\n");
    data = pgmoneta_append(data, "  <h2>pgmoneta_restore_newest_size</h2>\n");
    data = pgmoneta_append(data, "  The size of the newest restore for a server\n");
    data = pgmoneta_append(data, "  <table border=\"1\">\n");
@@ -1546,6 +1599,177 @@ backup_information(int client_fd)
          data = pgmoneta_append(data, "name=\"");
          data = pgmoneta_append(data, config->servers[i].name);
          data = pgmoneta_append(data, "\",label=\"0\"} 0");
+
+         data = pgmoneta_append(data, "\n");
+      }
+
+      for (int j = 0; j < number_of_backups; j++)
+      {
+         free(backups[j]);
+      }
+      free(backups);
+
+      free(d);
+   }
+   data = pgmoneta_append(data, "\n");
+
+   data = pgmoneta_append(data, "#HELP pgmoneta_backup_start_timeline The starting timeline of a backup for a server\n");
+   data = pgmoneta_append(data, "#TYPE pgmoneta_backup_start_timeline gauge\n");
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      d = pgmoneta_get_server_backup(i);
+
+      number_of_backups = 0;
+      backups = NULL;
+
+      pgmoneta_get_backups(d, &number_of_backups, &backups);
+
+      if (number_of_backups > 0)
+      {
+         for (int j = 0; j < number_of_backups; j++)
+         {
+            if (backups[j]->valid == VALID_TRUE)
+            {
+               data = pgmoneta_append(data, "pgmoneta_backup_start_timeline{");
+
+               data = pgmoneta_append(data, "name=\"");
+               data = pgmoneta_append(data, config->servers[i].name);
+               data = pgmoneta_append(data, "\",label=\"");
+               data = pgmoneta_append(data, backups[j]->label);
+               data = pgmoneta_append(data, "\"} ");
+
+               data = pgmoneta_append_int(data, backups[j]->start_timeline);
+
+               data = pgmoneta_append(data, "\n");
+            }
+         }
+      }
+      else
+      {
+         data = pgmoneta_append(data, "pgmoneta_backup_start_timeline{");
+
+         data = pgmoneta_append(data, "name=\"");
+         data = pgmoneta_append(data, config->servers[i].name);
+         data = pgmoneta_append(data, "\",label=\"0\"} 0");
+
+         data = pgmoneta_append(data, "\n");
+      }
+
+      for (int j = 0; j < number_of_backups; j++)
+      {
+         free(backups[j]);
+      }
+      free(backups);
+
+      free(d);
+   }
+   data = pgmoneta_append(data, "\n");
+
+   data = pgmoneta_append(data, "#HELP pgmoneta_backup_start_walpos The starting WAL position of a backup for a server\n");
+   data = pgmoneta_append(data, "#TYPE pgmoneta_backup_start_walpos gauge\n");
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      d = pgmoneta_get_server_backup(i);
+
+      number_of_backups = 0;
+      backups = NULL;
+
+      pgmoneta_get_backups(d, &number_of_backups, &backups);
+
+      if (number_of_backups > 0)
+      {
+         for (int j = 0; j < number_of_backups; j++)
+         {
+            if (backups[j]->valid == VALID_TRUE)
+            {
+               char walpos[MISC_LENGTH];
+               memset(walpos, 0, MISC_LENGTH);
+               data = pgmoneta_append(data, "pgmoneta_backup_start_walpos{");
+
+               data = pgmoneta_append(data, "name=\"");
+               data = pgmoneta_append(data, config->servers[i].name);
+               data = pgmoneta_append(data, "\",label=\"");
+               data = pgmoneta_append(data, backups[j]->label);
+               data = pgmoneta_append(data, "\", ");
+
+               snprintf(walpos, MISC_LENGTH, "%X/%X", backups[j]->start_lsn_hi32, backups[j]->start_lsn_lo32);
+               data = pgmoneta_append(data, "walpos=\"");
+               data = pgmoneta_append(data, walpos);
+               data = pgmoneta_append(data, "\"} ");
+
+               data = pgmoneta_append_int(data, 1);
+
+               data = pgmoneta_append(data, "\n");
+            }
+         }
+      }
+      else
+      {
+         data = pgmoneta_append(data, "pgmoneta_backup_start_walpos{");
+
+         data = pgmoneta_append(data, "name=\"");
+         data = pgmoneta_append(data, config->servers[i].name);
+         data = pgmoneta_append(data, "\",label=\"0\", ");
+         data = pgmoneta_append(data, "walpos=\"0/0\"} 0");
+
+         data = pgmoneta_append(data, "\n");
+      }
+      for (int j = 0; j < number_of_backups; j++)
+      {
+         free(backups[j]);
+      }
+      free(backups);
+
+      free(d);
+   }
+   data = pgmoneta_append(data, "\n");
+
+   data = pgmoneta_append(data, "#HELP pgmoneta_backup_checkpoint_walpos The checkpoint WAL position of a backup for a server\n");
+   data = pgmoneta_append(data, "#TYPE pgmoneta_backup_checkpoint_walpos gauge\n");
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      d = pgmoneta_get_server_backup(i);
+
+      number_of_backups = 0;
+      backups = NULL;
+
+      pgmoneta_get_backups(d, &number_of_backups, &backups);
+
+      if (number_of_backups > 0)
+      {
+         for (int j = 0; j < number_of_backups; j++)
+         {
+            if (backups[j]->valid == VALID_TRUE)
+            {
+               char walpos[MISC_LENGTH];
+               memset(walpos, 0, MISC_LENGTH);
+               data = pgmoneta_append(data, "pgmoneta_backup_checkpoint_walpos{");
+
+               data = pgmoneta_append(data, "name=\"");
+               data = pgmoneta_append(data, config->servers[i].name);
+               data = pgmoneta_append(data, "\",label=\"");
+               data = pgmoneta_append(data, backups[j]->label);
+               data = pgmoneta_append(data, "\", ");
+
+               snprintf(walpos, MISC_LENGTH, "%X/%X", backups[j]->checkpoint_lsn_hi32, backups[j]->checkpoint_lsn_lo32);
+               data = pgmoneta_append(data, "walpos=\"");
+               data = pgmoneta_append(data, walpos);
+               data = pgmoneta_append(data, "\"} ");
+
+               data = pgmoneta_append_int(data, 1);
+
+               data = pgmoneta_append(data, "\n");
+            }
+         }
+      }
+      else
+      {
+         data = pgmoneta_append(data, "pgmoneta_backup_checkpoint_walpos{");
+
+         data = pgmoneta_append(data, "name=\"");
+         data = pgmoneta_append(data, config->servers[i].name);
+         data = pgmoneta_append(data, "\",label=\"0\", ");
+         data = pgmoneta_append(data, "walpos=\"0/0\"} 0");
 
          data = pgmoneta_append(data, "\n");
       }

--- a/src/libpgmoneta/wf_backup.c
+++ b/src/libpgmoneta/wf_backup.c
@@ -89,6 +89,9 @@ basebackup_execute(int server, char* identifier, struct node* i_nodes, struct no
    char* label = NULL;
    char version[10];
    char* wal = NULL;
+   char* startpos = NULL;
+   char* chkptpos = NULL;
+   uint32_t start_timeline = 0;
    char old_label_path[MAX_PATH];
    struct node* o_root = NULL;
    struct node* o_to = NULL;
@@ -254,6 +257,7 @@ basebackup_execute(int server, char* identifier, struct node* i_nodes, struct no
 
    size = pgmoneta_directory_size(d);
    pgmoneta_read_wal(d, &wal);
+   pgmoneta_read_wal_info(d, &startpos, &chkptpos, &start_timeline);
 
    if (pgmoneta_create_node_string(root, "root", &o_root))
    {
@@ -272,6 +276,19 @@ basebackup_execute(int server, char* identifier, struct node* i_nodes, struct no
    pgmoneta_update_info_unsigned_long(root, INFO_RESTORE, size);
    pgmoneta_update_info_string(root, INFO_VERSION, version);
    pgmoneta_update_info_bool(root, INFO_KEEP, false);
+   // in case of parsing error
+   if (startpos != NULL)
+   {
+      pgmoneta_update_info_string(root, INFO_START_WALPOS, startpos);
+   }
+   if (chkptpos != NULL)
+   {
+      pgmoneta_update_info_string(root, INFO_CHKPT_WALPOS, chkptpos);
+   }
+   if (start_timeline != 0)
+   {
+      pgmoneta_update_info_unsigned_long(root, INFO_START_TIMELINE, start_timeline);
+   }
 
    current_tablespace = tablespaces;
    while (current_tablespace != NULL)


### PR DESCRIPTION
Extracts WAL start position, WAL checkpoint position and WAL starting timeline from backup_label into backup.info, which can be parsed into `backup` struct, and exposed to prometheus.