### PR TITLE
[#207] Expose WAL log sequence number (pgmoneta_current_wal_lsn) to Prometheus

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Haoran Zhang <andrewzhr9911@gmail.com>
 Hazem Alrawi <hazemalrawi7@gmail.com>
 Shahryar Soltanpour <shahryar.soltanpour@gmail.com>
 Shikhar Soni <shikharish05@gmail.com>
+Nguyen Cong Nhat Le <lenguyencongnhat2001@gmail.com>

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -197,6 +197,7 @@ struct server
    char username[MAX_USERNAME_LENGTH]; /**< The user name */
    char wal_slot[MISC_LENGTH];         /**< The WAL slot name */
    char current_wal_filename[MISC_LENGTH]; /**< The current WAL filename*/
+   char current_wal_lsn[MISC_LENGTH]; /**< The current WAL log sequence number*/
    char follow[MISC_LENGTH];           /**< Follow a server */
    int retention_days;                 /**< The retention days for the server */
    int retention_weeks;                /**< The retention weeks for the server */

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -2923,6 +2923,7 @@ copy_server(struct server* dst, struct server* src)
    dst->wal_streaming = src->wal_streaming;
    /* dst->valid = src->valid; */
    memcpy(&dst->current_wal_filename[0], &src->current_wal_filename[0], MISC_LENGTH);
+   memcpy(&dst->current_wal_lsn[0], &src->current_wal_lsn[0], MISC_LENGTH);
 }
 
 static void

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -615,6 +615,21 @@ home_page(int client_fd)
    data = pgmoneta_append(data, "    </tbody>\n");
    data = pgmoneta_append(data, "  </table>\n");
    data = pgmoneta_append(data, "  <p>\n");
+   data = pgmoneta_append(data, "  <h2>pgmoneta_current_wal_lsn</h2>\n");
+   data = pgmoneta_append(data, "  The current WAL log sequence number\n");
+   data = pgmoneta_append(data, "  <table border=\"1\">\n");
+   data = pgmoneta_append(data, "    <tbody>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>server</td>\n");
+   data = pgmoneta_append(data, "        <td>The identifier for the server</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "      <tr>\n");
+   data = pgmoneta_append(data, "        <td>lsn</td>\n");
+   data = pgmoneta_append(data, "        <td>The current WAL log sequence number</td>\n");
+   data = pgmoneta_append(data, "      </tr>\n");
+   data = pgmoneta_append(data, "    </tbody>\n");
+   data = pgmoneta_append(data, "  </table>\n");
+   data = pgmoneta_append(data, "  <p>\n");
    data = pgmoneta_append(data, "  <a href=\"https://pgmoneta.github.io/\">pgmoneta.github.io/</a>\n");
    data = pgmoneta_append(data, "</body>\n");
    data = pgmoneta_append(data, "</html>\n");
@@ -2369,6 +2384,34 @@ size_information(int client_fd)
 
       data = pgmoneta_append(data, "file=\"");
       data = pgmoneta_append(data, config->servers[i].current_wal_filename);
+      data = pgmoneta_append(data, "\"} ");
+
+      data = pgmoneta_append_bool(data, config->servers[i].wal_streaming);
+
+      data = pgmoneta_append(data, "\n");
+   }
+   data = pgmoneta_append(data, "\n");
+
+   // Append the WAL LSN of every server
+   data = pgmoneta_append(data, "#HELP pgmoneta_current_wal_lsn The current WAL log sequence number\n");
+   data = pgmoneta_append(data, "#TYPE pgmoneta_current_wal_lsn gauge\n");
+   for (int i = 0; i < config->number_of_servers; i++)
+   {
+      data = pgmoneta_append(data, "pgmoneta_current_wal_lsn{");
+
+      data = pgmoneta_append(data, "server=\"");
+      data = pgmoneta_append(data, config->servers[i].name);
+      data = pgmoneta_append(data, "\", ");
+
+      data = pgmoneta_append(data, "lsn=\"");
+      if (!strcmp(config->servers[i].current_wal_lsn, ""))
+      {
+         data = pgmoneta_append(data, "0/0");
+      }
+      else
+      {
+         data = pgmoneta_append(data, config->servers[i].current_wal_lsn);
+      }
       data = pgmoneta_append(data, "\"} ");
 
       data = pgmoneta_append_bool(data, config->servers[i].wal_streaming);


### PR DESCRIPTION
My steps for implementing a pgmoneta_current_wal_lsn are:
1. Create a new attribute pgmoneta_current_wal_lsn, which will be used to store xlogpos, in the struct server. (in pgmoneta.h file)
2. Every time xlogpos gets updated by pgmoneta_query_response_get_data function, its value will also get stored in pgmoneta_current_wal_lsn (in wal.c)
3. Append the WAL LSN of every server to Prometheus (in prometheus.c)
4. In the copy_server function, allow pgmoneta_current_wal_lsn to be copied from one server to another. (in configuration.c)