### PR TITLE
[#265] initial manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
       run: sudo apt install -y clang
     - name: Install cJSON
       run: sudo apt install -y libcjson-dev
+    - name: Install pandoc
+      run: sudo apt install pandoc
+    - name: Install pdflatex
+      run: sudo apt install texlive-latex-extra
     - name: GCC/mkdir
       run: mkdir build
       working-directory: /home/runner/work/pgmoneta/pgmoneta/
@@ -148,6 +152,24 @@ jobs:
       run: brew install llvm
     - name: Install cJSON
       run: brew install cjson
+    - name: Install pandoc
+      run: brew install pandoc
+    - name: Install pdflatex
+      run: brew install --cask basictex
+    - name: Refresh env
+      run: eval "$(/usr/libexec/path_helper)"
+    - name: Locate pdflatex and update PATH
+      run: |
+        PDFLATEX_PATH=$(find /usr/local/texlive -name pdflatex -print -quit)
+        if [ -n "$PDFLATEX_PATH" ]; then
+          PDFLATEX_DIR=$(dirname "$PDFLATEX_PATH")
+          echo "PDFLATEX_DIR=$PDFLATEX_DIR" >> $GITHUB_ENV
+          echo "PATH=$PDFLATEX_DIR:$PATH" >> $GITHUB_ENV
+        else
+          echo "pdflatex could not be found"
+          exit 1
+        fi
+      shell: bash
     - name: Install PostgreSQL
       run: brew install postgresql
     - name: GCC/mkdir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,38 @@ if(NOT COMPILER_SUPPORTS_C17)
   message(FATAL_ERROR "The compiler ${CMAKE_C_COMPILER} has no C17 support. Please use a different C compiler.")
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # Homebrew ships libarchive keg only, include dirs have to be set manually
+    execute_process(
+      COMMAND brew --prefix libarchive
+      OUTPUT_VARIABLE LIBARCHIVE_PREFIX
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      COMMAND_ERROR_IS_FATAL ANY
+    )
+    set(LibArchive_INCLUDE_DIR "${LIBARCHIVE_PREFIX}/include")
+
+    execute_process(
+        COMMAND brew --prefix pandoc
+        OUTPUT_VARIABLE PANDOC_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND_ERROR_IS_FATAL ANY
+    )
+endif()
+
+find_package(Pandoc)
+if (PANDOC_FOUND)
+  message(STATUS "pandoc found")
+else ()
+  message(FATAL_ERROR "pandoc needed")
+endif()
+
+find_package(Pdflatex)
+if (PDFLATEX_FOUND)
+  message(STATUS "pdflatex found")
+else ()
+  message(FATAL_ERROR "pdflatex needed")
+endif()
+
 find_package(ZLIB)
 if (ZLIB_FOUND)
   message(STATUS "zlib found")
@@ -97,17 +129,6 @@ if (OPENSSL_FOUND)
   message(STATUS "OpenSSL found")
 else ()
   message(FATAL_ERROR "OpenSSL needed")
-endif()
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    # Homebrew ships libarchive keg only, include dirs have to be set manually
-    execute_process(
-        COMMAND brew --prefix libarchive
-        OUTPUT_VARIABLE LIBARCHIVE_PREFIX
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        COMMAND_ERROR_IS_FATAL ANY
-    )
-    set(LibArchive_INCLUDE_DIR "${LIBARCHIVE_PREFIX}/include")
 endif()
 
 find_package(LibArchive)

--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ See [Architecture](./doc/ARCHITECTURE.md) for the architecture of `pgmoneta`.
 * [libcurl](https://curl.se/libcurl/)
 * [libarchive](http://www.libarchive.org/)
 * [cJSON](https://github.com/DaveGamble/cJSON)
+* [pandoc](https://pandoc.org/)
+* [texlive](https://www.tug.org/texlive/)
 
 ```sh
-dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel libcurl libcurl-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel cjson cjson-devel
+dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel libcurl libcurl-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel cjson cjson-devel pandoc texlive-scheme-basic 'tex(footnote.sty)'
 ```
 
 Alternative [clang 8+](https://clang.llvm.org/) can be used.

--- a/cmake/FindPandoc.cmake
+++ b/cmake/FindPandoc.cmake
@@ -1,0 +1,13 @@
+#
+# pandoc Support
+#
+
+find_program(PANDOC_EXECUTABLE 
+  NAMES pandoc
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Pandoc DEFAULT_MSG 
+                                    PANDOC_EXECUTABLE)
+
+mark_as_advanced(PANDOC_EXECUTABLE)

--- a/cmake/FindPdflatex.cmake
+++ b/cmake/FindPdflatex.cmake
@@ -1,0 +1,33 @@
+#
+# pdflatex Support
+#
+
+find_program(PDFLATEX_EXECUTABLE 
+  NAMES pdflatex
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Pdflatex DEFAULT_MSG
+                                  PDFLATEX_EXECUTABLE)
+
+if(PDFLATEX_FOUND)
+  find_program(KPSEWHICH kpsewhich)
+  if(NOT KPSEWHICH)
+    message(FATAL_ERROR "kpsewhich not found. Please check your TeX installation.")
+  endif()
+
+  execute_process(
+    COMMAND ${KPSEWHICH} footnote.sty
+    OUTPUT_VARIABLE FOOTNOTE_STY_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(NOT FOOTNOTE_STY_PATH)
+    message(FATAL_ERROR "footnote.sty not found. Please install the necessary LaTeX packages.")
+  else()
+    message(STATUS "footnote.sty found at: ${FOOTNOTE_STY_PATH}")
+  endif()
+
+endif()
+
+mark_as_advanced(PDFLATEX_EXECUTABLE)

--- a/doc/manual/dev-00-head.en.md
+++ b/doc/manual/dev-00-head.en.md
@@ -1,0 +1,2 @@
+% pgmoneta
+% Developer Guide

--- a/doc/manual/dev-01-install.en.md
+++ b/doc/manual/dev-01-install.en.md
@@ -1,4 +1,6 @@
-# Developer guide
+\newpage
+
+# Install and Configurateion
 
 for Fedora 38
 
@@ -340,82 +342,4 @@ Now that we've attempted our first backup, take a moment to relax. There are a f
 
 2. Always use uncrustify to format your code when you make modifications.
 
-## Basic git guide
-
-Here are some links that will help you
-
-* [How to Squash Commits in Git](https://www.git-tower.com/learn/git/faq/git-squash)
-* [ProGit book](https://github.com/progit/progit2/releases)
-
-### Start by forking the repository
-
-This is done by the "Fork" button on GitHub.
-
-### Clone your repository locally
-
-This is done by
-
-```sh
-git clone git@github.com:<username>/pgmoneta.git
-```
-
-### Add upstream
-
-Do
-
-```sh
-cd pgmoneta
-git remote add upstream https://github.com/pgmoneta/pgmoneta.git
-```
-
-### Do a work branch
-
-```sh
-git checkout -b mywork main
-```
-
-### Make the changes
-
-Remember to verify the compile and execution of the code
-
-### Multiple commits
-
-If you have multiple commits on your branch then squash them
-
-``` sh
-git rebase -i HEAD~2
-```
-
-for example. It is `p` for the first one, then `s` for the rest
-
-### Rebase
-
-Always rebase
-
-``` sh
-git fetch upstream
-git rebase -i upstream/main
-```
-
-### Force push
-
-When you are done with your changes force push your branch
-
-``` sh
-git push -f origin mywork
-```
-
-and then create a pull requests for it
-
-### Repeat
-
-Based on feedback keep making changes, squashing, rebasing and force pushing
-
-### Undo
-
-Normally you can reset to an earlier commit using `git reset <commit hash> --hard`. 
-But if you accidentally squashed two or more commits, and you want to undo that, 
-you need to know where to reset to, and the commit seems to have lost after you rebased. 
-
-But they are not actually lost - using `git reflog`, you can find every commit the HEAD pointer
-has ever pointed to. Find the commit you want to reset to, and do `git reset --hard`.
+3. If you encounter any problems during testing, the first recommendation is to check the logs. You will find specific details about the error in the log.

--- a/doc/manual/dev-02-git.en.md
+++ b/doc/manual/dev-02-git.en.md
@@ -1,0 +1,82 @@
+\newpage
+
+# Git guide
+
+Here are some links that will help you
+
+* [How to Squash Commits in Git](https://www.git-tower.com/learn/git/faq/git-squash)
+* [ProGit book](https://github.com/progit/progit2/releases)
+
+## Basic steps
+
+### Start by forking the repository
+
+This is done by the "Fork" button on GitHub.
+
+## Clone your repository locally
+
+This is done by
+
+```sh
+git clone git@github.com:<username>/pgmoneta.git
+```
+
+### Add upstream
+
+Do
+
+```sh
+cd pgmoneta
+git remote add upstream https://github.com/pgmoneta/pgmoneta.git
+```
+
+### Do a work branch
+
+```sh
+git checkout -b mywork main
+```
+
+### Make the changes
+
+Remember to verify the compile and execution of the code
+
+### Multiple commits
+
+If you have multiple commits on your branch then squash them
+
+``` sh
+git rebase -i HEAD~2
+```
+
+for example. It is `p` for the first one, then `s` for the rest
+
+### Rebase
+
+Always rebase
+
+``` sh
+git fetch upstream
+git rebase -i upstream/main
+```
+
+### Force push
+
+When you are done with your changes force push your branch
+
+``` sh
+git push -f origin mywork
+```
+
+and then create a pull requests for it
+
+### Repeat
+
+Based on feedback keep making changes, squashing, rebasing and force pushing
+
+### Undo
+
+Normally you can reset to an earlier commit using `git reset <commit hash> --hard`.
+
+But if you accidentally squashed two or more commits, and you want to undo that, you need to know where to reset to, and the commit seems to have lost after you rebased.
+
+But they are not actually lost - using `git reflog`, you can find every commit the HEAD pointer has ever pointed to. Find the commit you want to reset to, and do `git reset --hard`.

--- a/doc/manual/dev-03-architecture.en.md
+++ b/doc/manual/dev-03-architecture.en.md
@@ -1,0 +1,124 @@
+\newpage
+
+# Architecture
+
+## Overview
+
+`pgmoneta` use a process model (`fork()`), where each process handles one Write-Ahead Log (WAL) receiver to [PostgreSQL](https://www.postgresql.org).
+
+The main process is defined in [main.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/main.c).
+
+Backup is handled in [backup.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/backup.h) ([backup.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/backup.c)).
+
+Restore is handled in [restore.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/restore.h) ([restore.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/restore.c)) with linking handled in [link.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/link.h) ([link.c](https://github.com/pgmoneta/pgmoneta/blob/main/libpgmoneta/link.c)).
+
+Archive is handled in [achv.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/achv.h) ([archive.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/archive.c)) backed by restore.
+
+Write-Ahead Log is handled in [wal.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/wal.h) ([wal.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/wal.c)).
+
+Backup information is handled in [info.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/info.h) ([info.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/info.c)).
+
+Retention is handled in [retention.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/retention.h) ([retention.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/retention.c)).
+
+Compression is handled in [gzip.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/gzip.h) ([gzip.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/gzip.c)) and [zstandard.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/zstandard.h) ([zstandard.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/zstandard.c)).
+
+## Shared memory
+
+A memory segment ([shmem.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/shmem.h)) is shared among all processes which contains the `pgmoneta` state containing the configuration and the list of servers.
+
+The configuration of `pgmoneta` (`struct configuration`) and the configuration of the servers (`struct server`) is initialized in this shared memory segment. These structs are all defined in [pgmoneta.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/pgmoneta.h).
+
+The shared memory segment is created using the `mmap()` call.
+
+## Network and messages
+
+All communication is abstracted using the `struct message` data type defined in [messge.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/message.h).
+
+Reading and writing messages are handled in the [message.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/message.h) ([message.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/message.c)) files.
+
+Network operations are defined in [network.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/network.h) ([network.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/network.c)).
+
+## Memory
+
+Each process uses a fixed memory block for its network communication, which is allocated upon startup of the process.
+
+That way we don't have to allocate memory for each network message, and more importantly free it after end of use.
+
+The memory interface is defined in [memory.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/memory.h) ([memory.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/memory.c)).
+
+## Management
+
+`pgmoneta` has a management interface which defines the administrator abilities that can be performed when it is running. This include for example taking a backup. The `pgmoneta-cli` program is used for these operations ([cli.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/cli.c)).
+
+The management interface use Unix Domain Socket for communication.
+
+The management interface is defined in [management.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/management.h). The management interface uses its own protocol which always consist of a header
+
+| Field      | Type | Description |
+|------------|------|-------------|
+| `id` | Byte | The identifier of the message type |
+
+The rest of the message is depending on the message type.
+
+### Remote management
+
+The remote management functionality uses the same protocol as the standard management method.
+
+However, before the management packet is sent the client has to authenticate using SCRAM-SHA-256 using the same message format that PostgreSQL uses, e.g. StartupMessage, AuthenticationSASL, AuthenticationSASLContinue, AuthenticationSASLFinal and AuthenticationOk. The SSLRequest message is supported.
+
+The remote management interface is defined in [remote.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/remote.h) ([remote.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/remote.c)).
+
+## libev usage
+
+[libev](http://software.schmorp.de/pkg/libev.html) is used to handle network interactions, which is "activated" upon an `EV_READ` event.
+
+Each process has its own event loop, such that the process only gets notified when data related only to that process is ready. The main loop handles the system wide "services" such as idle timeout checks and so on.
+
+## Signals
+
+The main process of `pgmoneta` supports the following signals `SIGTERM`, `SIGINT` and `SIGALRM` as a mechanism for shutting down. The `SIGABRT` is used to request a core dump (`abort()`).
+
+The `SIGHUP` signal will trigger a reload of the configuration.
+
+It should not be needed to use `SIGKILL` for `pgmoneta`. Please, consider using `SIGABRT` instead, and share the core dump and debug logs with the `pgmoneta` community.
+
+## Reload
+
+The `SIGHUP` signal will trigger a reload of the configuration.
+
+However, some configuration settings requires a full restart of `pgmoneta` in order to take effect. These are
+
+* `hugepage`
+* `libev`
+* `log_path`
+* `log_type`
+* `unix_socket_dir`
+* `pidfile`
+
+The configuration can also be reloaded using `pgmoneta-cli -c pgmoneta.conf conf reload`. The command is only supported over the local interface, and hence doesn't work remotely.
+
+## Prometheus
+
+pgmoneta has support for [Prometheus](https://prometheus.io/) when the `metrics` port is specified.
+
+The module serves two endpoints
+
+* `/` - Overview of the functionality (`text/html`)
+* `/metrics` - The metrics (`text/plain`)
+
+All other URLs will result in a 403 response.
+
+The metrics endpoint supports `Transfer-Encoding: chunked` to account for a large amount of data.
+
+The implementation is done in [prometheus.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/prometheus.h) and
+[prometheus.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/prometheus.c).
+
+## Logging
+
+Simple logging implementation based on a `atomic_schar` lock.
+
+The implementation is done in [logging.h](https://github.com/pgmoneta/pgmoneta/blob/main/src/include/logging.h) and [logging.c](https://github.com/pgmoneta/pgmoneta/blob/main/src/libpgmoneta/logging.c).
+
+## Protocol
+
+The protocol interactions can be debugged using [Wireshark](https://www.wireshark.org/) or [pgprtdbg](https://github.com/jesperpedersen/pgprtdbg).

--- a/doc/manual/dev-04-distributions.en.md
+++ b/doc/manual/dev-04-distributions.en.md
@@ -1,11 +1,18 @@
+\newpage
+
+# Distributions
+
 This tutorial will show you how to compile and install pgmoneta on various platforms.
+
 Currently, primarily supported platforms covered in this tutorial are:
+
 1. Fedora (37, 38)
 2. Rocky (8.x, 9.x)
 3. RHEL (8.x, 9.x)
 4. FreeBSD 14
 
 ## Requirements
+
 `pgmoneta` requires:
 
 * [gcc 8+](https://gcc.gnu.org) (C17)
@@ -27,75 +34,97 @@ Currently, primarily supported platforms covered in this tutorial are:
 * [texlive](https://www.tug.org/texlive/)
 
 On Fedora, these can be installed using `dnf` or `yum`:
-```
+
+``` sh
 dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel libcurl libcurl-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel cjson cjson-devel pandoc texlive-scheme-basic 'tex(footnote.sty)'
 ```
+
 On Rocky, before you install the required packages, some additional repositories, PowerTools and EPEL in this case, need to be enabled or installed first.
-```
+
+``` sh
 dnf install epel-release
 ```
+
 Then in order to enable powertools, you need to first install subscription-manager
-```
+
+``` sh
 dnf install subscription-manager
 ```
+
 Then
-```
+
+``` sh
 # On Rocky 8.x
 dnf config-manager --set-enabled powertools
 
 # On Rocky 9.x, PowerTools is called crb (CodeReady Builder)
 dnf config-manager --set-enabled crb
-```
+``` 
+
 It is OK to disregard the registration and subscription warning.
-You can verify the repos using 
-```
+
+You can verify the repos using
+
+``` sh
 dnf repolist
 ```
+
 Check if epel and powertools/crb are listed. Then use the command above to install the required packages.
 
-On RHEL, similarly to Rocky, some additional repos need to be enabled/installed first. The only difference is that we'll use
-the CodeReady Linux Builder repository instead of PowerTools.
+On RHEL, similarly to Rocky, some additional repos need to be enabled/installed first. The only difference is that we'll use the CodeReady Linux Builder repository instead of PowerTools.
+
 First you will still need to install EPEL, use
-```
+
+``` sh
 # On RHEL 8.x
 dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 # On RHEL 9.x
 dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 ```
-Then for the CodeReady Linux Builder repository, 
-```
+
+Then for the CodeReady Linux Builder repository,
+
+``` sh
 dnf install subscription-manager
 # On RHEL 8.x
 dnf config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms
 # On RHEL 9.x
 dnf config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms
 ```
-Alternatively, after installing subscription manager, if you have a RedHat corporate account
-(you need to specify the company/organization name in your account), you can first register with subscription manager using
-```
+
+Alternatively, after installing subscription manager, if you have a RedHat corporate account (you need to specify the company/organization name in your account), you can first register with subscription manager using
+
+``` sh
 subscription-manager register --username <your-account-email-or-login> --password <your-password> --auto-attach
 ```
+
 Then do
-```
+
+``` sh
 # On RHEL 8.x
 subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 # On RHEL 9.x
 subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
 ```
+
 Also verify the repos using
-```
+
+``` sh
 dnf repolist
 ```
+
 Install required packages after the previous steps.
 
-On FreeBSD, `pkg` is used instead of `dnf` or `yum`. 
+On FreeBSD, `pkg` is used instead of `dnf` or `yum`.
 
 Use `pkg install <package name>` to install the following packages
-```
+
+``` sh
 git gcc cmake libev openssl libssh zlib-ng zstd liblz4 bzip2 curl py39-docutils libarchive libcjson
 ```
 
 ## Compile
+
 Compiling pgmoneta on different platforms is the same.
 
 ### Release build
@@ -128,5 +157,5 @@ make
 Remember to set the `log_level` configuration option to `debug5`.
 
 ## Install
-The installation process of `pgmoneta` is the same on all platforms. Please follow the
-instructions in the [tutorial](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/01_install.md).
+
+The installation process of `pgmoneta` is the same on all platforms. Please follow the instructions in the [tutorial](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/01_install.md).

--- a/doc/manual/dev-05-encryption.en.md
+++ b/doc/manual/dev-05-encryption.en.md
@@ -1,0 +1,162 @@
+\newpage
+
+# Encryption
+
+## Overview
+
+AES Cipher block chaining (CBC) mode and AES Counter (CTR) mode are supported in pgmoneta. The default setup is no encryption.
+
+CBC is the most commonly used and considered save mode. Its main drawbacks are that encryption is sequential (decryption can be parallelized).
+
+Along with CBC, CTR mode is one of two block cipher modes recommended by Niels Ferguson and Bruce Schneier. Both encryption and decryption are parallelizable.
+
+Longer the key length, safer the encryption. However, with 20% (192 bit) and 40% (256 bit) extra workload compare to 128 bit.
+
+## Encryption Configuration
+
+`none`: No encryption (default value)
+
+`aes | aes-256 | aes-256-cbc`: AES CBC (Cipher Block Chaining) mode with 256 bit key length
+
+`aes-192 | aes-192-cbc`: AES CBC mode with 192 bit key length
+
+`aes-128 | aes-128-cbc`: AES CBC mode with 128 bit key length
+
+`aes-256-ctr`: AES CTR (Counter) mode with 256 bit key length
+
+`aes-192-ctr`: AES CTR mode with 192 bit key length
+
+`aes-128-ctr`: AES CTR mode with 128 bit key length
+
+## Encryption / Decryption CLI Commands
+
+### decrypt
+
+Decrypt the file in place, remove encrypted file after successful decryption.
+
+Command
+
+``` sh
+pgmoneta-cli decrypt <file>
+```
+
+### encrypt
+
+Encrypt the file in place, remove unencrypted file after successful encryption.
+
+Command
+
+``` sh
+pgmoneta-cli encrypt <file>
+```
+
+## Benchmark
+
+Check if your CPU have [AES-NI](https://en.wikipedia.org/wiki/AES_instruction_set)
+
+```sh
+cat /proc/cpuinfo | grep aes
+```
+
+Query number of cores on your CPU
+
+```sh
+lscpu | grep '^CPU(s):'
+```
+
+By default openssl using AES-NI if the CPU have it.
+
+```sh
+openssl speed -elapsed -evp aes-128-cbc
+```
+
+Speed test with explicit disabled AES-NI feature
+
+```sh
+OPENSSL_ia32cap="~0x200000200000000" openssl speed -elapsed -evp aes-128-cbc
+```
+
+Test decrypt
+
+```sh
+openssl speed -elapsed -decrypt -evp aes-128-cbc
+```
+
+Speed test with 8 cores
+
+``` sh
+openssl speed -multi 8 -elapsed -evp aes-128-cbc
+```
+
+```console
+Architecture:            x86_64
+  CPU op-mode(s):        32-bit, 64-bit
+  Address sizes:         39 bits physical, 48 bits virtual
+  Byte Order:            Little Endian
+CPU(s):                  12
+  On-line CPU(s) list:   0-11
+Vendor ID:               GenuineIntel
+  Model name:            Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+    CPU family:          6
+    Model:               158
+    Thread(s) per core:  2
+    Core(s) per socket:  6
+    Socket(s):           1
+    Stepping:            10
+    BogoMIPS:            5183.98
+    Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 s
+                         s ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid pni pclmulqdq vmx ssse
+                         3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowpr
+                         efetch invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi ept vpid ept_ad fsgsbase bmi1 avx2 s
+                         mep bmi2 erms invpcid rdseed adx smap clflushopt xsaveopt xsavec xgetbv1 xsaves flush_l1d arch_capa
+                         bilities
+Virtualization features: 
+  Virtualization:        VT-x
+  Hypervisor vendor:     Microsoft
+  Virtualization type:   full
+Caches (sum of all):     
+  L1d:                   192 KiB (6 instances)
+  L1i:                   192 KiB (6 instances)
+  L2:                    1.5 MiB (6 instances)
+  L3:                    12 MiB (1 instance)
+Vulnerabilities:         
+  Itlb multihit:         KVM: Mitigation: VMX disabled
+  L1tf:                  Mitigation; PTE Inversion; VMX conditional cache flushes, SMT vulnerable
+  Mds:                   Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
+  Meltdown:              Mitigation; PTI
+  Spec store bypass:     Mitigation; Speculative Store Bypass disabled via prctl and seccomp
+  Spectre v1:            Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+  Spectre v2:            Mitigation; Full generic retpoline, IBPB conditional, IBRS_FW, STIBP conditional, RSB filling
+  Srbds:                 Unknown: Dependent on hypervisor status
+  Tsx async abort:       Not affected
+
+openssl version: 3.0.5
+built on: Tue Jul  5 00:00:00 2022 UTC
+options: bn(64,64)
+compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wa,--noexecstack -Wa,--generate-missing-build-notes=yes -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DZLIB -DNDEBUG -DPURIFY -DDEVRANDOM="\"/dev/urandom\"" -DSYSTEM_CIPHERS_FILE="/etc/crypto-policies/back-ends/openssl.config"
+The 'numbers' are in 1000s of bytes per second processed.
+type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
+AES-128-CBC *   357381.06k   414960.06k   416301.23k   416687.10k   416175.45k   416268.29k
+AES-128-CBC     902160.83k  1496344.68k  1514778.62k  1555236.52k  1542537.22k  1569259.52k
+AES-128-CBC d   909710.79k  2941259.46k  5167110.31k  5927086.76k  6365967.70k  6349198.68k
+AES-128-CBC 8  3912786.36k  8042348.31k  9870507.86k 10254096.38k 10653332.82k 10310331.05k
+AES-128-CBC 8d 4157037.26k 12337480.36k 26613686.27k 29902703.27k 32306793.13k 31440366.25k
+
+AES-128-CTR *   146971.83k   165696.94k   574871.64k   634507.61k   676448.94k   668139.52k
+AES-128-CTR     887783.06k  2255074.22k  4800168.19k  5930596.01k  6431110.49k  6376062.98k
+AES-128-CTR d   793432.63k  2181439.06k  4541298.09k  5743022.42k  6480090.45k  6271221.76k
+AES-128-CTR 8  3833975.47k 10832239.55k 23757293.40k 28413146.79k 30514317.99k 30092356.27k
+AES-128-CTR 8d 3456838.44k  9749773.91k 22107652.18k 27229352.28k 30703026.18k 29387025.07k
+
+AES-192-CBC     853380.50k  1238507.90k  1299788.12k  1257189.03k  1272591.70k  1271840.77k
+AES-192-CBC d   876094.29k  2843770.82k  4523019.52k  5177496.92k  5442652.84k  5372559.36k
+AES-192-CTR     869039.84k  2285946.18k  4229439.91k  5049118.04k  5422994.77k  5309748.57k
+AES-192-CTR d   789470.51k  2177050.05k  4194812.76k  4935891.63k  5257865.90k  5323046.91k
+
+AES-256-CBC     834298.24k  1100648.64k  1117826.90k  1104301.40k  1130657.11k  1097285.63k
+AES-256-CBC d   843079.68k  2714917.67k  4084088.23k  4510005.59k  4557821.27k  4594783.57k
+AES-256-CTR     811325.74k  2222582.89k  3749333.08k  4412143.27k  4640549.55k  4554828.46k
+AES-256-CTR d   730844.97k  2081179.20k  3673258.15k  4346793.64k  4515722.58k  4594335.74k
+```
+
+*: AES-NI disabled; 8: 8 cores; d: decryption

--- a/doc/manual/dev-06-rpm.en.md
+++ b/doc/manual/dev-06-rpm.en.md
@@ -1,0 +1,37 @@
+\newpage
+
+# RPM
+
+`pgmoneta` can be built into a RPM for [Fedora](https://getfedora.org/) systems.
+
+## Requirements
+
+```sh
+dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools chrpath
+```
+
+## Setup RPM development
+
+```sh
+rpmdev-setuptree
+```
+
+## Create source package
+
+```sh
+git clone https://github.com/pgmoneta/pgmoneta.git
+cd pgmoneta
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make package_source
+```
+
+## Create RPM package
+
+```sh
+cp pgmoneta-$VERSION.tar.gz ~/rpmbuild/SOURCES
+QA_RPATHS=0x0001 rpmbuild -bb pgmoneta.spec
+```
+
+The resulting RPM will be located in `~/rpmbuild/RPMS/x86_64/`, if your architecture is `x86_64`.

--- a/doc/manual/user-00-head.en.md
+++ b/doc/manual/user-00-head.en.md
@@ -1,0 +1,2 @@
+% pgmoneta
+% User Guide

--- a/doc/manual/user-01-introduction.en.md
+++ b/doc/manual/user-01-introduction.en.md
@@ -1,0 +1,30 @@
+\newpage
+
+# Introduction
+
+[**pgmoneta**](https://github.com/pgmoneta/pgmoneta) is a backup / restore solution for [PostgreSQL](https://www.postgresql.org).
+
+**pgmoneta** is named after the Roman Goddess of Memory.
+
+## Features
+
+* Full backup
+* Restore
+* Compression (gzip, zstd, lz4, bzip2)
+* AES encryption support
+* Symlink support
+* WAL shipping support
+* Prometheus support
+* Remote management
+* Offline mode
+* Transport Layer Security (TLS) v1.2+ support
+* Daemon mode
+* User vault
+
+## Tested platforms
+
+* [Fedora](https://getfedora.org/) 32+
+* [RHEL](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux) 8.x with
+  [AppStream](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_managing_and_removing_user-space_components/using-appstream_using-appstream)
+* [FreeBSD](https://www.freebsd.org/)
+* [OpenBSD](http://www.openbsd.org/)

--- a/doc/manual/user-02-quickstart.en.md
+++ b/doc/manual/user-02-quickstart.en.md
@@ -1,0 +1,314 @@
+\newpage
+
+# Quick start
+
+## Compiling the source
+
+We recommend using `Fedora` to test and run pgmoneta, but other Linux systems and macOS are also supported.
+
+`pgmoneta` requires
+
+* [gcc 8+](https://gcc.gnu.org) (C17)
+* [cmake](https://cmake.org)
+* [make](https://www.gnu.org/software/make/)
+* [libev](http://software.schmorp.de/pkg/libev.html)
+* [OpenSSL](http://www.openssl.org/)
+* [zlib](https://zlib.net)
+* [zstd](http://www.zstd.net)
+* [lz4](https://lz4.github.io/lz4/)
+* [bzip2](http://sourceware.org/bzip2/)
+* [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
+* [rst2man](https://docutils.sourceforge.io/)
+* [libssh](https://www.libssh.org/)
+* [libcurl](https://curl.se/libcurl/)
+* [libarchive](http://www.libarchive.org/)
+* [cJSON](https://github.com/DaveGamble/cJSON)
+* [pandoc](https://pandoc.org/)
+* [texlive](https://www.tug.org/texlive/)
+
+```sh
+dnf install git gcc cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel libcurl libcurl-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel cjson cjson-devel pandoc texlive-scheme-basic 'tex(footnote.sty)'
+```
+
+Alternative [clang 8+](https://clang.llvm.org/) can be used.
+
+## Build
+
+### Release build
+
+The following commands will install `pgmoneta` in the `/usr/local` hierarchy.
+
+```sh
+git clone https://github.com/pgmoneta/pgmoneta.git
+cd pgmoneta
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+make
+sudo make install
+```
+
+See [RPM](https://github.com/pgmoneta/pgmoneta/blob/main/doc/RPM.md) for how to build a RPM of `pgmoneta`.
+
+### Debug build
+
+The following commands will create a `DEBUG` version of `pgmoneta`.
+
+```sh
+git clone https://github.com/pgmoneta/pgmoneta.git
+cd pgmoneta
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make
+```
+
+## Check
+
+Make sure that `pgmoneta` is installed and in your path by using `pgmoneta -?`. You should see
+
+``` console
+pgmoneta 0.11.0
+  Backup / restore solution for PostgreSQL
+
+Usage:
+  pgmoneta [ -c CONFIG_FILE ] [ -u USERS_FILE ] [ -d ]
+
+Options:
+  -c, --config CONFIG_FILE Set the path to the pgmoneta.conf file
+  -u, --users USERS_FILE   Set the path to the pgmoneta_users.conf file
+  -A, --admins ADMINS_FILE Set the path to the pgmoneta_admins.conf file
+  -d, --daemon             Run as a daemon
+      --offline            Run in offline mode
+  -V, --version            Display version information
+  -?, --help               Display help
+```
+
+If you encounter any issues following the above steps, you can refer to the **Developer Guide** under **Install pgmoneta** to see how to compile and install pgmoneta on your system.
+
+## Configuration
+
+Lets create a simple configuration file called `pgmoneta.conf` with the content
+
+``` ini
+[pgmoneta]
+host = *
+metrics = 5001
+
+base_dir = /home/pgmoneta
+
+compression = zstd
+
+storage_engine = local
+
+retention = 7
+
+log_type = file
+log_level = info
+log_path = /tmp/pgmoneta.log
+
+unix_socket_dir = /tmp/
+
+[primary]
+host = localhost
+port = 5432
+user = repl
+wal_slot = repl
+```
+
+In our main section called `[pgmoneta]` we setup `pgmoneta` to listen on all network addresses. We will enable Prometheus metrics on port 5001 and have the backups live in the `/home/pgmoneta` directory. All backups are being compressed with zstd and kept for 7 days. Logging will be performed at `info` level and put in a file called `/tmp/pgmoneta.log`. Last we specify the location of the `unix_socket_dir` used for management operations and the path for the PostgreSQL command line tools.
+
+Next we create a section called `[primary]` which has the information about our [PostgreSQL](https://www.postgresql.org) instance. In this case it is running on `localhost` on port `5432` and we will use the `repl` user account to connect, and the Write+Ahead slot will be named `repl` as well.
+
+The `repl` user must have the `REPLICATION` role and have access to the `postgres` database,
+so for example
+
+``` sh
+CREATE ROLE repl WITH LOGIN REPLICATION PASSWORD 'secretpassword';
+```
+
+and in `pg_hba.conf`
+
+``` ini
+local   postgres        repl                                   scram-sha-256
+host    postgres        repl           127.0.0.1/32            scram-sha-256
+host    postgres        repl           ::1/128                 scram-sha-256
+host    replication     repl           127.0.0.1/32            scram-sha-256
+host    replication     repl           ::1/128                 scram-sha-256
+```
+
+The authentication type should be based on `postgresql.conf`'s `password_encryption` value.
+
+Then, create a physical replication slot that will be used for Write-Ahead Log streaming, like
+
+``` sh
+SELECT pg_create_physical_replication_slot('repl', true, false);
+```
+
+Alternatively, configure automatically slot creation by adding `create_slot = yes` to `[pgmoneta]` or corresponding server section.
+
+We will need a user vault for the `repl` account, so the following commands will add a master key, and the `repl` password. The master key should be longer than 8 characters.
+
+``` sh
+pgmoneta-admin master-key
+pgmoneta-admin -f pgmoneta_users.conf user add
+```
+
+We are now ready to run `pgmoneta`.
+
+See charpter **Configuration** for all configuration options.
+
+## Running
+
+We will run `pgmoneta` using the command
+
+``` sh
+pgmoneta -c pgmoneta.conf -u pgmoneta_users.conf
+```
+
+If this doesn't give an error, then we are ready to do backups.
+
+`pgmoneta` is stopped by pressing Ctrl-C (`^C`) in the console where you started it, or by sending the `SIGTERM` signal to the process using `kill <pid>`.
+
+## Run-time administration
+
+`pgmoneta` has a run-time administration tool called `pgmoneta-cli`.
+
+You can see the commands it supports by using `pgmoneta-cli -?` which will give
+
+``` console
+pgmoneta-cli 0.11.0
+  Command line utility for pgmoneta
+
+Usage:
+  pgmoneta-cli [ -c CONFIG_FILE ] [ COMMAND ]
+
+Options:
+  -c, --config CONFIG_FILE Set the path to the pgmoneta.conf file
+  -h, --host HOST          Set the host name
+  -p, --port PORT          Set the port number
+  -U, --user USERNAME      Set the user name
+  -P, --password PASSWORD  Set the password
+  -L, --logfile FILE       Set the log file
+  -v, --verbose            Output text string of result
+  -V, --version            Display version information
+  -?, --help               Display help
+
+Commands:
+  backup                   Backup a server
+  list-backup              List the backups for a server
+  restore                  Restore a backup from a server
+  archive                  Archive a backup from a server
+  delete                   Delete a backup from a server
+  retain                   Retain a backup from a server
+  expunge                  Expunge a backup from a server
+  encrypt                  Encrypt a file using master-key
+  decrypt                  Decrypt a file using master-key
+  ping                     Check if pgmoneta is alive
+  stop                     Stop pgmoneta
+  status [details]         Status of pgmoneta, with optional details
+  conf <action>            Manage the configuration, with one of subcommands:
+                           - 'reload' to reload the configuration
+  clear <what>             Clear data, with:
+                           - 'prometheus' to reset the Prometheus statistics
+```
+
+This tool can be used on the machine running `pgmoneta` to do a backup like
+
+``` sh
+pgmoneta-cli -c pgmoneta.conf backup primary
+```
+
+A restore would be
+
+``` sh
+pgmoneta-cli -c pgmoneta.conf restore primary <timestamp> /path/to/restore
+```
+
+To stop pgmoneta you would use
+
+``` sh
+pgmoneta-cli -c pgmoneta.conf stop
+```
+
+Check the outcome of the operations by verifying the exit code, like
+
+``` sh
+echo $?
+```
+
+or by using the `-v` flag.
+
+If pgmoneta has both Transport Layer Security (TLS) and `management` enabled then `pgmoneta-cli` can connect with TLS using the files `~/.pgmoneta/pgmoneta.key` (must be 0600 permission), `~/.pgmoneta/pgmoneta.crt` and `~/.pgmoneta/root.crt`.
+
+## Administration
+
+`pgmoneta` has an administration tool called `pgmoneta-admin`, which is used to control user registration with `pgmoneta`.
+
+You can see the commands it supports by using `pgmoneta-admin -?` which will give
+
+``` console
+pgmoneta-admin 0.11.0
+  Administration utility for pgmoneta
+
+Usage:
+  pgmoneta-admin [ -f FILE ] [ COMMAND ]
+
+Options:
+  -f, --file FILE         Set the path to a user file
+  -U, --user USER         Set the user name
+  -P, --password PASSWORD Set the password for the user
+  -g, --generate          Generate a password
+  -l, --length            Password length
+  -V, --version           Display version information
+  -?, --help              Display help
+
+Commands:
+  master-key              Create or update the master key
+  user <subcommand>       Manage a specific user, where <subcommand> can be
+                          - add  to add a new user
+                          - del  to remove an existing user
+                          - edit to change the password for an existing user
+                          - ls   to list all available users
+
+```
+
+In order to set the master key for all users you can use
+
+``` sh
+pgmoneta-admin -g master-key
+```
+
+The master key must be at least 8 characters.
+
+Then use the other commands to add, update, remove or list the current user names, f.ex.
+
+``` sh
+pgmoneta-admin -f pgmoneta_users.conf user add
+```
+
+## Next Steps
+
+Next steps in improving pgmoneta's configuration could be
+
+* Update `pgmoneta.conf` with the required settings for your system
+* Enable Transport Layer Security v1.2+ (TLS) for administrator access
+
+See [Configuration](https://github.com/pgmoneta/pgmoneta/blob/main/doc/CONFIGURATION.md) for more information on these subjects.
+
+## Tutorials
+
+There are a few short tutorials available to help you better understand and configure `pgmoneta`:
+
+* [Installing pgmoneta](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/01_install.md)
+* [Using a replication slot](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/02_replication_slot.md)
+* [Enabling remote management](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/03_remote_management.md)
+* [Enabling Prometheus metrics](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/04_prometheus.md)
+* [Doing backup and restore](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/05_backup_restore.md)
+* [Creating an archive](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/06_archive.md)
+* [Deleting a backup](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/07_delete.md)
+* [Encryption and decryption](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/08_encryption.md)
+* [Retention](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/09_retention.md)
+* [Enabling Grafana dashboard](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/10_grafana.md)
+* [Add WAL shipping](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/11_wal_shipping.md)
+* [Working with Transport Level Security](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/12_tls.md)

--- a/doc/manual/user-03-configuration.en.md
+++ b/doc/manual/user-03-configuration.en.md
@@ -1,0 +1,116 @@
+\newpage
+
+# Configuration
+
+The configuration is loaded from either the path specified by the `-c` flag or `/etc/pgmoneta/pgmoneta.conf`.
+
+The configuration of `pgmoneta` is split into sections using the `[` and `]` characters.
+
+The main section, called `[pgmoneta]`, is where you configure the overall properties of `pgmoneta`.
+
+Other sections doesn't have any requirements to their naming so you can give them meaningful names like `[primary]` for the primary [PostgreSQL](https://www.postgresql.org) instance.
+
+All properties are in the format `key = value`.
+
+The characters `#` and `;` can be used for comments; must be the first character on the line.
+
+The `Bool` data type supports the following values: `on`, `yes`, `1`, `true`, `off`, `no`, `0` and `false`.
+
+See a [sample](https://github.com/pgmoneta/pgmoneta/blob/main/doc/etc/pgmoneta.conf) configuration for running `pgmoneta` on `localhost`.
+
+## [pgmoneta]
+
+| Property | Default | Unit | Required | Description |
+|----------|---------|------|----------|-------------|
+| host | | String | Yes | The bind address for pgmoneta |
+| unix_socket_dir | | String | Yes | The Unix Domain Socket location |
+| base_dir | | String | Yes | The base directory for the backup |
+| metrics | 0 | Int | No | The metrics port (disable = 0) |
+| metrics_cache_max_age | 0 | String | No | The number of seconds to keep in cache a Prometheus (metrics) response. If set to zero, the caching will be disabled. Can be a string with a suffix, like `2m` to indicate 2 minutes |
+| metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
+| management | 0 | Int | No | The remote management port (disable = 0) |
+| compression | zstd | String | No | The compression type (none, gzip, client-gzip, server-gzip, zstd, client-zstd, server-zstd, lz4, client-lz4, server-lz4, bzip2, client-bzip2) |
+| compression_level | 3 | Int | No | The compression level |
+| workers | 0 | Int | No | The number of workers that each process can use for its work. Use 0 to disable |
+| storage_engine | local | String | No | The storage engine type (local, ssh, s3, azure) |
+| encryption | none | String | No | The encryption mode for encrypt wal and data<br/> `none`: No encryption <br/> `aes` or `aes-256` or `aes-256-cbc`: AES CBC (Cipher Block Chaining) mode with 256 bit key length<br/> `aes-192` or `aes-192-cbc`: AES CBC mode with 192 bit key length<br/> `aes-128` or `aes-128-cbc`: AES CBC mode with 128 bit key length<br/> `aes-256-ctr`: AES CTR (Counter) mode with 256 bit key length<br/> `aes-192-ctr`: AES CTR mode with 192 bit key length<br/> `aes-128-ctr`: AES CTR mode with 128 bit key length |
+| create_slot | no | Bool | No | Create a replication slot for all server. Valid values are: yes, no |
+| ssh_hostname | | String | Yes | Defines the hostname of the remote system for connection |
+| ssh_username | | String | Yes | Defines the username of the remote system for connection |
+| ssh_base_dir | | String | Yes | The base directory for the remote backup |
+| ssh_ciphers | aes-256-ctr, aes-192-ctr, aes-128-ctr | String | No | The supported ciphers for communication. `aes` or `aes-256` or `aes-256-cbc`: AES CBC (Cipher Block Chaining) mode with 256 bit key length<br/> `aes-192` or `aes-192-cbc`: AES CBC mode with 192 bit key length<br/> `aes-128` or `aes-128-cbc`: AES CBC mode with 128 bit key length<br/> `aes-256-ctr`: AES CTR (Counter) mode with 256 bit key length<br/> `aes-192-ctr`: AES CTR mode with 192 bit key length<br/> `aes-128-ctr`: AES CTR mode with 128 bit key length. Otherwise verbatim |
+| s3_aws_region | | String | Yes | The AWS region |
+| s3_access_key_id | | String | Yes | The IAM access key ID |
+| s3_secret_access_key | | String | Yes | The IAM secret access key |
+| s3_bucket | | String | Yes | The AWS S3 bucket name |
+| s3_base_dir | | String | Yes | The base directory for the S3 bucket |
+| azure_storage_account | | String | Yes | The Azure storage account name |
+| azure_container | | String | Yes | The Azure container name |
+| azure_shared_key | | String | Yes | The Azure storage account key |
+| azure_base_dir | | String | Yes | The base directory for the Azure container |
+| retention | 7, - , - , - | Array | No | The retention time in days, weeks, months, years |
+| link | `on` | Bool | No | Use links to limit backup size |
+| log_type | console | String | No | The logging type (console, file, syslog) |
+| log_level | info | String | No | The logging level, any of the (case insensitive) strings `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG` (that can be more specific as `DEBUG1` thru `DEBUG5`). Debug level greater than 5 will be set to `DEBUG5`. Not recognized values will make the log_level be `INFO` |
+| log_path | pgmoneta.log | String | No | The log file location. Can be a strftime(3) compatible string. |
+| log_rotation_age | 0 | String | No | The age that will trigger a log file rotation. If expressed as a positive number, is managed as seconds. Supports suffixes: 'S' (seconds, the default), 'M' (minutes), 'H' (hours), 'D' (days), 'W' (weeks). A value of `0` disables. |
+| log_rotation_size | 0 | String | No | The size of the log file that will trigger a log rotation. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes). A value of `0` (with or without suffix) disables. |
+| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | A strftime(3) compatible string to use as prefix for every log line. Must be quoted if contains spaces. |
+| log_mode | append | String | No | Append to or create the log file (append, create) |
+| blocking_timeout | 30 | Int | No | The number of seconds the process will be blocking for a connection (disable = 0) |
+| tls | `off` | Bool | No | Enable Transport Layer Security (TLS) |
+| tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgmoneta or root. |
+| tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgmoneta or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |
+| tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgmoneta or root.  |
+| libev | `auto` | String | No | Select the [libev](http://software.schmorp.de/pkg/libev.html) backend to use. Valid options: `auto`, `select`, `poll`, `epoll`, `iouring`, `devpoll` and `port` |
+| buffer_size | 65535 | Int | No | The network buffer size (`SO_RCVBUF` and `SO_SNDBUF`) |
+| backup_max_rate | 0 | Int | No | The number of bytes of tokens added every one second to limit the backup rate|
+| network_max_rate | 0 | Int | No | The number of bytes of tokens added every one second to limit the netowrk backup rate|
+| keep_alive | on | Bool | No | Have `SO_KEEPALIVE` on sockets |
+| nodelay | on | Bool | No | Have `TCP_NODELAY` on sockets |
+| non_blocking | on | Bool | No | Have `O_NONBLOCK` on sockets |
+| backlog | 16 | Int | No | The backlog for `listen()`. Minimum `16` |
+| hugepage | `try` | String | No | Huge page support (`off`, `try`, `on`) |
+| pidfile | | String | No | Path to the PID file. If not specified, it will be automatically set to `unix_socket_dir/pgmoneta.<host>.pid` where `<host>` is the value of the `host` parameter or `all` if `host = *`.|
+| update_process_title | `verbose` | String | No | The behavior for updating the operating system process title. Allowed settings are: `never` (or `off`), does not update the process title; `strict` to set the process title without overriding the existing initial process title length; `minimal` to set the process title to the base description; `verbose` (or `full`) to set the process title to the full description. Please note that `strict` and `minimal` are honored only on those systems that do not provide a native way to set the process title (e.g., Linux). On other systems, there is no difference between `strict` and `minimal` and the assumed behaviour is `minimal` even if `strict` is used. `never` and `verbose` are always honored, on every system. On Linux systems the process title is always trimmed to 255 characters, while on system that provide a natve way to set the process title it can be longer. |
+
+## Server section
+
+| Property | Default | Unit | Required | Description |
+|----------|---------|------|----------|-------------|
+| host | | String | Yes | The address of the PostgreSQL instance |
+| port | | Int | Yes | The port of the PostgreSQL instance |
+| user | | String | Yes | The replication user name |
+| wal_slot | | String | Yes | The replication slot for WAL |
+| create_slot | no | Bool | No | Create a replication slot for this server. Valid values are: yes, no |
+| follow | | String | No | Failover to this server if follow server fails |
+| retention | | Array | No | The retention for the server in days, weeks, months, years |
+| wal_shipping | | String | No | The WAL shipping directory |
+| hot_standby | | String | No | Hot standby directory |
+| hot_standby_overrides | | String | No | Files to override in the hot standby directory |
+| workers | -1 | Int | No | The number of workers that each process can use for its work. Use 0 to disable, -1 means use the global settting |
+| backup_max_rate | -1 | Int | No | The number of bytes of tokens added every one second to limit the backup rate. Use 0 to disable, -1 means use the global settting|
+| network_max_rate | -1 | Int | No | The number of bytes of tokens added every one second to limit the netowrk backup rate. Use 0 to disable, -1 means use the global settting|
+| tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgmoneta or root. |
+| tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgmoneta or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. |
+| tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgmoneta or root.  |
+
+The `user` specified must have the `REPLICATION` option in order to stream the Write-Ahead Log (WAL), and must have access to the `postgres` database in order to get the necessary configuration parameters.
+
+Note, that PostgreSQL 12+ is required, as well as having `wal_level` at `replica` or `logical` level.
+
+Note, that if `host` starts with a `/` it represents a path and `pgmoneta` will connect using a Unix Domain Socket.
+
+## pgmoneta_users configuration
+
+The `pgmoneta_users` configuration defines the users known to the system. This file is created and managed through the `pgmoneta-admin` tool.
+
+The configuration is loaded from either the path specified by the `-u` flag or `/etc/pgmoneta/pgmoneta_users.conf`.
+
+## pgmoneta_admins configuration
+
+The `pgmoneta_admins` configuration defines the administrators known to the system. This file is created and managed through the `pgmoneta-admin` tool.
+
+The configuration is loaded from either the path specified by the `-A` flag or `/etc/pgmoneta/pgmoneta_admins.conf`.
+
+If pgmoneta has both Transport Layer Security (TLS) and `management` enabled then `pgmoneta-cli` can connect with TLS using the files `~/.pgmoneta/pgmoneta.key` (must be 0600 permission), `~/.pgmoneta/pgmoneta.crt` and `~/.pgmoneta/root.crt`.

--- a/doc/manual/user-04-cli.en.md
+++ b/doc/manual/user-04-cli.en.md
@@ -1,0 +1,243 @@
+\newpage
+
+# Command line interface
+
+``` sh
+pgmoneta-cli [ -c CONFIG_FILE ] [ COMMAND ]
+
+-c, --config CONFIG_FILE Set the path to the pgmoneta.conf file
+-h, --host HOST          Set the host name
+-p, --port PORT          Set the port number
+-U, --user USERNAME      Set the user name
+-P, --password PASSWORD  Set the password
+-L, --logfile FILE       Set the log file
+-v, --verbose            Output text string of result
+-V, --version            Display version information
+-?, --help               Display help
+```
+
+## backup
+
+Backup a server
+
+Command
+
+``` sh
+pgmoneta-cli backup [<server>|all]
+```
+
+Example
+
+``` sh
+pgmoneta-cli backup primary
+```
+
+## list-backup
+
+List the backups for a server
+
+Command
+
+``` sh
+pgmoneta-cli list-backup <server>
+```
+
+Example
+
+``` sh
+pgmoneta-cli list-backup primary
+```
+
+## restore
+
+Restore a backup from a server
+
+Command
+
+``` sh
+pgmoneta-cli restore <server> [<timestamp>|oldest|newest] [[current|name=X|xid=X|lsn=X|time=X|inclusive=X|timeline=X|action=X|primary|replica],*] <directory>
+```
+
+Example
+
+``` sh
+pgmoneta-cli restore primary newest name=MyLabel,primary /tmp
+```
+
+## archive
+
+Archive a backup from a server
+
+Command
+
+``` sh
+pgmoneta-cli archive <server> [<timestamp>|oldest|newest] [[current|name=X|xid=X|lsn=X|time=X|inclusive=X|timeline=X|action=X|primary|replica],*] <directory>
+```
+
+Example
+
+``` sh
+pgmoneta-cli archive primary newest current /tmp
+```
+
+## delete
+
+Delete a backup from a server
+
+Command
+
+``` sh
+pgmoneta-cli delete <server> [<timestamp>|oldest|newest]
+```
+
+Example
+
+``` sh
+pgmoneta-cli delete primary oldest
+```
+
+## retain
+
+Retain a backup from a server. The backup will not be deleted by the retention policy
+
+Command
+
+``` sh
+pgmoneta-cli retain <server> [<timestamp>|oldest|newest]
+```
+
+Example
+
+``` sh
+pgmoneta-cli retain primary oldest
+```
+
+## expunge
+
+Expunge a backup from a server. The backup will be deleted by the retention policy
+
+Command
+
+``` sh
+pgmoneta-cli expunge <server> [<timestamp>|oldest|newest]
+```
+
+Example
+
+``` sh
+pgmoneta-cli expunge primary oldest
+```
+
+## ping
+
+Verify if pgmoneta is alive
+
+Command
+
+``` sh
+pgmoneta-cli ping
+```
+
+Example
+
+``` sh
+pgmoneta-cli ping
+```
+
+## stop
+
+Stop pgmoneta
+
+Command
+
+``` sh
+pgmoneta-cli stop
+```
+
+Example
+
+``` sh
+pgmoneta-cli stop
+```
+
+## status
+
+Status of pgmoneta, with a `details` option
+
+Command
+
+``` sh
+pgmoneta-cli status [details]
+```
+
+Example
+
+``` sh
+pgmoneta-cli status details
+```
+
+## conf
+
+Manage the configuration
+
+Command
+
+``` sh
+pgmoneta-cli conf [reload]
+```
+
+Subcommand
+
+- `reload`: Reload configuration
+
+Example
+
+``` sh
+pgmoneta-cli conf reload
+```
+
+## Clear
+
+Clear data/statistics
+
+Command
+
+``` sh
+pgmoneta-cli clear [prometheus]
+```
+
+Subcommand
+
+- `prometheus`: Reset the Prometheus statistics
+
+Example
+
+``` sh
+pgmoneta-cli clear prometheus
+```
+
+## decrypt
+
+Decrypt the file in place, remove encrypted file after successful decryption.
+
+Command
+
+``` sh
+pgmoneta-cli decrypt <file>
+```
+
+## encrypt
+
+Encrypt the file in place, remove unencrypted file after successful encryption.
+
+Command
+
+``` sh
+pgmoneta-cli encrypt <file>
+```
+
+## Shell completions
+
+There is a minimal shell completion support for `pgmoneta-cli`.
+
+Please refer to the [Install pgmoneta](https://github.com/pgmoneta/pgmoneta/blob/master/doc/tutorial/01_install.md) tutorial for detailed information about how to enable and use shell completions.

--- a/doc/manual/user-05-ssh.en.md
+++ b/doc/manual/user-05-ssh.en.md
@@ -1,0 +1,74 @@
+\newpage
+
+# SSH
+
+## Prerequisites
+
+First of all, you need to have a remote server where you can store your backups on.
+
+Lets take an EC2 instance as an example, after launching an EC2 instance you need to add new user account with SSH access to the EC2 instance:
+
+1. [Connect to your Linux instance using SSH.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html)
+
+2. Use the adduser command to add a new user account to an EC2 instance (replace new_user with the new account name).
+
+``` sh
+sudo adduser new_user --disabled-password
+```
+
+3. Change the security context to the new_user account so that folders and files you create have the correct permissions:
+
+``` sh
+sudo su - new_user
+```
+
+4. Create a .ssh directory in the new_user home directory and use the chmod command to change the .ssh directory's permissions to 700:
+
+```sh
+mkdir .ssh && chmod 700 .ssh
+```
+
+5. Use the touch command to create the authorized_keys file in the .ssh directory and use the chmod command to change the .ssh/authorized_keys file permissions to 600:
+
+```sh
+touch .ssh/authorized_keys && chmod 600 .ssh/authorized_keys
+```
+
+6. Retrieve the public key for the key pair in your local computer:
+
+```sh
+cat ~/.ssh/id_rsa.pub
+```
+
+7. In the EC2 instance, run the cat command in append mode:
+
+```sh
+cat >> .ssh/authorized_keys
+```
+
+8. Paste the public key into the .ssh/authorized_keys file and then press Enter.
+
+9. Press and hold Ctrl+d to exit cat and return to the command line session prompt.
+
+To verify that the new user can use SSH to connect to the EC2 instance, run the following command from a command line prompt on your local computer:
+
+```sh
+ssh new_user@public_dns_name_of_EC2_instance
+```
+
+## Modify the pgmoneta configuration
+
+You need to create a directory on your remote server where backups can be stored in.
+
+In addition, your local computer needs to have a storage space for 1 backup.
+
+Change `pgmoneta.conf` to add
+
+```sh
+storage_engine = ssh
+ssh_hostname =  your-public_dns_name_of_EC2_instance
+ssh_username = new_user
+ssh_base_dir = the-path-of-the-directory-where-backups-stored-in
+```
+
+under the `[pgmoneta]` section.

--- a/doc/manual/user-06-azure.en.md
+++ b/doc/manual/user-06-azure.en.md
@@ -1,0 +1,73 @@
+\newpage
+
+# Azure
+
+## Prerequisites
+
+First of all, you need to have an Azure account, an Azure storage account and a blob container.
+
+A container organizes a set of blobs, similar to a directory in a file system. A storage account can include an unlimited number of containers, and a container can store an unlimited number of blobs.
+
+To create an Azure storage account with the Azure portal:
+
+1. Sign in to the [Azure portal](https://portal.azure.com/#home).
+
+2. From the left portal menu, select Storage accounts to display a list of your storage accounts. If the portal menu isn't visible, click the menu button to toggle it on.
+
+3. On the Storage accounts page, select Create.
+
+4. On the Basics tab, provide a resource group name and storage account name. You can go for the default settings of the other fields.
+
+5. Choose Next: Advanced.
+
+6. On the Advanced tab, you can configure additional options and modify default settings for your new storage account. You can go for the default settings.
+
+7. Choose Next: Networking.
+
+8. On the Networking tab, you can go for the default settings.
+
+9. Choose Next: Data protection.
+
+10. On the Data protection tab, you can for the default settings.
+
+11. Choose Next: Encryption.
+
+12. On the Encryption tab, you can for the default settings.
+
+13. Choose Next: Tags.
+
+14. Choose Next: Review to see all of the choices you made up to this point. When you are ready to proceed, choose Create.
+
+To create a blob container with the Azure portal:
+
+1. In the navigation pane for the storage account, scroll to the `Data storage` section and select Containers.
+
+2. Within the Containers pane, select the `+ Container` button to open the New container pane.
+
+3. Within the New Container pane, provide a Name for your new container.
+
+4. Select Create to create the container.
+
+To get the Azure storage account shared key which is required for pgmoneta configuration:
+
+1. In the navigation pane for the storage account, scroll to the `Security + networking` section and select Access Keys.
+
+2. Under key1, find the Key value. Select the Copy button to copy the account key.
+
+You can use either of the two keys to access Azure Storage, but in general it's a good practice to use the first key, and reserve the use of the second key for when you are rotating keys.
+
+## Modify the pgmoneta configuration
+
+You need to have a storage space for 1 backup on your local computer.
+
+Change `pgmoneta.conf` to add
+
+``` ini
+storage_engine = azure
+azure_storage_account = the-storage-account-name
+azure_container = the-container-name
+azure_shared_key = the-storage-account-shared-key
+azure_base_dir = directory-where-backups-will-be-stored-in
+```
+
+under the `[pgmoneta]` section.

--- a/doc/manual/user-07-s3.en.md
+++ b/doc/manual/user-07-s3.en.md
@@ -1,0 +1,56 @@
+\newpage
+
+# S3
+
+## Prerequisites
+
+First of all, you need to have an AWS account, an IAM user and S3 bucket.
+
+To create an IAM user:
+
+1. Sign in to the AWS Management Console and open the [IAM console](https://console.aws.amazon.com/iam/).
+
+2. In the navigation pane, choose Users and then choose Add users.
+
+3. Type the user name for the new user.
+
+4. Select the type of access to be both programmatic access and access to the AWS Management Console.
+
+5. Choose Next: Permissions.
+
+6. On the Set permissions page, select attach existing policies directly, search for AmazonS3FullAccess and choose it, then choose Next: Review, then choose Add permissions.
+
+7. Choose Next: Tags.
+
+8. Choose Next: Review to see all of the choices you made up to this point. When you are ready to proceed, choose Create user.
+
+9. To view the users' access keys (access key IDs and secret access keys), choose Show next to each password and access key that you want to see. To save the access keys, choose Download .csv and then save the file to a safe location.
+
+You are now ready to create a S3 bucket, To create a S3 bucket:
+
+1. Sign in to the AWS Management Console using your IAM user credentials and open the [Amazon S3 console](https://console.aws.amazon.com/s3/).
+
+2. Choose Create bucket.
+
+3. In Bucket name, enter a name for your bucket.
+
+4. In Region, choose the AWS Region where you want the bucket to reside. 
+
+5. Keep the default values as it is and Choose Create bucket.
+
+## Modify the pgmoneta configuration
+
+You need to have a storage space for 1 backup on your local computer.
+
+Change `pgmoneta.conf` to add
+
+``` ini
+storage_engine = s3
+s3_aws_region = the-aws-region
+s3_access_key_id = your-access-key-id-from-the-downloaded-file
+s3_secret_access_key = your-secret-access-key-from-the-downloaded-file
+s3_bucket = your-s3-bucket-name
+s3_base_dir = directory-where-backups-will-be-stored-in
+```
+
+under the `[pgmoneta]` section.

--- a/doc/manual/user-08-acknowledgement.en.md
+++ b/doc/manual/user-08-acknowledgement.en.md
@@ -1,0 +1,25 @@
+\newpage
+
+# Acknowledgement
+
+## Contributing
+
+Contributions to `pgmoneta` are managed on [GitHub.com](https://github.com/pgmoneta/pgmoneta/)
+
+* [Ask a question](https://github.com/pgmoneta/pgmoneta/discussions)
+* [Raise an issue](https://github.com/pgmoneta/pgmoneta/issues)
+* [Feature request](https://github.com/pgmoneta/pgmoneta/issues)
+* [Code submission](https://github.com/pgmoneta/pgmoneta/pulls)
+
+Contributions are most welcome!
+
+Please, consult our [Code of Conduct](./CODE_OF_CONDUCT.md) policies for interacting in our
+community.
+
+Consider giving the project a [star](https://github.com/pgmoneta/pgmoneta/stargazers) on
+[GitHub](https://github.com/pgmoneta/pgmoneta/) if you find it useful. And, feel free to follow
+the project on [Twitter](https://twitter.com/pgmoneta/) as well.
+
+## License
+
+[BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)

--- a/pgmoneta.spec
+++ b/pgmoneta.spec
@@ -7,7 +7,7 @@ URL:           https://github.com/pgmoneta/pgmoneta
 Source0:       https://github.com/pgmoneta/pgmoneta/archive/%{version}.tar.gz
 
 BuildRequires: gcc cmake make python3-docutils zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel bzip2 bzip2-devel
-BuildRequires: libev libev-devel openssl openssl-devel systemd systemd-devel libssh libssh-devel libarchive libarchive-devel cjson cjson-devel
+BuildRequires: libev libev-devel openssl openssl-devel systemd systemd-devel libssh libssh-devel libarchive libarchive-devel cjson cjson-devel pandoc texlive-latex
 Requires:      libev openssl systemd zlib libzstd lz4 bzip2 libssh libarchive cjson
 
 %description
@@ -31,6 +31,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 %{__mkdir} -p %{buildroot}%{_docdir}/%{name}/etc
 %{__mkdir} -p %{buildroot}%{_docdir}/%{name}/shell_comp
 %{__mkdir} -p %{buildroot}%{_docdir}/%{name}/tutorial
+%{__mkdir} -p %{buildroot}%{_docdir}/%{name}/manual
 %{__mkdir} -p %{buildroot}%{_mandir}/man1
 %{__mkdir} -p %{buildroot}%{_mandir}/man5
 %{__mkdir} -p %{buildroot}%{_sysconfdir}/pgmoneta
@@ -69,6 +70,8 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/tutorial/10_grafana.md %{buildroot}%{_docdir}/%{name}/tutorial/10_grafana.md
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/tutorial/11_wal_shipping.md %{buildroot}%{_docdir}/%{name}/tutorial/11_wal_shipping.md
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/tutorial/12_tls.md %{buildroot}%{_docdir}/%{name}/tutorial/12_tls.md
+%{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-manual.en.pdf %{buildroot}%{_docdir}/%{name}/manual/pgmoneta-manual.en.pdf
+%{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-manual.en.html %{buildroot}%{_docdir}/%{name}/manual/pgmoneta-manual.en.html
 
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta.1 %{buildroot}%{_mandir}/man1/pgmoneta.1
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-admin.1 %{buildroot}%{_mandir}/man1/pgmoneta-admin.1
@@ -120,6 +123,8 @@ cd %{buildroot}%{_libdir}/
 %{_docdir}/%{name}/tutorial/10_grafana.md
 %{_docdir}/%{name}/tutorial/11_wal_shipping.md
 %{_docdir}/%{name}/tutorial/12_tls.md
+%{_docdir}/%{name}/manual/pgmoneta-manual.en.pdf
+%{_docdir}/%{name}/manual/pgmoneta-manual.en.html
 %{_mandir}/man1/pgmoneta.1*
 %{_mandir}/man1/pgmoneta-admin.1*
 %{_mandir}/man1/pgmoneta-cli.1*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,11 @@
 #
 FILE(GLOB SOURCE_FILES "libpgmoneta/*.c")
 FILE(GLOB HEADER_FILES "include/*.h")
+FILE(GLOB UMDS "../doc/manual/user-??-*.en.md")
+FILE(GLOB DMDS "../doc/manual/dev-??-*.en.md")
 
 set(SOURCES ${SOURCE_FILES} ${HEADER_FILES})
+set(MANUAL_OUTPUT_DIR "${CMAKE_BINARY_DIR}/doc")
 
 #
 # OS
@@ -309,3 +312,37 @@ endif()
 target_link_libraries(pgmoneta-admin-bin pgmoneta)
 
 install(TARGETS pgmoneta-admin-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+#
+# Generate manual
+#
+add_custom_command(
+    OUTPUT ${MANUAL_OUTPUT_DIR}/pgmoneta-user-guide.en.pdf
+    COMMAND ${PANDOC_EXECUTABLE} -o ${MANUAL_OUTPUT_DIR}/pgmoneta-user-guide.en.pdf -s -f markdown-smart --toc ${UMDS}
+    DEPENDS ${UMDS}
+    COMMENT "Generating User Guide PDF documentation"
+)
+add_custom_command(
+    OUTPUT ${MANUAL_OUTPUT_DIR}/pgmoneta-dev-guide.en.pdf
+    COMMAND ${PANDOC_EXECUTABLE} -o ${MANUAL_OUTPUT_DIR}/pgmoneta-dev-guide.en.pdf -s -f markdown-smart --toc ${DMDS}
+    DEPENDS ${DMDS}
+    COMMENT "Generating Developer Guide PDF documentation"
+)
+
+add_custom_command(
+    OUTPUT ${MANUAL_OUTPUT_DIR}/pgmoneta-user-guide.en.html
+    COMMAND ${PANDOC_EXECUTABLE} -o ${MANUAL_OUTPUT_DIR}/pgmoneta-user-guide.en.html -s -f markdown-smart --toc -t html5 ${UMDS}
+    DEPENDS ${UMDS}
+    COMMENT "Generating User Guide HTML documentation"
+)
+add_custom_command(
+    OUTPUT ${MANUAL_OUTPUT_DIR}/pgmoneta-dev-guide.en.html
+    COMMAND ${PANDOC_EXECUTABLE} -o ${MANUAL_OUTPUT_DIR}/pgmoneta-dev-guide.en.html -s -f markdown-smart --toc -t html5 ${DMDS}
+    DEPENDS ${DMDS}
+    COMMENT "Generating Developer Guide HTML documentation"
+)
+
+add_custom_target(
+    all_docs ALL
+    DEPENDS ${MANUAL_OUTPUT_DIR}/pgmoneta-user-guide.en.pdf ${MANUAL_OUTPUT_DIR}/pgmoneta-user-guide.en.html ${MANUAL_OUTPUT_DIR}/pgmoneta-dev-guide.en.pdf ${MANUAL_OUTPUT_DIR}/pgmoneta-dev-guide.en.html
+)


### PR DESCRIPTION
- Add a new initial `/manual` directory.
- Modify the `CMake` file to enable the use of `pandoc` and `LaTeX` for generating `.html` and `.pdf` files from `Markdown`.
- Update the Git `.workflows`.