### PR TITLE
[#205] Add json format option for command output

### DIFF
--- a/src/include/json.h
+++ b/src/include/json.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_JSON_H
+#define PGMONETA_JSON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* pgmoneta */
+#include <pgmoneta.h>
+
+/* system */
+#include <cjson/cJSON.h>
+
+/**
+ * JSON related command tags, used to build and retrieve
+ * a JSON piece of information related to a single command
+ */
+#define JSON_TAG_COMMAND "command"
+#define JSON_TAG_COMMAND_NAME "name"
+#define JSON_TAG_COMMAND_STATUS "status"
+#define JSON_TAG_COMMAND_ERROR "error"
+#define JSON_TAG_COMMAND_OUTPUT "output"
+#define JSON_TAG_COMMAND_EXIT_STATUS "exit-status"
+
+#define JSON_TAG_APPLICATION_NAME "name"
+#define JSON_TAG_APPLICATION_VERSION_MAJOR "major"
+#define JSON_TAG_APPLICATION_VERSION_MINOR "minor"
+#define JSON_TAG_APPLICATION_VERSION_PATCH "patch"
+#define JSON_TAG_APPLICATION_VERSION "version"
+
+#define JSON_TAG_ARRAY_NAME "list"
+
+/**
+ * JSON pre-defined values
+ */
+#define JSON_STRING_SUCCESS "OK"
+#define JSON_STRING_ERROR   "KO"
+#define JSON_BOOL_SUCCESS   0
+#define JSON_BOOL_ERROR     1
+
+/**
+ * Utility method to create a new JSON object that wraps a
+ * single command. This method should be called to initialize the
+ * object and then the other specific methods that read the
+ * answer from pgmoneta should populate the object accordingly.
+ *
+ * Moreover, an 'application' object is placed to indicate from
+ * where the command has been launched (i.e., which executable)
+ * and at which version.
+ *
+ * @param command_name the name of the command this object wraps
+ * an answer for
+ * @param success true if the command is supposed to be successful
+ * @returns the new JSON object to use and populate
+ * @param executable_name the name of the executable that is creating this
+ * response object
+ */
+cJSON*
+pgmoneta_json_create_new_command_object(char* command_name, bool success, char* executable_name);
+
+/**
+ * Utility method to "jump" to the output JSON object wrapped into
+ * a command object.
+ *
+ * The "output" object is the one that every single method that reads
+ * back an answer from pgmoneta has to populate in a specific
+ * way according to the data received from pgmoneta.
+ *
+ * @param json the command object that wraps the command
+ * @returns the pointer to the output object of NULL in case of an error
+ */
+cJSON*
+pgmoneta_json_extract_command_output_object(cJSON* json);
+
+/**
+ * Utility function to set a command JSON object as faulty, that
+ * means setting the 'error' and 'status' message accordingly.
+ *
+ * @param json the whole json object that must include the 'command'
+ * tag
+ * @param message the message to use to set the faulty diagnostic
+ * indication
+ *
+ * @param exit status
+ *
+ * @returns 0 on success
+ *
+ * Example:
+ * json_set_command_object_faulty( json, strerror( errno ) );
+ */
+int
+pgmoneta_json_set_command_object_faulty(cJSON* json, char* message);
+
+/**
+ * Utility method to inspect if a JSON object that wraps a command
+ * is faulty, that means if it has the error flag set to true.
+ *
+ * @param json the json object to analyzer
+ * @returns the value of the error flag in the object, or false if
+ * the object is not valid
+ */
+bool
+pgmoneta_json_is_command_object_faulty(cJSON* json);
+
+/**
+ * Utility method to extract the message related to the status
+ * of the command wrapped in the JSON object.
+ *
+ * @param json the JSON object to analyze
+ * #returns the status message or NULL in case the JSON object is not valid
+ */
+const char*
+pgmoneta_json_get_command_object_status(cJSON* json);
+
+/**
+ * Utility method to check if a JSON object wraps a specific command name.
+ *
+ * @param json the JSON object to analyze
+ * @param command_name the name to search for
+ * @returns true if the command name matches, false otherwise and in case
+ * the JSON object is not valid or the command name is not valid
+ */
+bool
+pgmoneta_json_command_name_equals_to(cJSON* json, char* command_name);
+
+/**
+ * Utility method to print out the JSON object
+ * on standard output.
+ *
+ * After the object has been printed, it is destroyed, so
+ * calling this method will make the pointer invalid
+ * and the jeon object cannot be used anymore.
+ *
+ * This should be the last method to be called
+ * when there is the need to print out the information
+ * contained in a json object.
+ *
+ * @param json the json object to print
+ */
+void
+pgmoneta_json_print_and_free_json_object(cJSON* json);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -57,6 +57,12 @@ extern "C" {
 #define MANAGEMENT_ENCRYPT    14
 
 /**
+ * Available command output formats
+ */
+#define COMMAND_OUTPUT_FORMAT_TEXT 'T'
+#define COMMAND_OUTPUT_FORMAT_JSON 'J'
+
+/**
  * Read the management header
  * @param socket The socket descriptor
  * @param id The resulting management identifier
@@ -103,10 +109,11 @@ pgmoneta_management_list_backup(SSL* ssl, int socket, char* server);
  * @param ssl The SSL connection
  * @param socket The socket descriptor
  * @param server The server name
+ * @param output_format The output format
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_management_read_list_backup(SSL* ssl, int socket, char* server);
+pgmoneta_management_read_list_backup(SSL* ssl, int socket, char* server, char output_format);
 
 /**
  * Management operation: List backups for a server (Write)
@@ -160,10 +167,11 @@ pgmoneta_management_delete(SSL* ssl, int socket, char* server, char* backup_id);
  * @param socket The socket descriptor
  * @param server The server name
  * @param backup_id The backup identifier
+ * @param output_format The output format
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_management_read_delete(SSL* ssl, int socket, char* server, char* backup_id);
+pgmoneta_management_read_delete(SSL* ssl, int socket, char* server, char* backup_id, char output_format);
 
 /**
  * Management operation: Delete a backup for a server (Write)
@@ -196,10 +204,11 @@ pgmoneta_management_status(SSL* ssl, int socket);
 /**
  * Management: Read status
  * @param socket The socket
+ * @param output_format The output format
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_management_read_status(SSL* ssl, int socket);
+pgmoneta_management_read_status(SSL* ssl, int socket, char output_format);
 
 /**
  * Management: Write status
@@ -222,10 +231,11 @@ pgmoneta_management_details(SSL* ssl, int socket);
 /**
  * Management: Read details
  * @param socket The socket
+ * @param output_format The output format
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_management_read_details(SSL* ssl, int socket);
+pgmoneta_management_read_details(SSL* ssl, int socket, char output_format);
 
 /**
  * Management: Write details
@@ -248,10 +258,11 @@ pgmoneta_management_isalive(SSL* ssl, int socket);
  * Management: Read isalive
  * @param socket The socket
  * @param status The resulting status
+ * @param output_format The output format
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_management_read_isalive(SSL* ssl, int socket, int* status);
+pgmoneta_management_read_isalive(SSL* ssl, int socket, int* status, char output_format);
 
 /**
  * Management: Write isalive

--- a/src/libpgmoneta/json.c
+++ b/src/libpgmoneta/json.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* pgmoneta */
+#include <pgmoneta.h>
+#include <json.h>
+
+cJSON*
+pgmoneta_json_create_new_command_object(char* command_name, bool success, char* executable_name)
+{
+   cJSON* json = NULL;
+   cJSON* command = NULL;
+   cJSON* output = NULL;
+   cJSON* application = NULL;
+   // root of the JSON structure
+   json = cJSON_CreateObject();
+
+   if (!json)
+   {
+      goto error;
+   }
+
+   // the command structure
+   command = cJSON_CreateObject();
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON_AddStringToObject(command, JSON_TAG_COMMAND_NAME, command_name);
+   cJSON_AddStringToObject(command, JSON_TAG_COMMAND_STATUS, success ? JSON_STRING_SUCCESS : JSON_STRING_ERROR);
+   cJSON_AddNumberToObject(command, JSON_TAG_COMMAND_ERROR, success ? JSON_BOOL_SUCCESS : JSON_BOOL_ERROR);
+   cJSON_AddStringToObject(command, JSON_TAG_APPLICATION_VERSION, VERSION);
+
+   // the output of the command, this has to be filled by the caller
+   output = cJSON_CreateObject();
+   if (!output)
+   {
+      goto error;
+   }
+
+   cJSON_AddItemToObject(command, JSON_TAG_COMMAND_OUTPUT, output);
+
+   application = cJSON_CreateObject();
+   if (!application)
+   {
+      goto error;
+   }
+   cJSON_AddStringToObject(application, JSON_TAG_APPLICATION_NAME, executable_name);
+   // add objects to the whole json thing
+   cJSON_AddItemToObject(json, "command", command);
+   cJSON_AddItemToObject(json, "application", application);
+
+   return json;
+error:
+   if (json)
+   {
+      cJSON_Delete(json);
+   }
+
+   return NULL;
+}
+
+cJSON*
+pgmoneta_json_extract_command_output_object(cJSON* json)
+{
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   return cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_OUTPUT);
+
+error:
+   return NULL;
+
+}
+
+bool
+pgmoneta_json_command_name_equals_to(cJSON* json, char* command_name)
+{
+   if (!json || !command_name || strlen(command_name) <= 0)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* cName = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_NAME);
+   if (!cName || !cJSON_IsString(cName) || !cName->valuestring)
+   {
+      goto error;
+   }
+
+   return !strncmp(command_name,
+                   cName->valuestring,
+                   MISC_LENGTH);
+
+error:
+   return false;
+}
+
+int
+pgmoneta_json_set_command_object_faulty(cJSON* json, char* message)
+{
+   if (!json)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* current = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_STATUS);
+   if (!current)
+   {
+      goto error;
+   }
+
+   cJSON_SetValuestring(current, message);
+
+   current = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_ERROR);
+   if (!current)
+   {
+      goto error;
+   }
+
+   cJSON_SetIntValue(current, JSON_BOOL_ERROR);   // cannot use cJSON_SetBoolValue unless cJSON >= 1.7.16
+
+   return 0;
+
+error:
+   return 1;
+}
+
+bool
+pgmoneta_json_is_command_object_faulty(cJSON* json)
+{
+   if (!json)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* status = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_ERROR);
+   if (!status || !cJSON_IsNumber(status))
+   {
+      goto error;
+   }
+
+   return status->valueint == JSON_BOOL_SUCCESS ? false : true;
+
+error:
+   return false;
+}
+
+const char*
+pgmoneta_json_get_command_object_status(cJSON* json)
+{
+   if (!json)
+   {
+      goto error;
+   }
+
+   cJSON* command = cJSON_GetObjectItemCaseSensitive(json, JSON_TAG_COMMAND);
+   if (!command)
+   {
+      goto error;
+   }
+
+   cJSON* status = cJSON_GetObjectItemCaseSensitive(command, JSON_TAG_COMMAND_STATUS);
+   if (!cJSON_IsString(status) || (status->valuestring == NULL))
+   {
+      goto error;
+   }
+
+   return status->valuestring;
+error:
+   return NULL;
+
+}
+
+void
+pgmoneta_json_print_and_free_json_object(cJSON* json)
+{
+   printf("%s\n", cJSON_Print(json));
+   cJSON_Delete(json);
+}


### PR DESCRIPTION
Port the json functionality for command output from [pgagroal](https://github.com/agroal/pgagroal). Though a lot of local adaptations had to be made. Now `status`, `details`, `delete` and `list-backup` command support json format output.