### PR TITLE
[#239] Add warning for illegal key while setting master-key manually

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -478,6 +478,7 @@ is_valid_key(char* key)
 
    if (strlen(key) < 8)
    {
+      warnx("Master key must be at least 8 characters long");
       return false;
    }
 
@@ -488,6 +489,7 @@ is_valid_key(char* key)
       /* Only support ASCII for now */
       if ((unsigned char)c & 0x80)
       {
+         warnx("Master key cannot contain non-ASCII characters");
          return false;
       }
    }


### PR DESCRIPTION
This pull request enhances the master key validation process in the `master_key` function by adding warning messages.

Changes:

1. Modified the `is_valid_key` function to check for the following conditions:
   - Key length hint
   - Key cannot contain non-ASCII characters

Optional things could be done in the future:
   - Max length of key, like 64 characters
   - Key must contain at least one digit, one uppercase letter, one lowercase letter, and one symbol