### PR TITLE
Fix prompts not being printed by disabling stdout buffering

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -208,6 +208,9 @@ main(int argc, char** argv)
    size_t command_count = sizeof(command_table) / sizeof(struct pgmoneta_command);
    struct pgmoneta_parsed_command parsed = {.cmd = NULL, .args = {0}};
 
+   // Disable stdout buffering (i.e. write to stdout immediatelly).
+   setbuf(stdout, NULL);
+
    while (1)
    {
       static struct option long_options[] =

--- a/src/cli.c
+++ b/src/cli.c
@@ -358,6 +358,9 @@ main(int argc, char** argv)
    size_t command_count = sizeof(command_table) / sizeof(struct pgmoneta_command);
    struct pgmoneta_parsed_command parsed = {.cmd = NULL, .args = {0}};
 
+   // Disable stdout buffering (i.e. write to stdout immediatelly).
+   setbuf(stdout, NULL);
+
    while (1)
    {
       static struct option long_options[] =


### PR DESCRIPTION
When built against musl libc, prompts like "Master key:", "Username:" etc. are not printed to console because of stdout buffering.

See https://github.com/pgexporter/pgexporter/pull/134