### PR TITLE
Adding PGMONETA_VERSION in backup.info Issue #235

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Chao Gu <chadraven369@gmail.com>
 Luchen Zhao <lucian.zlc@gmail.com>
 Joan Jeremiah J <joanjeremiah04@gmail.com>
 Iury Santos <iuryroberto@gmail.com>
+Palak Chaturvedi <palakchaturvedi2843@gmail.com>

--- a/src/libpgmoneta/info.c
+++ b/src/libpgmoneta/info.c
@@ -61,6 +61,10 @@ pgmoneta_create_info(char* directory, char* label, int status)
    snprintf(&buffer[0], sizeof(buffer), "TABLESPACES=0\n");
    fputs(&buffer[0], sfile);
 
+   memset(&buffer[0], 0, sizeof(buffer));
+   snprintf(&buffer[0], sizeof(buffer), "PGMONETA_VERSION=%s\n", VERSION);
+   fputs(&buffer[0], sfile);
+
    pgmoneta_permission(s, 6, 0, 0);
 
    if (sfile != NULL)

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -272,6 +272,9 @@ home_page(int client_fd)
    data = pgmoneta_append(data, "    <li>1 = Running</li>\n");
    data = pgmoneta_append(data, "  </ul>\n");
    data = pgmoneta_append(data, "  <p>\n");
+   data = pgmoneta_append(data, "  <h2>pgmoneta_version</h2>\n");
+   data = pgmoneta_append(data, "  The version of pgmoneta\n");
+   data = pgmoneta_append(data, "  <p>\n");
    data = pgmoneta_append(data, "  <h2>pgmoneta_retention_days</h2>\n");
    data = pgmoneta_append(data, "  The retention of pgmoneta in days\n");
    data = pgmoneta_append(data, "  <h2>pgmoneta_retention_weeks</h2>\n");
@@ -949,7 +952,12 @@ general_information(int client_fd)
    data = pgmoneta_append(data, "pgmoneta_state ");
    data = pgmoneta_append(data, "1");
    data = pgmoneta_append(data, "\n\n");
-
+   data = pgmoneta_append(data, "#HELP pgmoneta_version The version of pgmoneta\n");
+   data = pgmoneta_append(data, "#TYPE pgmoneta_version gauge\n");
+   data = pgmoneta_append(data, "pgmoneta_version{version=\"");
+   data = pgmoneta_append(data, VERSION);
+   data = pgmoneta_append(data, "\"} 1");
+   data = pgmoneta_append(data, "\n\n");   
    data = pgmoneta_append(data, "#HELP pgmoneta_retention_days The retention days of pgmoneta\n");
    data = pgmoneta_append(data, "#TYPE pgmoneta_retention_days gauge\n");
    data = pgmoneta_append(data, "pgmoneta_retention_days ");


### PR DESCRIPTION
The backup.info can updated to add version number to it from the pgmoneta.h file.

example
VERSION = 0.10.0

