### PR TITLE
[#216] Implement a mechanism to exclude some files in the first restore round

### DIFF
--- a/src/include/restore.h
+++ b/src/include/restore.h
@@ -37,6 +37,14 @@ extern "C" {
 #include <stdlib.h>
 
 /**
+ * Fill the passed arugment with the last files names to restore
+ * @param output The string array that will be filled with the last files names to restore
+ * @return integer showing the status of the operation
+ */
+int
+pgmoneta_get_restore_last_files_names(char*** output);
+
+/**
  * Create a restore
  * @param client_fd The client
  * @param server The server

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -440,11 +440,12 @@ pgmoneta_copy_postgresql(char* from, char* to, char* base, char* server, char* i
  * Copy a directory
  * @param from The from directory
  * @param to The to directory
+ * @param restore_last_paths The string array of file names that should be excluded from being copied in this round
  * @param workers The workers
  * @return The result
  */
 int
-pgmoneta_copy_directory(char* from, char* to, struct workers* workers);
+pgmoneta_copy_directory(char* from, char* to, char** restore_last_paths, struct workers* workers);
 
 /**
  * Copy a file

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -168,6 +168,13 @@ struct workflow*
 pgmoneta_workflow_create_recovery_info(void);
 
 /**
+ * Create a workflow to restore the excluded files in the first round of restore
+ * @return The workflow
+ */
+struct workflow*
+pgmoneta_restore_excluded_files(void);
+
+/**
  * Create a workflow for permissions
  * @param type The type of operation
  * @return The workflow

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -42,6 +42,33 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+static char* restore_last_files_names[] = {"/global/pg_control"};
+
+int
+pgmoneta_get_restore_last_files_names(char*** output)
+{
+   int number_of_elements = 0;
+   number_of_elements = sizeof(restore_last_files_names) / sizeof(restore_last_files_names[0]);
+
+   *output = (char**)malloc((number_of_elements + 1) * sizeof(char*));
+   if (*output == NULL)
+   {
+      return 1;
+   }
+
+   for (int i = 0; i < number_of_elements; i++)
+   {
+      (*output)[i] = strdup(restore_last_files_names[i]);
+      if ((*output)[i] == NULL)
+      {
+         return 1;
+      }
+   }
+   (*output)[number_of_elements] = NULL;
+
+   return 0;
+}
+
 void
 pgmoneta_restore(int client_fd, int server, char* backup_id, char* position, char* directory, char** argv)
 {

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -208,6 +208,9 @@ wf_restore(void)
    current->next = pgmoneta_workflow_create_recovery_info();
    current = current->next;
 
+   current->next = pgmoneta_restore_excluded_files();
+   current = current->next;
+
    current->next = pgmoneta_workflow_create_permissions(PERMISSION_TYPE_RESTORE);
    current = current->next;
 


### PR DESCRIPTION
Hi everyone!

This PR is addressing issue #216.

In this PR, I have defined a global variable named `excluded_files_names`, these files are ignored during the first round of restoring in the `pgmoneta_copy_postgresql` function. and I have defined a workflow named  `restore_excluded_files` and added it after the compression and restoring recovery files workflow. This ensures that files such as `pg_control` are restored only after the initial files are successfully decrypted, decompressed, and restored. 
