### PR TITLE
[#221] Add a label of minor version in backup.info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Shahryar Soltanpour <shahryar.soltanpour@gmail.com>
 Shikhar Soni <shikharish05@gmail.com>
 Nguyen Cong Nhat Le <lenguyencongnhat2001@gmail.com>
 Chao Gu <chadraven369@gmail.com>
+Luchen Zhao <lucian.zlc@gmail.com>

--- a/src/include/info.h
+++ b/src/include/info.h
@@ -44,6 +44,7 @@ extern "C" {
 #define INFO_WAL            "WAL"
 #define INFO_ELAPSED        "ELAPSED"
 #define INFO_VERSION        "VERSION"
+#define INFO_MINOR_VERSION  "MINOR_VERSION"
 #define INFO_KEEP           "KEEP"
 #define INFO_BACKUP         "BACKUP"
 #define INFO_RESTORE        "RESTORE"
@@ -67,6 +68,7 @@ struct backup
    unsigned long restore_size;                               /**< The restore size */
    int elapsed_time;                                         /**< The elapsed time in seconds */
    int version;                                              /**< The version */
+   int minor_version;                                        /**< The minor version */
    bool keep;                                                /**< Keep the backup */
    char valid;                                               /**< Is the backup valid */
    unsigned long number_of_tablespaces;                      /**< The number of tablespaces */

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -212,6 +212,7 @@ struct server
    bool wal_streaming;                 /**< Is WAL streaming active */
    bool valid;                         /**< Is the server valid */
    int version;                        /**< The major version of the server*/
+   int minor_version;                  /**< The minor version of the server*/
    int operation_count;                /**< Operation count of the server */
    int failed_operation_count;         /**< Failed operation count of the server */
    uint32_t cur_timeline;              /**< Current timeline the server is on*/

--- a/src/include/workers.h
+++ b/src/include/workers.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 #include <pgmoneta.h>
-   
+
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -104,7 +104,7 @@ pgmoneta_workers_initialize(int num, struct workers** workers);
  * @return 0 upon success, otherwise 1.
  */
 int
-pgmoneta_workers_add(struct workers* workers, void(*function)(void*), void* ap);
+pgmoneta_workers_add(struct workers* workers, void (*function)(void*), void* ap);
 
 /**
  * Wait for all queued work units to finish
@@ -126,7 +126,6 @@ pgmoneta_workers_destroy(struct workers* workers);
  */
 int
 pgmoneta_get_number_of_workers(int server);
-
 
 /**
  * Create worker input

--- a/src/libpgmoneta/bzip2_compression.c
+++ b/src/libpgmoneta/bzip2_compression.c
@@ -156,7 +156,6 @@ do_bzip2_compress(void* arg)
    free(wi);
 }
 
-
 void
 pgmoneta_bzip2_tablespaces(char* root, struct workers* workers)
 {

--- a/src/libpgmoneta/server.c
+++ b/src/libpgmoneta/server.c
@@ -282,7 +282,9 @@ pgmoneta_server_get_version(SSL* ssl, int socket, int server)
 
    config = (struct configuration*)shmem;
 
-   ret = pgmoneta_create_query_message("SELECT split_part(split_part(version(), ' ', 2), '.', 1);", &query_msg);
+   ret = pgmoneta_create_query_message("SELECT split_part(split_part(version(), ' ', 2), '.', 1) AS major, "
+                                       "split_part(split_part(version(), ' ', 2), '.', 2) AS minor;",
+                                       &query_msg);
    if (ret != MESSAGE_STATUS_OK)
    {
       goto error;
@@ -294,6 +296,7 @@ pgmoneta_server_get_version(SSL* ssl, int socket, int server)
    }
 
    config->servers[server].version = atoi(response->tuples->data[0]);
+   config->servers[server].minor_version = atoi(response->tuples->data[1]);
 
    pgmoneta_free_query_response(response);
    pgmoneta_free_copy_message(query_msg);

--- a/src/libpgmoneta/wf_backup.c
+++ b/src/libpgmoneta/wf_backup.c
@@ -88,6 +88,7 @@ basebackup_execute(int server, char* identifier, struct node* i_nodes, struct no
    int number_of_tablespaces = 0;
    char* label = NULL;
    char version[10];
+   char minor_version[10];
    char* wal = NULL;
    char* startpos = NULL;
    char* chkptpos = NULL;
@@ -135,6 +136,8 @@ basebackup_execute(int server, char* identifier, struct node* i_nodes, struct no
    }
    memset(version, 0, sizeof(version));
    snprintf(version, sizeof(version), "%d", config->servers[server].version);
+   memset(minor_version, 0, sizeof(minor_version));
+   snprintf(minor_version, sizeof(version), "%d", config->servers[server].minor_version);
 
    pgmoneta_create_query_message("SELECT spcname, pg_tablespace_location(oid) FROM pg_tablespace;", &tablespace_msg);
    if (pgmoneta_query_execute(ssl, socket, tablespace_msg, &response) || response == NULL)
@@ -275,6 +278,7 @@ basebackup_execute(int server, char* identifier, struct node* i_nodes, struct no
    pgmoneta_update_info_string(root, INFO_WAL, wal);
    pgmoneta_update_info_unsigned_long(root, INFO_RESTORE, size);
    pgmoneta_update_info_string(root, INFO_VERSION, version);
+   pgmoneta_update_info_string(root, INFO_MINOR_VERSION, minor_version);
    pgmoneta_update_info_bool(root, INFO_KEEP, false);
    // in case of parsing error
    if (startpos != NULL)

--- a/src/libpgmoneta/workers.c
+++ b/src/libpgmoneta/workers.c
@@ -119,7 +119,7 @@ error:
 }
 
 int
-pgmoneta_workers_add(struct workers* workers, void(*function)(void*), void* ap)
+pgmoneta_workers_add(struct workers* workers, void (*function)(void*), void* ap)
 {
    struct task* t = NULL;
 
@@ -265,7 +265,7 @@ worker_init(struct workers* workers, struct worker** worker)
 
    w->workers = workers;
 
-   pthread_create(&w->pthread, NULL, (void* (*)(void*))worker_do, w);
+   pthread_create(&w->pthread, NULL, (void* (*)(void*)) worker_do, w);
    pthread_detach(w->pthread);
 
    *worker = w;


### PR DESCRIPTION
I added a **MINOR_VERSION** label to record the minor version of the postgres server in "backup.info" generated after making a full backup.