### PR TITLE
[#197] Rate limit: Disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 .vscode/
 .cache
 *.uncrustify
+.DS_Store

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -65,6 +65,7 @@ See a [sample](./etc/pgmoneta.conf) configuration for running `pgmoneta` on `loc
 | tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgmoneta or root.  |
 | libev | `auto` | String | No | Select the [libev](http://software.schmorp.de/pkg/libev.html) backend to use. Valid options: `auto`, `select`, `poll`, `epoll`, `iouring`, `devpoll` and `port` |
 | buffer_size | 65535 | Int | No | The network buffer size (`SO_RCVBUF` and `SO_SNDBUF`) |
+| backup_max_rate | 0 | Int | No | The number of bytes of tokens added every one second to limit the backup rate|
 | keep_alive | on | Bool | No | Have `SO_KEEPALIVE` on sockets |
 | nodelay | on | Bool | No | Have `TCP_NODELAY` on sockets |
 | non_blocking | on | Bool | No | Have `O_NONBLOCK` on sockets |

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -46,6 +46,8 @@ extern "C" {
 #define MESSAGE_STATUS_OK    1
 #define MESSAGE_STATUS_ERROR 2
 
+extern struct token_bucket bucket;
+
 /** @struct
  * Defines a message
  */
@@ -516,10 +518,11 @@ pgmoneta_consume_data_row_messages(SSL* ssl, int socket, struct stream_buffer* b
  * @param basedir The base directory for the backup data
  * @param tablespaces The user level tablespaces
  * @param version The server version
+ * @param bucket The rate limit bucket
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_receive_archive_files(SSL* ssl, int socket, struct stream_buffer* buffer, char* basedir, struct tablespace* tablespaces, int version);
+pgmoneta_receive_archive_files(SSL* ssl, int socket, struct stream_buffer* buffer, char* basedir, struct tablespace* tablespaces, int version, struct token_bucket* bucket);
 
 /**
  * Receive backup tar files from the copy stream and write to disk
@@ -529,10 +532,11 @@ pgmoneta_receive_archive_files(SSL* ssl, int socket, struct stream_buffer* buffe
  * @param buffer The stream buffer
  * @param basedir The base directory for the backup data
  * @param tablespaces The user level tablespaces
+ * @param bucket The rate limit bucket
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_receive_archive_stream(SSL* ssl, int socket, struct stream_buffer* buffer, char* basedir, struct tablespace* tablespaces);
+pgmoneta_receive_archive_stream(SSL* ssl, int socket, struct stream_buffer* buffer, char* basedir, struct tablespace* tablespaces, struct token_bucket* bucket);
 
 /**
  * Receive mainfest file from the copy stream and write to disk
@@ -541,10 +545,11 @@ pgmoneta_receive_archive_stream(SSL* ssl, int socket, struct stream_buffer* buff
  * @param socket The socket
  * @param buffer The stream buffer
  * @param basedir The base directory for the manifest
+ * @param bucket The rate limit bucket
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_receive_manifest_file(SSL* ssl, int socket, struct stream_buffer* buffer, char* basedir);
+pgmoneta_receive_manifest_file(SSL* ssl, int socket, struct stream_buffer* buffer, char* basedir, struct token_bucket* bucket);
 
 #ifdef __cplusplus
 }

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -59,6 +59,9 @@ extern "C" {
 #define MAX_BUFFER_SIZE      65535
 #define DEFAULT_BUFFER_SIZE  65535
 
+#define DEFAULT_BURST 65535
+#define DEFAULT_EVERY 1
+
 #define MAX_USERNAME_LENGTH  128
 #define MAX_PASSWORD_LENGTH 1024
 
@@ -351,6 +354,8 @@ struct configuration
    int number_of_servers;        /**< The number of servers */
    int number_of_users;          /**< The number of users */
    int number_of_admins;         /**< The number of admins */
+
+   unsigned long backup_max_rate; /**< Number of tokens added to the bucket with each replenishment for backup. */
 
    struct server servers[NUMBER_OF_SERVERS];       /**< The servers */
    struct user users[NUMBER_OF_USERS];             /**< The users */

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -919,6 +919,60 @@ pgmoneta_get_file_size(char* file_path);
 bool
 pgmoneta_is_file_archive(char* file_path);
 
+/** @struct
+ * Defines token bucket structure
+ */
+struct token_bucket
+{
+   unsigned long burst; /**< default value is 0, no limit */
+   atomic_ulong cur_tokens;
+   unsigned long max_rate;
+   int every;
+   atomic_ulong last_time;
+};
+
+/**
+ * Init a token bucket
+ * @param tb The token bucket
+ * @param max_rate The number of bytes of tokens added every one second
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_token_bucket_init(struct token_bucket* tb, unsigned long max_rate);
+
+/**
+ * Free the memory of the token bucket
+ * @param tb The token bucket
+ */
+void
+pgmoneta_token_bucket_destroy(struct token_bucket* tb);
+
+/**
+ * Add new token into the bucket
+ * @param tb The token bucket
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_token_bucket_add(struct token_bucket* tb);
+
+/**
+ * Get tokens from token bucket wrapper
+ * @param tb The token bucket
+ * @param tokens Needed tokens
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_token_bucket_consume(struct token_bucket* tb, unsigned long tokens);
+
+/**
+ * Get tokens from token bucket once
+ * @param tb The token bucket
+ * @param tokens Needed tokens
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_token_bucket_once(struct token_bucket* tb, unsigned long tokens);
+
 #ifdef DEBUG
 
 /**


### PR DESCRIPTION
This is just the first version of the rate limit. I have only implemented rate limiting for `pgmoneta_receive_archive_stream`, not for `pgmoneta_receive_archive_files`. 

What I want to make sure:
- This is the correct way to implement the limit.
- The code style is consistent with the rest of the file for integration.

Test Run:
- Successfully implemented backup rate limiting with no errors for now.