### PR TITLE
Compare manifest in chunks using adaptive radix tree and iterative json parser

### DIFF
--- a/doc/manual/98-licenses.md
+++ b/doc/manual/98-licenses.md
@@ -38,3 +38,41 @@ OF SUCH DAMAGE.
 ```
 
 [BSD-3-Clause][license]
+
+
+## libart
+Our adaptive radix tree (ART) implementation is based on
+ [The Adaptive Radix Tree: ARTful Indexing for Main-Memory Databases][ART_paper]
+ and [libart][libart] which has a [3-BSD license][license] as
+ 
+```
+Copyright (c) 2012, Armon Dadgar
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+  
+* Neither the name of the organization nor the
+  names of its contributors may be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARMON DADGAR 
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/doc/manual/99-references.md
+++ b/doc/manual/99-references.md
@@ -35,6 +35,8 @@
   [wireshark]: https://www.wireshark.org/
   [pgprtdbg]: https://github.com/jesperpedersen/pgprtdbg
   [aes_ni]: https://en.wikipedia.org/wiki/AES_instruction_set
+  [ART_paper]: http://www-db.in.tum.de/~leis/papers/ART.pdf
+  [libart]: https://github.com/armon/libart
 
 <!-- doc/ -->
   [rpm]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/RPM.md

--- a/src/include/art.h
+++ b/src/include/art.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_ART_H
+#define PGMONETA_ART_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <deque.h>
+
+#include <stdint.h>
+
+#define MAX_PREFIX_LEN 10
+
+typedef int (*art_callback)(void* data, const unsigned char* key, uint32_t key_len, void* value);
+
+typedef void (*value_destroy_callback)(void* value);
+
+/**
+ * The ART tree
+ */
+struct art
+{
+   struct art_node* root;
+   uint64_t size;
+   value_destroy_callback val_destroy_cb;
+};
+
+/**
+ * The ART leaf with key buffer of arbitrary size
+ */
+struct art_leaf
+{
+   void* value;
+   uint32_t key_len;
+   unsigned char key[];
+} __attribute__ ((aligned (64)));
+
+
+struct art_iterator
+{
+   struct deque* que;
+   struct art* tree;
+   uint32_t count;
+};
+
+/**
+ * Initializes an adaptive radix tree
+ * @param tree [out] The tree
+ * @param val_destroy_cb The callback to destroy the val in leaf,
+ * simple free() is used as default if input is NULL.
+ * See pgmoneta_art_destroy_value_noop() if you don't need value to be freed.
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_art_init(struct art** tree, value_destroy_callback val_destroy_cb);
+
+/**
+ * Destroys an ART tree
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_art_destroy(struct art* tree);
+
+/**
+ * inserts a new value into the art tree, note that the key is copied while the value is not
+ * @param t the tree
+ * @param key the key
+ * @param key_len the length of the key
+ * @param value opaque value
+ * @return null if the item was newly inserted, otherwise
+ * the old value pointer is returned
+ */
+void*
+pgmoneta_art_insert(struct art* t, unsigned char* key, int key_len, void* value);
+
+/**
+ * Deletes a value from the ART tree
+ * @param t The tree
+ * @param key The key
+ * @param key_len The length of the key
+ * @return NULL if the item was not found, otherwise
+ * the value pointer is returned
+ */
+void*
+pgmoneta_art_delete(struct art* t, unsigned char* key, int key_len);
+
+/**
+ * Searches for a value in the ART tree
+ * @param t The tree
+ * @param key The key
+ * @param key_len The length of the key
+ * @return NULL if the item was not found, otherwise
+ * the value pointer is returned
+ */
+void*
+pgmoneta_art_search(struct art* t, unsigned char* key, int key_len);
+
+/**
+ * Iterates through the entries pairs in the map,
+ * invoking a callback for each. The call back gets a
+ * key, value for each and returns an integer stop value
+ * If the callback returns non-zero, then the iteration stops
+ * @param t The tree to iterate over
+ * @param cb The callback function to invoke
+ * @param data Opaque handle passed to the callback
+ * @return 0 on success, or the return of the callback
+ */
+int
+pgmoneta_art_iterate(struct art* t, art_callback cb, void* data);
+
+/**
+ * Create an art iterator
+ * @param iter [out] The iterator
+ * @param t The tree
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_art_iterator_init(struct art_iterator** iter, struct art* t);
+
+/**
+ * Destroy the iterator
+ * @param iter The iterator
+ */
+void
+pgmoneta_art_iterator_destroy(struct art_iterator* iter);
+
+/**
+ * Return the next leaf in the ART
+ * @param iter The iterator
+ * @return The next leaf, or NULL if all leaves have been visited
+ */
+struct art_leaf*
+pgmoneta_art_iterator_next(struct art_iterator* iter);
+
+/**
+ * Check if iterator has next
+ * @param iter The iterator
+ * @return true if the iterator has the next leaf, otherwise false
+ */
+bool
+pgmoneta_art_iterator_has_next(struct art_iterator* iter);
+
+/**
+ * The noop callback function for destroying value when destroying ART
+ * @param val The value
+ */
+void
+pgmoneta_art_destroy_value_noop(void* val);
+
+/**
+ * The default callback function for destroying value when destroying ART
+ * @param val The value
+ */
+void
+pgmoneta_art_destroy_value_default(void* val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/deque.h
+++ b/src/include/deque.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_DEQUE_H
+#define PGMONETA_DEQUE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum node_type {
+   NodeInt,
+   NodeString,
+   NodeBool,
+   NodeRef,
+};
+
+struct deque_node
+{
+   enum node_type type;
+   char* data;
+   char* tag;
+   struct deque_node* next;
+   struct deque_node* prev;
+};
+
+struct deque
+{
+   uint32_t size;
+   struct deque_node* start;
+   struct deque_node* end;
+};
+
+/**
+ * Create a deque
+ * @param deque The deque
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_deque_create(struct deque** deque);
+
+/**
+ * Add a string node to deque's tail, the string and tag are copied if not NULL
+ * @param deque The deque
+ * @param data The nullable string data
+ * @param tag The tag, optional
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_deque_offer_string(struct deque* deque, char* data, char* tag);
+
+/**
+ * Add an integer node to deque's tail, the tag is copied if not NULL
+ * @param deque The deque
+ * @param data The int data
+ * @param tag The tag, optional
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_deque_offer_int(struct deque* deque, int data, char* tag);
+
+/**
+ * Add a bool node to deque's tail, the tag is copied if not NULL
+ * @param deque The deque
+ * @param data The bool data
+ * @param tag The tag, optional
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_deque_offer_bool(struct deque* deque, bool data, char* tag);
+
+/**
+ * Add a object reference node to deque's tail, that tag is copied if not NULL
+ * @param deque The deque
+ * @param data The object pointer
+ * @param tag The tag, optional
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_deque_offer_ref(struct deque* deque, void* data, char* tag);
+
+/**
+ * Retrieve and remove the node from deque's head
+ * @param deque The deque
+ * @return The node if deque's not empty, otherwise NULL
+ */
+struct deque_node*
+pgmoneta_deque_poll(struct deque* deque);
+
+/**
+ * Retrieve but not remove the node from deque's head
+ * @param deque The deque
+ * @return The node if deque's not empty, otherwise NULL
+ */
+struct deque_node*
+pgmoneta_deque_peek(struct deque* deque);
+
+/**
+ * Retrieve and remove the int value from deque's head
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise 0
+ */
+int
+pgmoneta_deque_poll_int(struct deque* deque);
+
+/**
+ * Retrieve but not remove the int value from deque's head
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise 0
+ */
+int
+pgmoneta_deque_peek_int(struct deque* deque);
+
+/**
+ * Retrieve and remove the string value from deque's head, note that the string is copied so it must be freed explicitly
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise NULL
+ */
+char*
+pgmoneta_deque_poll_string(struct deque* deque);
+
+/**
+ * Retrieve but not remove the string value from deque's head
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise NULL
+ */
+char*
+pgmoneta_deque_peek_string(struct deque* deque);
+
+/**
+ * Retrieve and remove the bool value from deque's head
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise false
+ */
+bool
+pgmoneta_deque_poll_bool(struct deque* deque);
+
+/**
+ * Retrieve but not remove the bool value from deque's head
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise false
+ */
+bool
+pgmoneta_deque_peek_bool(struct deque* deque);
+
+/**
+ * Retrieve and remove the object pointer from deque's head
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise NULL
+ */
+void*
+pgmoneta_deque_poll_ref(struct deque* deque);
+
+/**
+ * Retrieve but not remove the object pointer from deque's head
+ * @param deque The deque
+ * @return The value if deque's not empty and the node type matches, otherwise NULL
+ */
+void*
+pgmoneta_deque_peek_ref(struct deque* deque);
+
+/**
+ * Check if the deque is empty
+ * @param deque The deque
+ * @return true if deque size is 0, otherwise false
+ */
+bool
+pgmoneta_deque_empty(struct deque* deque);
+
+/**
+ * Destroy the deque and free its and its nodes' memory
+ * @param deque The deque
+ */
+void
+pgmoneta_deque_destroy(struct deque* deque);
+
+/**
+ * Remove a node from the deque.
+ * @param deque The deque
+ * @param node The node
+ * @return Next node of the deleted node
+ */
+struct deque_node*
+pgmoneta_deque_node_remove(struct deque* deque, struct deque_node* node);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/link.h
+++ b/src/include/link.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+#include <art.h>
 #include <workers.h>
 
 #include <stdlib.h>
@@ -45,6 +46,19 @@ extern "C" {
  */
 void
 pgmoneta_link(char* from, char* to, struct workers* workers);
+
+/**
+ * Create link between two directories with processed manifest info
+ * @param base_from The base from directory (newer)
+ * @param base_to The base to directory
+ * @param from The current from directory
+ * @param to The current to directory
+ * @param changed The changed files
+ * @param added The added files
+ * @param workers The optional workers
+ */
+void
+pgmoneta_link_with_manifest(char* base_from, char* base_to, char* from, struct art* changed, struct art* added, struct workers* workers);
 
 /**
  * Relink link two directories

--- a/src/include/manifest.h
+++ b/src/include/manifest.h
@@ -34,7 +34,21 @@ extern "C" {
 #endif
 
 #include <pgmoneta.h>
-#include <node.h>
+#include <art.h>
+
+#define MANIFEST_CHUNK_SIZE 8192
+
+struct manifest_file
+{
+   char* path;
+   char* checksum;
+};
+
+struct manifest_chunk
+{
+   struct manifest_file files[MANIFEST_CHUNK_SIZE];
+   int size;
+};
 
 /**
  * Verify checksum of the manifest and the checksum
@@ -50,11 +64,11 @@ pgmoneta_manifest_checksum_verify(char* root);
  * @param manifest2 The path to the second manifest
  * @param deleted_files The deleted files
  * @param changed_files The changed files
- * @param new_files The new files
+ * @param added_files The added files
  * @return 0 on parsing success, otherwise 1
  */
 int
-pgmoneta_compare_manifests(char* old_manifest, char* new_manifest, struct node** deleted_files, struct node** changed_files, struct node** new_files);
+pgmoneta_compare_manifests(char* old_manifest, char* new_manifest, struct art** deleted_files, struct art** changed_files, struct art** added_files);
 
 #ifdef __cplusplus
 }

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -483,6 +483,15 @@ char*
 pgmoneta_remove_whitespace(char* orig);
 
 /**
+ * Remove the common prefix from orig
+ * @param orig The original string
+ * @param prefix The prefix string
+ * @return The resulting string
+ */
+char*
+pgmoneta_remove_prefix(char* orig, char* prefix);
+
+/**
  * Calculate the directory size
  * @param directory The directory
  * @return The size in bytes

--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -79,7 +79,9 @@ pgmoneta_encrypt_data(char* d, struct workers* workers)
       {
          if (!pgmoneta_ends_with(entry->d_name, ".aes") &&
              !pgmoneta_ends_with(entry->d_name, ".partial") &&
-             !pgmoneta_ends_with(entry->d_name, ".history"))
+             !pgmoneta_ends_with(entry->d_name, ".history") &&
+             !pgmoneta_ends_with(entry->d_name, "backup_label") &&
+             !pgmoneta_ends_with(entry->d_name, "backup_manifest"))
          {
             from = NULL;
 

--- a/src/libpgmoneta/art.c
+++ b/src/libpgmoneta/art.c
@@ -1,0 +1,1404 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <art.h>
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define IS_LEAF(x) (((uintptr_t)x & 1))
+#define SET_LEAF(x) ((void*)((uintptr_t)x | 1))
+#define GET_LEAF(x) ((struct art_leaf*)((void*)((uintptr_t)x & ~1)))
+
+enum art_node_type {
+   Node4,
+   Node16,
+   Node48,
+   Node256
+};
+
+/**
+ * This struct is included as part
+ * of all the various node sizes.
+ * All node types should be aligned
+ * because we need the last bit to be 0 as a flag bit for leaf.
+ * So that leaf can be treated as a node as well and stored in the children field,
+ * and only converted back when necessary
+ */
+struct art_node
+{
+   uint32_t prefix_len;                     /**< The actual length of the prefix segment */
+   enum art_node_type type;                 /**< The node type */
+   uint8_t num_children;                    /**< The number of children */
+   unsigned char prefix[MAX_PREFIX_LEN];    /**< The (potentially partial) prefix, only record up to MAX_PREFIX_LEN characters */
+} __attribute__ ((aligned (64)));
+
+/**
+ * The ART node with only 4 children,
+ * the key character and the children pointer are stored
+ * in the same position of the corresponding array.
+ * The keys are stored in sorted order sequentially.
+ */
+struct art_node4
+{
+   struct art_node node;
+   unsigned char keys[4];
+   struct art_node* children[4];
+} __attribute__ ((aligned (64)));
+
+/**
+ * Similar structure as node4, but with 16 children.
+ * The keys are stored in sorted order sequentially.
+ */
+struct art_node16
+{
+   struct art_node node;
+   unsigned char keys[16];
+   struct art_node* children[16];
+} __attribute__ ((aligned (64)));
+
+/**
+ * A full key array that can be indexed by the key character directly,
+ * the array stores the index of the corresponding child in the array.
+ * Note that in practice 0 is used for invalid index,
+ * so the actual index is the index in key array - 1
+ */
+struct art_node48
+{
+   struct art_node node;
+   unsigned char keys[256];
+   struct art_node* children[48];
+} __attribute__ ((aligned (64)));
+
+/**
+ * A direct array of children using key character as index
+ */
+struct art_node256
+{
+   struct art_node node;
+   struct art_node* children[256];
+} __attribute__ ((aligned (64)));
+
+static struct art_node**
+node_get_child(struct art_node* node, unsigned char ch);
+
+// Get the left most leaf of a child
+static struct art_leaf*
+node_get_minimum(struct art_node* node);
+
+static void
+create_art_leaf(struct art_leaf** leaf, unsigned char* key, int key_len, void* value);
+
+static void
+create_art_node(struct art_node** node, enum art_node_type type);
+
+static void
+create_art_node4(struct art_node4** node);
+
+static void
+create_art_node16(struct art_node16** node);
+
+static void
+create_art_node48(struct art_node48** node);
+
+static void
+create_art_node256(struct art_node256** node);
+
+// Destroy ART nodes/leaves recursively
+static void
+destroy_art_node(struct art_node* node, value_destroy_callback val_destroy_cb);
+
+/**
+ * Get where the keys diverge starting from depth.
+ * This function only compares within the partial prefix range
+ * @param node The node
+ * @param key The key
+ * @param depth The starting depth
+ * @param key_len The length of the key
+ * @return The length of the part of the prefix that matches
+ */
+static uint32_t
+check_prefix_partial(struct art_node* node, unsigned char* key, uint32_t depth, int key_len);
+
+/**
+ * Get where the keys diverge starting from depth.
+ * This function compares with the complete key to determine if diverging point goes beyond current prefix or partial prefix
+ * @param node The node
+ * @param key The key
+ * @param depth The starting depth
+ * @param key_len The length of the key
+ * @return The length of the part of the prefix that matches
+ */
+static uint32_t
+check_prefix(struct art_node* node, unsigned char* key, uint32_t depth, int key_len);
+
+/**
+ * Compare the key stored in leaf and the original key
+ * @param leaf
+ * @param key
+ * @param key_len
+ * @return true if the key matches
+ */
+static bool
+leaf_match(struct art_leaf* leaf, unsigned char* key, int key_len);
+
+/**
+ * Find the index of the corresponding key character using binary search.
+ * If not found, the index of the largest element smaller than ch,
+ * or -1 if ch is the smallest, will be returned,
+ * @param ch
+ * @param keys
+ * @param length
+ * @return The index
+ */
+static int
+find_index(unsigned char ch, const unsigned char* keys, int length);
+
+/**
+ * Insert a value into a node recursively, adopting lazy expansion and path compression --
+ * Expand the leaf, or split inner node should keys diverge within node's prefix range
+ * @param node The node
+ * @param node_ref The reference to node pointer
+ * @param depth The depth into the node, which is the same as the total prefix length
+ * @param key The key
+ * @param key_len The length of the key
+ * @param value The value
+ * @param new If the key value is newly inserted (not replaced)
+ * @return Old value if the key exists, otherwise NULL
+ */
+static void*
+art_node_insert(struct art_node* node, struct art_node** node_ref, uint32_t depth, unsigned char* key, int key_len, void* value, bool* new);
+
+/**
+ * Delete a value from a node recursively.
+ * @param node The node
+ * @param node_ref The reference to node pointer
+ * @param depth The depth into the node
+ * @param key The key
+ * @param key_len The length of the key
+ * @return Deleted value if the key exists, otherwise NULL
+ */
+static struct art_leaf*
+art_node_delete(struct art_node* node, struct art_node** node_ref, uint32_t depth, unsigned char* key, int key_len);
+
+static int
+art_node_iterate(struct art_node* node, art_callback cb, void* data);
+
+static void
+node_add_child(struct art_node* node, struct art_node** node_ref, unsigned char ch, void* child);
+
+/**
+ * Add a child to the node. The function assumes node is not NULL,
+ * nor the key character already exists.
+ * If node is full, a new node of type node16 will be created. The old
+ * node will be replaced by new node through node_ref.
+ * @param node The node
+ * @param node_ref The reference of the node pointer
+ * @param ch The key character
+ * @param child The child
+ */
+static void
+node4_add_child(struct art_node4* node, struct art_node** node_ref, unsigned char ch, void* child);
+
+static void
+node16_add_child(struct art_node16* node, struct art_node** node_ref, unsigned char ch, void* child);
+
+static void
+node48_add_child(struct art_node48* node, struct art_node** node_ref, unsigned char ch, void* child);
+
+static void
+node256_add_child(struct art_node256* node, unsigned char ch, void* child);
+
+// All removal functions assume the child to remove is leaf, meaning they don't try removing anything recursively.
+// They also do not free the leaf node for bookkeeping purpose. The key insight is that due to path compression,
+// no node will have only one child, if node has only one child after deletion, it merges with this child
+static void
+node_remove_child(struct art_node* node, struct art_node** node_ref, unsigned char ch);
+
+static void
+node4_remove_child(struct art_node4* node, struct art_node** node_ref, unsigned char ch);
+
+static void
+node16_remove_child(struct art_node16* node, struct art_node** node_ref, unsigned char ch);
+
+static void
+node48_remove_child(struct art_node48* node, struct art_node** node_ref, unsigned char ch);
+
+static void
+node256_remove_child(struct art_node256* node, struct art_node** node_ref, unsigned char ch);
+
+static void
+copy_header(struct art_node* dest, struct art_node* src);
+
+static uint32_t
+min(uint32_t a, uint32_t b);
+
+int
+pgmoneta_art_init(struct art** tree, value_destroy_callback val_destroy_cb)
+{
+   struct art* t = NULL;
+   t = malloc(sizeof(struct art));
+   t->size = 0;
+   t->root = NULL;
+   if (val_destroy_cb == NULL)
+   {
+      t->val_destroy_cb = pgmoneta_art_destroy_value_default;
+   }
+   else
+   {
+      t->val_destroy_cb = val_destroy_cb;
+   }
+   *tree = t;
+   return 0;
+}
+
+int
+pgmoneta_art_destroy(struct art* tree)
+{
+   if (tree == NULL)
+   {
+      return 0;
+   }
+   destroy_art_node(tree->root, tree->val_destroy_cb);
+   free(tree);
+   return 0;
+}
+
+void*
+pgmoneta_art_search(struct art* t, unsigned char* key, int key_len)
+{
+   struct art_node* node = NULL;
+   struct art_node** child = NULL;
+   uint32_t depth = 0;
+   if (t == NULL || t->root == NULL)
+   {
+      return NULL;
+   }
+   node = t->root;
+   while (node != NULL)
+   {
+      if (IS_LEAF(node))
+      {
+         if (!leaf_match(GET_LEAF(node), key, key_len))
+         {
+            return NULL;
+         }
+         return GET_LEAF(node)->value;
+      }
+      // optimistically check the prefix,
+      // we move forward as long as up to MAX_PREFIX_LEN characters match
+      if (check_prefix_partial(node, key, depth, key_len) != min(node->prefix_len, MAX_PREFIX_LEN))
+      {
+         return NULL;
+      }
+      depth += node->prefix_len;
+      // you can't dereference what the function returns directly since it could be null
+      child = node_get_child(node, key[depth]);
+      node = child != NULL ? *child : NULL;
+      // child is indexed by key[depth], so the next round we should skip this byte and start checking at the next
+      depth++;
+   }
+   return NULL;
+}
+
+void*
+pgmoneta_art_insert(struct art* t, unsigned char* key, int key_len, void* value)
+{
+   void* old_val = NULL;
+   bool new = false;
+   if (t == NULL)
+   {
+      // c'mon, at least create a tree first...
+      return NULL;
+   }
+   old_val = art_node_insert(t->root, &t->root, 0, key, key_len, value, &new);
+   if (new)
+   {
+      t->size++;
+   }
+   return old_val;
+}
+
+void*
+pgmoneta_art_delete(struct art* t, unsigned char* key, int key_len)
+{
+   struct art_leaf* l = NULL;
+   void* old_val = NULL;
+   if (t == NULL)
+   {
+      return NULL;
+   }
+   l = art_node_delete(t->root, &t->root, 0, key, key_len);
+   if (l == NULL)
+   {
+      return NULL;
+   }
+   t->size--;
+   old_val = l->value;
+   free(l);
+   return old_val;
+}
+
+int
+pgmoneta_art_iterate(struct art* t, art_callback cb, void* data)
+{
+   return art_node_iterate(t->root, cb, data);
+}
+
+static uint32_t
+min(uint32_t a, uint32_t b)
+{
+   if (a >= b)
+   {
+      return b;
+   }
+   return a;
+}
+
+static void
+create_art_leaf(struct art_leaf** leaf, unsigned char* key, int key_len, void* value)
+{
+   struct art_leaf* l = NULL;
+   l = malloc(sizeof(struct art_leaf) + key_len);
+   memset(l, 0, sizeof(struct art_leaf) + key_len);
+   l->value = value;
+   l->key_len = key_len;
+   memcpy(l->key, key, key_len);
+   *leaf = l;
+}
+
+static void
+create_art_node(struct art_node** node, enum art_node_type type)
+{
+   struct art_node* n = NULL;
+   switch (type)
+   {
+      case Node4:
+      {
+         struct art_node4* n4 = malloc(sizeof(struct art_node4));
+         memset(n4, 0, sizeof(struct art_node4));
+         n4->node.type = Node4;
+         n = (struct art_node*) n4;
+         break;
+      }
+      case Node16:
+      {
+         struct art_node16* n16 = malloc(sizeof(struct art_node16));
+         memset(n16, 0, sizeof(struct art_node16));
+         n16->node.type = Node16;
+         n = (struct art_node*) n16;
+         break;
+      }
+      case Node48:
+      {
+         struct art_node48* n48 = malloc(sizeof(struct art_node48));
+         memset(n48, 0, sizeof(struct art_node48));
+         n48->node.type = Node48;
+         n = (struct art_node*) n48;
+         break;
+      }
+      case Node256:
+      {
+         struct art_node256* n256 = malloc(sizeof(struct art_node256));
+         memset(n256, 0, sizeof(struct art_node256));
+         n256->node.type = Node256;
+         n = (struct art_node*) n256;
+         break;
+      }
+   }
+   *node = n;
+}
+
+static void
+create_art_node4(struct art_node4** node)
+{
+   struct art_node* n = NULL;
+   create_art_node(&n, Node4);
+   *node = (struct art_node4*)n;
+}
+
+static void
+create_art_node16(struct art_node16** node)
+{
+   struct art_node* n = NULL;
+   create_art_node(&n, Node16);
+   *node = (struct art_node16*)n;
+}
+
+static void
+create_art_node48(struct art_node48** node)
+{
+   struct art_node* n = NULL;
+   create_art_node(&n, Node48);
+   *node = (struct art_node48*)n;
+}
+
+static void
+create_art_node256(struct art_node256** node)
+{
+   struct art_node* n = NULL;
+   create_art_node(&n, Node256);
+   *node = (struct art_node256*)n;
+}
+
+static void
+destroy_art_node(struct art_node* node, value_destroy_callback val_destroy_cb)
+{
+   if (node == NULL)
+   {
+      return;
+   }
+   if (IS_LEAF(node))
+   {
+      val_destroy_cb(GET_LEAF(node)->value);
+      free(GET_LEAF(node));
+      return;
+   }
+   switch (node->type)
+   {
+      case Node4:
+      {
+         struct art_node4* n = (struct art_node4*) node;
+         for (int i = 0; i < node->num_children; i++)
+         {
+            destroy_art_node(n->children[i], val_destroy_cb);
+         }
+         break;
+      }
+      case Node16:
+      {
+         struct art_node16* n = (struct art_node16*) node;
+         for (int i = 0; i < node->num_children; i++)
+         {
+            destroy_art_node(n->children[i], val_destroy_cb);
+         }
+         break;
+      }
+      case Node48:
+      {
+         struct art_node48* n = (struct art_node48*) node;
+         for (int i = 0; i < 256; i++)
+         {
+            int idx = n->keys[i];
+            if (idx == 0)
+            {
+               continue;
+            }
+            destroy_art_node(n->children[idx - 1], val_destroy_cb);
+         }
+         break;
+      }
+
+      case Node256:
+      {
+         struct art_node256* n = (struct art_node256*) node;
+         for (int i = 0; i < 256; i++)
+         {
+            if (n->children[i] == NULL)
+            {
+               continue;
+            }
+            destroy_art_node(n->children[i], val_destroy_cb);
+         }
+         break;
+      }
+   }
+   free(node);
+}
+
+static struct art_node**
+node_get_child(struct art_node* node, unsigned char ch)
+{
+   switch (node->type)
+   {
+      case Node4:
+      {
+         struct art_node4* n = (struct art_node4*)node;
+         int idx = find_index(ch, n->keys, n->node.num_children);
+         if (idx == -1 || n->keys[idx] != ch)
+         {
+            goto error;
+         }
+         return &n->children[idx];
+      }
+      case Node16:
+      {
+         struct art_node16* n = (struct art_node16*)node;
+         int idx = find_index(ch, n->keys, n->node.num_children);
+         if (idx == -1 || n->keys[idx] != ch)
+         {
+            goto error;
+         }
+         return &n->children[idx];
+      }
+      case Node48:
+      {
+         struct art_node48* n = (struct art_node48*)node;
+         if (n->keys[ch] == 0)
+         {
+            goto error;
+         }
+         return &n->children[n->keys[ch] - 1];
+      }
+      case Node256:
+      {
+         struct art_node256* n = (struct art_node256*)node;
+         return &n->children[ch];
+      }
+   }
+error:
+   return NULL;
+}
+
+static void*
+art_node_insert(struct art_node* node, struct art_node** node_ref, uint32_t depth, unsigned char* key, int key_len, void* value, bool* new)
+{
+   struct art_leaf* leaf = NULL;
+   struct art_leaf* min_leaf = NULL;
+   uint32_t idx = 0;
+   uint32_t diff_len = 0; // where the keys diverge
+   struct art_node* new_node = NULL;
+   struct art_node** next = NULL;
+   unsigned char* leaf_key = NULL;
+   void* old_val = NULL;
+   if (node == NULL)
+   {
+      // Lazy expansion, skip creating an inner node since it currently will have only this one leaf.
+      // We will compare keys when reach leaf anyway, the path doesn't need to 100% match the key along the way
+      create_art_leaf(&leaf, key, key_len, value);
+      *node_ref = SET_LEAF(leaf);
+      *new = true;
+      return NULL;
+   }
+   // base case, reaching leaf, either replace or expand
+   if (IS_LEAF(node))
+   {
+      // Lazy expansion, expand the leaf node to an inner node with 2 leaves
+      // If the key already exists, replace with new value and return old value
+      if (leaf_match(GET_LEAF(node), key, key_len))
+      {
+         old_val = GET_LEAF(node)->value;
+         GET_LEAF(node)->value = value;
+         return old_val;
+      }
+      // If the key does not match with existing key, old key and new key diverged some point after depth
+      // Even if we merely store a partial prefix for each node, it couldn't have diverged before depth.
+      // The reason is that when we find it diverged outside the partial prefix range,
+      // we compare with the existing key in the left most leaf and find an exact diverging point to split the node (see details below).
+      // This way we inductively guarantee that all children to a parent share the same prefix even if it's only partially stored
+      leaf_key = GET_LEAF(node)->key;
+      create_art_node(&new_node, Node4);
+      create_art_leaf(&leaf, key, key_len, value);
+      // Get the diverging index after point of depth
+      for (idx = depth; idx < min(key_len, GET_LEAF(node)->key_len); idx++)
+      {
+         if (key[idx] != leaf_key[idx])
+         {
+            break;
+         }
+         if (idx - depth < MAX_PREFIX_LEN)
+         {
+            new_node->prefix[idx - depth] = key[idx];
+         }
+      }
+      new_node->prefix_len = idx - depth;
+      depth += new_node->prefix_len;
+      node_add_child(new_node, &new_node, key[depth], SET_LEAF(leaf));
+      node_add_child(new_node, &new_node, leaf_key[depth], (void*)node);
+      // replace with new node
+      *node_ref = new_node;
+      *new = true;
+      return NULL;
+   }
+
+   // There are several cases,
+   // 1. The key diverges outside the current prefix (diff_len >= prefix_len)
+   // 2. The key diverges within the current prefix (diff_len < prefix_len)
+   //   2.1. The key diverges within the partial prefix range (diff_len < MAX_PREFIX_LEN)
+   //   2.2. The key diverges outside the partial prefix range (MAX_PREFIX_LEN <= diff_len < prefix_len)
+   // For case 1, go to the next child to add node recursively, or add leaf to current node in place
+   // For case 2, split the current node and add child to new node.
+   // Note that it's tricky to check case 2.2, or in that case know the exact diverging point,
+   // since we merely store the first 10 (MAX_PREFIX_LEN) bytes of the prefix.
+   // In this case we use the key in the left most leaf of the node to determine the diverging point.
+   // Theoretically we inductively guarantee that all children to the same parent share the same prefixes.
+   // So we can use the key inside any leaf under this node to see if the diverging point goes beyond the current prefix,
+   // but it's most convenient and efficient to reach the left most key.
+
+   diff_len = check_prefix(node, key, depth, key_len);
+   if (diff_len < node->prefix_len)
+   {
+      // case 2, split the node
+      create_art_node(&new_node, Node4);
+      create_art_leaf(&leaf, key, key_len, value);
+      new_node->prefix_len = diff_len;
+      memcpy(new_node->prefix, node->prefix, min(MAX_PREFIX_LEN, diff_len));
+      // We need to know if new bytes that were once outside the partial prefix range will now come into the range
+      // If original key didn't fill up the partial prefix buffer in the first place,
+      // no new bytes will come into buffer when prefix shifts left
+      if (node->prefix_len <= MAX_PREFIX_LEN)
+      {
+         node->prefix_len = node->prefix_len - (diff_len + 1);
+         node_add_child(new_node, &new_node, key[depth + diff_len], SET_LEAF(leaf));
+         node_add_child(new_node, &new_node, node->prefix[diff_len], node);
+         // Update node's prefix info since we move it downwards
+         // The first diverging character serves as the key byte in keys array,
+         // so we don't duplicate store it in the prefix.
+         // In other words, if prefix is the starting point,
+         // prefix + prefix_len - 1 is the last byte of the prefix,
+         // prefix + prefix_len is the indexing byte
+         // prefix + prefix_len + 1 is the starting point of the next prefix
+         memmove(node->prefix, node->prefix + diff_len + 1, node->prefix_len);
+      }
+      else
+      {
+         node->prefix_len = node->prefix_len - (diff_len + 1);
+         min_leaf = node_get_minimum(node);
+         node_add_child(new_node, &new_node, key[depth + diff_len], SET_LEAF(leaf));
+         node_add_child(new_node, &new_node, min_leaf->key[depth + diff_len], node);
+         // node is moved downwards
+         memmove(node->prefix, min_leaf->key + depth + diff_len + 1, min(MAX_PREFIX_LEN, node->prefix_len));
+      }
+      // replace
+      *node_ref = new_node;
+      *new = true;
+      return NULL;
+   }
+   else
+   {
+      // case 1
+      depth += node->prefix_len;
+      next = node_get_child(node, key[depth]);
+      if (next != NULL)
+      {
+         // recursively add node
+         if (*next == NULL)
+         {
+            node->num_children++;
+         }
+         return art_node_insert(*next, next, depth + 1, key, key_len, value, new);
+      }
+      else
+      {
+         // add a child to current node since the spot is available
+         create_art_leaf(&leaf, key, key_len, value);
+         node_add_child(node, node_ref, key[depth], SET_LEAF(leaf));
+         *new = true;
+         return NULL;
+      }
+   }
+}
+
+static struct art_leaf*
+art_node_delete(struct art_node* node, struct art_node** node_ref, uint32_t depth, unsigned char* key, int key_len)
+{
+   struct art_leaf* l = NULL;
+   struct art_node** child = NULL;
+   uint32_t diff_len = 0;
+   if (node == NULL)
+   {
+      return NULL;
+   }
+   // Only one way we encounter this case, the tree only has one leaf
+   if (IS_LEAF(node))
+   {
+      if (leaf_match(GET_LEAF(node), key, key_len))
+      {
+         l = GET_LEAF(node);
+         *node_ref = NULL;
+         return l;
+      }
+      return NULL;
+   }
+   diff_len = check_prefix_partial(node, key, depth, key_len);
+   if (diff_len != min(MAX_PREFIX_LEN, node->prefix_len))
+   {
+      return NULL;
+   }
+   else
+   {
+      depth += node->prefix_len;
+      child = node_get_child(node, key[depth]);
+      if (child == NULL)
+      {
+         // dead end
+         return NULL;
+      }
+      if (IS_LEAF(*child))
+      {
+         if (leaf_match(GET_LEAF(*child), key, key_len))
+         {
+            l = GET_LEAF(*child);
+            node_remove_child(node, node_ref, key[depth]);
+            return l;
+         }
+         else
+         {
+            return NULL;
+         }
+      }
+      else
+      {
+         return art_node_delete(*child, child, depth + 1, key, key_len);
+      }
+   }
+}
+
+static int
+art_node_iterate(struct art_node* node, art_callback cb, void* data)
+{
+   struct art_leaf* l = NULL;
+   struct art_node* child = NULL;
+   int idx = 0;
+   int res = 0;
+   if (node == NULL)
+   {
+      return 0;
+   }
+   if (IS_LEAF(node))
+   {
+      l = GET_LEAF(node);
+      return cb(data, l->key, l->key_len, l->value);
+   }
+   switch (node->type)
+   {
+      case Node4:
+      {
+         struct art_node4* n = (struct art_node4*) node;
+         for (int i = 0; i < node->num_children; i++)
+         {
+            child = n->children[i];
+            res = art_node_iterate(child, cb, data);
+            if (res)
+            {
+               return res;
+            }
+         }
+         break;
+      }
+      case Node16:
+      {
+         struct art_node16* n = (struct art_node16*) node;
+         for (int i = 0; i < node->num_children; i++)
+         {
+            child = n->children[i];
+            res = art_node_iterate(child, cb, data);
+            if (res)
+            {
+               return res;
+            }
+         }
+         break;
+      }
+      case Node48:
+      {
+         struct art_node48* n = (struct art_node48*) node;
+         for (int i = 0; i < 256; i++)
+         {
+            idx = n->keys[i];
+            if (idx == 0)
+            {
+               continue;
+            }
+            child = n->children[idx - 1];
+            res = art_node_iterate(child, cb, data);
+            if (res)
+            {
+               return res;
+            }
+         }
+         break;
+      }
+      case Node256:
+      {
+         struct art_node256* n = (struct art_node256*) node;
+         for (int i = 0; i < 256; i++)
+         {
+            if (n->children[i] == NULL)
+            {
+               continue;
+            }
+            child = n->children[i];
+            res = art_node_iterate(child, cb, data);
+            if (res)
+            {
+               return res;
+            }
+         }
+         break;
+      }
+   }
+   return 1;
+}
+
+static void
+node_add_child(struct art_node* node, struct art_node** node_ref, unsigned char ch, void* child)
+{
+   switch (node->type)
+   {
+      case Node4:
+         node4_add_child((struct art_node4*) node, node_ref, ch, child);
+         break;
+      case Node16:
+         node16_add_child((struct art_node16*) node, node_ref, ch, child);
+         break;
+      case Node48:
+         node48_add_child((struct art_node48*) node, node_ref, ch, child);
+         break;
+      case Node256:
+         node256_add_child((struct art_node256*) node, ch, child);
+         break;
+   }
+}
+
+static void
+node4_add_child(struct art_node4* node, struct art_node** node_ref, unsigned char ch, void* child)
+{
+   if (node->node.num_children < 4)
+   {
+      int idx = find_index(ch, node->keys, node->node.num_children);
+      // right shift the right part to make space for the key, so that we keep the keys in order
+      memmove(node->keys + (idx + 1) + 1, node->keys + (idx + 1), node->node.num_children - (idx + 1));
+      memmove(node->children + (idx + 1) + 1, node->children + (idx + 1), (node->node.num_children - (idx + 1)) * sizeof(void*));
+
+      node->keys[idx + 1] = ch;
+      node->children[idx + 1] = (struct art_node*)child;
+      node->node.num_children++;
+   }
+   else
+   {
+      // expand
+      struct art_node16* new_node = NULL;
+      create_art_node16(&new_node);
+      copy_header((struct art_node*)new_node, (struct art_node*)node);
+      memcpy(new_node->children, node->children, node->node.num_children * sizeof(void*));
+      memcpy(new_node->keys, node->keys, node->node.num_children);
+      // replace the node through node reference
+      *node_ref = (struct art_node*)new_node;
+      free(node);
+
+      node16_add_child(new_node, node_ref, ch, child);
+   }
+}
+
+static void
+node16_add_child(struct art_node16* node, struct art_node** node_ref, unsigned char ch, void* child)
+{
+   if (node->node.num_children < 16)
+   {
+      int idx = find_index(ch, node->keys, node->node.num_children);
+      // right shift the right part to make space for the key, so that we keep the keys in order
+      memmove(node->keys + (idx + 1) + 1, node->keys + (idx + 1), node->node.num_children - (idx + 1));
+      memmove(node->children + (idx + 1) + 1, node->children + (idx + 1), (node->node.num_children - (idx + 1)) * sizeof(void*));
+
+      node->keys[idx + 1] = ch;
+      node->children[idx + 1] = (struct art_node*)child;
+      node->node.num_children++;
+   }
+   else
+   {
+      // expand
+      struct art_node48* new_node = NULL;
+      create_art_node48(&new_node);
+      copy_header((struct art_node*)new_node, (struct art_node*)node);
+      memcpy(new_node->children, node->children, node->node.num_children * sizeof(void*));
+      for (int i = 0; i < node->node.num_children; i++)
+      {
+         new_node->keys[node->keys[i]] = i + 1;
+      }
+      // replace the node through node reference
+      *node_ref = (struct art_node*)new_node;
+      free(node);
+      node48_add_child(new_node, node_ref, ch, child);
+   }
+}
+
+static void
+node48_add_child(struct art_node48* node, struct art_node** node_ref, unsigned char ch, void* child)
+{
+   if (node->node.num_children < 48)
+   {
+      // we cannot simply append to last because delete could have caused fragmentation
+      int pos = 0;
+      while (node->children[pos] != NULL)
+      {
+         pos++;
+      }
+      node->children[pos] = (struct art_node*) child;
+      node->keys[ch] = pos + 1;
+      node->node.num_children++;
+   }
+   else
+   {
+      // expand
+      struct art_node256* new_node = NULL;
+      create_art_node256(&new_node);
+      copy_header((struct art_node*)new_node, (struct art_node*)node);
+      for (int i = 0; i < 256; i++)
+      {
+         if (node->keys[i] == 0)
+         {
+            continue;
+         }
+         new_node->children[i] = node->children[node->keys[i] - 1];
+      }
+      // replace the node through node reference
+      *node_ref = (struct art_node*)new_node;
+      free(node);
+      node256_add_child(new_node, ch, child);
+   }
+}
+
+static void
+node256_add_child(struct art_node256* node, unsigned char ch, void* child)
+{
+   node->node.num_children++;
+   node->children[ch] = (struct art_node*)child;
+}
+
+static int
+find_index(unsigned char ch, const unsigned char* keys, int length)
+{
+   int left = 0;
+   int right = length - 1;
+   int mid = 0;
+   if (length == 0)
+   {
+      return -1;
+   }
+   while (left + 1 < right)
+   {
+      mid = (left + right) / 2;
+      if (keys[mid] == ch)
+      {
+         return mid;
+      }
+      if (keys[mid] < ch)
+      {
+         left = mid;
+      }
+      else
+      {
+         right = mid;
+      }
+   }
+   if (keys[right] <= ch)
+   {
+      return right;
+   }
+   else if (keys[left] <= ch)
+   {
+      return left;
+   }
+   return -1;
+}
+
+static void
+copy_header(struct art_node* dest, struct art_node* src)
+{
+   dest->num_children = src->num_children;
+   dest->prefix_len = src->prefix_len;
+   memcpy(dest->prefix, src->prefix, min(MAX_PREFIX_LEN, src->prefix_len));
+}
+
+static uint32_t
+check_prefix_partial(struct art_node* node, unsigned char* key, uint32_t depth, int key_len)
+{
+   uint32_t len = 0;
+   uint32_t max_cmp = min(min(node->prefix_len, MAX_PREFIX_LEN), key_len - depth);
+   while (len < max_cmp && key[depth + len] == node->prefix[len])
+   {
+      len++;
+   }
+   return len;
+}
+
+static uint32_t
+check_prefix(struct art_node* node, unsigned char* key, uint32_t depth, int key_len)
+{
+   uint32_t len = 0;
+   struct art_leaf* leaf = NULL;
+   uint32_t max_cmp = min(min(node->prefix_len, MAX_PREFIX_LEN), key_len - depth);
+   while (len < max_cmp && key[depth + len] == node->prefix[len])
+   {
+      len++;
+   }
+   // diverge within partial prefix range
+   if (len < MAX_PREFIX_LEN)
+   {
+      return len;
+   }
+
+   leaf = node_get_minimum(node);
+   max_cmp = min(leaf->key_len, key_len) - depth;
+   // continue comparing the real keys
+   while (len < max_cmp && leaf->key[depth + len] == key[depth + len])
+   {
+      len++;
+   }
+   return len;
+}
+
+static bool
+leaf_match(struct art_leaf* leaf, unsigned char* key, int key_len)
+{
+   if (leaf->key_len != key_len)
+   {
+      return false;
+   }
+   return memcmp(leaf->key, key, key_len) == 0;
+}
+
+static struct art_leaf*
+node_get_minimum(struct art_node* node)
+{
+   if (node == NULL)
+   {
+      return NULL;
+   }
+   while (node != NULL && !IS_LEAF(node))
+   {
+      switch (node->type)
+      {
+         case Node4:
+         {
+            struct art_node4* n = (struct art_node4*)node;
+            node = n->children[0];
+            break;
+         }
+         case Node16:
+         {
+            struct art_node16* n = (struct art_node16*)node;
+            node = n->children[0];
+            break;
+         }
+         case Node48:
+         {
+            struct art_node48* n = (struct art_node48*) node;
+            int idx = 0;
+            while (n->keys[idx] == 0)
+            {
+               idx++;
+            }
+            node = n->children[n->keys[idx] - 1];
+            break;
+         }
+         case Node256:
+         {
+            struct art_node256* n = (struct art_node256*) node;
+            int idx = 0;
+            while (n->children[idx] == NULL)
+            {
+               idx++;
+            }
+            node = n->children[idx];
+            break;
+         }
+      }
+   }
+   if (node == NULL)
+   {
+      return NULL;
+   }
+   return GET_LEAF(node);
+}
+
+static void
+node_remove_child(struct art_node* node, struct art_node** node_ref, unsigned char ch)
+{
+   switch (node->type)
+   {
+      case Node4:
+         node4_remove_child((struct art_node4*)node, node_ref, ch);
+         break;
+      case Node16:
+         node16_remove_child((struct art_node16*)node, node_ref, ch);
+         break;
+      case Node48:
+         node48_remove_child((struct art_node48*)node, node_ref, ch);
+         break;
+      case Node256:
+         node256_remove_child((struct art_node256*)node, node_ref, ch);
+         break;
+   }
+}
+
+static void
+node4_remove_child(struct art_node4* node, struct art_node** node_ref, unsigned char ch)
+{
+   int idx = 0;
+   uint32_t len = 0;
+   struct art_node* child = NULL;
+   idx = find_index(ch, node->keys, node->node.num_children);
+   memmove(node->keys + idx, node->keys + idx + 1, node->node.num_children - (idx + 1));
+   memmove(node->children + idx, node->children + idx + 1, sizeof(void*) * (node->node.num_children - (idx + 1)));
+   node->node.num_children--;
+   // path compression, merge the node with its child
+   if (node->node.num_children == 1)
+   {
+      child = node->children[0];
+      if (IS_LEAF(child))
+      {
+         // replace directly
+         *node_ref = child;
+         return;
+      }
+      // parent prefix bytes + byte index to child + child prefix bytes
+      len = node->node.prefix_len;
+      if (len < MAX_PREFIX_LEN)
+      {
+         node->node.prefix[len] = node->keys[0];
+         len++;
+      }
+      // keep filling as much as we can
+      for (int i = 0; len + i < MAX_PREFIX_LEN && i < child->prefix_len; i++)
+      {
+         node->node.prefix[len + i] = child->prefix[i];
+      }
+      child->prefix_len = node->node.prefix_len + 1 + child->prefix_len;
+      memcpy(child->prefix, node->node.prefix, min(child->prefix_len, MAX_PREFIX_LEN));
+      free(node);
+      // replace
+      *node_ref = child;
+   }
+}
+
+static void
+node16_remove_child(struct art_node16* node, struct art_node** node_ref, unsigned char ch)
+{
+   int idx = 0;
+   struct art_node4* new_node = NULL;
+   idx = find_index(ch, node->keys, node->node.num_children);
+   memmove(node->keys + idx, node->keys + idx + 1, node->node.num_children - (idx + 1));
+   memmove(node->children + idx, node->children + idx + 1, sizeof(void*) * (node->node.num_children - (idx + 1)));
+   node->node.num_children--;
+   // downgrade node
+   // Trick from libart, do not downgrade immediately to avoid jumping on 4/5 boundary
+   if (node->node.num_children <= 3)
+   {
+      create_art_node4(&new_node);
+      copy_header((struct art_node*)new_node, (struct art_node*)node);
+      memcpy(new_node->keys, node->keys, node->node.num_children);
+      memcpy(new_node->children, node->children, node->node.num_children * sizeof(void*));
+      free(node);
+      *node_ref = (struct art_node*)new_node;
+   }
+}
+
+static void
+node48_remove_child(struct art_node48* node, struct art_node** node_ref, unsigned char ch)
+{
+   int idx = node->keys[ch];
+   int cnt = 0;
+   struct art_node16* new_node = NULL;
+   node->children[idx - 1] = NULL;
+   node->keys[ch] = 0;
+   node->node.num_children--;
+
+   if (node->node.num_children <= 12)
+   {
+      create_art_node16(&new_node);
+      copy_header((struct art_node*)new_node, (struct art_node*)node);
+      for (int i = 0; i < 256; i++)
+      {
+         if (node->keys[i] != 0)
+         {
+            new_node->children[cnt] = node->children[node->keys[i] - 1];
+            new_node->keys[cnt] = i;
+            cnt++;
+         }
+      }
+      free(node);
+      *node_ref = (struct art_node*)new_node;
+   }
+}
+
+static void
+node256_remove_child(struct art_node256* node, struct art_node** node_ref, unsigned char ch)
+{
+   int num = 0;
+   for (int i = 0; i < 48; i++)
+   {
+      if (node->children[i] != NULL)
+      {
+         num++;
+      }
+   }
+   if (num != node->node.num_children)
+   {
+      num++;
+   }
+   struct art_node48* new_node = NULL;
+   int cnt = 0;
+   node->children[ch] = NULL;
+   node->node.num_children--;
+
+   if (node->node.num_children <= 37)
+   {
+      create_art_node48(&new_node);
+      copy_header((struct art_node*)new_node, (struct art_node*)node);
+      for (int i = 0; i < 256; i++)
+      {
+         if (node->children[i] != NULL)
+         {
+            new_node->keys[i] = cnt + 1;
+            new_node->children[cnt] = node->children[i];
+            cnt++;
+         }
+      }
+      free(node);
+      *node_ref = (struct art_node*)new_node;
+   }
+}
+
+int
+pgmoneta_art_iterator_init(struct art_iterator** iter, struct art* t)
+{
+   struct art_iterator* i = NULL;
+   i = malloc(sizeof(struct art_iterator));
+   if (i == NULL || t == NULL)
+   {
+      return 1;
+   }
+   i->count = 0;
+   i->tree = t;
+   pgmoneta_deque_create(&i->que);
+   *iter = i;
+   return 0;
+}
+
+struct art_leaf*
+pgmoneta_art_iterator_next(struct art_iterator* iter)
+{
+   struct deque* que = NULL;
+   struct art* tree = NULL;
+   struct art_node* node = NULL;
+   struct art_node* child = NULL;
+   int idx = 0;
+   if (iter == NULL || iter->que == NULL || iter->tree == NULL || iter->count == iter->tree->size)
+   {
+      return NULL;
+   }
+   que = iter->que;
+   tree = iter->tree;
+   if (iter->count == 0)
+   {
+      pgmoneta_deque_offer_ref(que, tree->root, NULL);
+   }
+   while (!pgmoneta_deque_empty(que))
+   {
+      node = pgmoneta_deque_poll_ref(que);
+      if (IS_LEAF(node))
+      {
+         iter->count++;
+         return GET_LEAF(node);
+      }
+      switch (node->type)
+      {
+         case Node4:
+         {
+            struct art_node4* n = (struct art_node4*) node;
+            for (int i = 0; i < node->num_children; i++)
+            {
+               child = n->children[i];
+               pgmoneta_deque_offer_ref(que, child, NULL);
+            }
+            break;
+         }
+         case Node16:
+         {
+            struct art_node16* n = (struct art_node16*) node;
+            for (int i = 0; i < node->num_children; i++)
+            {
+               child = n->children[i];
+               pgmoneta_deque_offer_ref(que, child, NULL);
+            }
+            break;
+         }
+         case Node48:
+         {
+            struct art_node48* n = (struct art_node48*) node;
+            for (int i = 0; i < 256; i++)
+            {
+               idx = n->keys[i];
+               if (idx == 0)
+               {
+                  continue;
+               }
+               child = n->children[idx - 1];
+               pgmoneta_deque_offer_ref(que, child, NULL);
+            }
+            break;
+         }
+         case Node256:
+         {
+            struct art_node256* n = (struct art_node256*) node;
+            for (int i = 0; i < 256; i++)
+            {
+               if (n->children[i] == NULL)
+               {
+                  continue;
+               }
+               child = n->children[i];
+               pgmoneta_deque_offer_ref(que, child, NULL);
+            }
+            break;
+         }
+      }
+   }
+   return NULL;
+}
+
+void
+pgmoneta_art_iterator_destroy(struct art_iterator* iter)
+{
+   if (iter == NULL)
+   {
+      return;
+   }
+   pgmoneta_deque_destroy(iter->que);
+}
+
+bool
+pgmoneta_art_iterator_has_next(struct art_iterator* iter)
+{
+   return iter->count < iter->tree->size;
+}
+
+void
+pgmoneta_art_destroy_value_noop(void* val)
+{
+   return;
+}
+
+void
+pgmoneta_art_destroy_value_default(void* val)
+{
+   free(val);
+}

--- a/src/libpgmoneta/bzip2_compression.c
+++ b/src/libpgmoneta/bzip2_compression.c
@@ -98,6 +98,11 @@ pgmoneta_bzip2_data(char* directory, struct workers* workers)
       }
       else if (entry->d_type == DT_REG)
       {
+         if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
+             pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+         {
+            continue;
+         }
          if (!pgmoneta_is_file_archive(entry->d_name))
          {
             from = NULL;

--- a/src/libpgmoneta/deque.c
+++ b/src/libpgmoneta/deque.c
@@ -1,0 +1,327 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <deque.h>
+#include <utils.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+// tag is copied if not NULL, while data is not
+static void
+deque_offer(struct deque* deque, void* data, char* tag, enum node_type type);
+
+// tag is copied if not NULL, while data is not
+static void
+deque_node_create(struct deque_node** node, void* data, char* tag, enum node_type type);
+
+// if node type is not ref, data is freed. Tag will always be freed
+static void
+deque_node_destroy(struct deque_node* node);
+
+int
+pgmoneta_deque_create(struct deque** deque)
+{
+   struct deque* q = NULL;
+   q = malloc(sizeof(struct deque));
+   q->size = 0;
+   deque_node_create(&q->start, NULL, NULL, NodeRef);
+   deque_node_create(&q->end, NULL, NULL, NodeRef);
+   q->start->next = q->end;
+   q->end->prev = q->start;
+   *deque = q;
+   return 0;
+}
+
+int
+pgmoneta_deque_offer_string(struct deque* deque, char* data, char* tag)
+{
+   char* s = NULL;
+   if (data != NULL)
+   {
+      s = malloc(strlen(data) + 1);
+      strcpy(s, data);
+   }
+   deque_offer(deque, (void*)s, tag, NodeString);
+   return 0;
+}
+
+int
+pgmoneta_deque_offer_int(struct deque* deque, int data, char* tag)
+{
+   int* i = NULL;
+   i = malloc(sizeof(int));
+   *i = data;
+   deque_offer(deque, (void*)i, tag, NodeInt);
+   return 0;
+}
+
+int
+pgmoneta_deque_offer_bool(struct deque* deque, bool data, char* tag)
+{
+   bool* f = NULL;
+   f = malloc(sizeof(bool));
+   *f = data;
+   deque_offer(deque, (void*)f, tag, NodeBool);
+   return 0;
+}
+
+int
+pgmoneta_deque_offer_ref(struct deque* deque, void* data, char* tag)
+{
+   deque_offer(deque, data, tag, NodeRef);
+   return 0;
+}
+
+struct deque_node*
+pgmoneta_deque_poll(struct deque* deque)
+{
+   struct deque_node* head = NULL;
+   if (deque == NULL || deque->size == 0)
+   {
+      return NULL;
+   }
+   head = deque->start->next;
+   // remove node
+   deque->start->next = head->next;
+   head->next->prev = deque->start;
+   deque->size--;
+   return head;
+}
+
+struct deque_node*
+pgmoneta_deque_peek(struct deque* deque)
+{
+   if (deque == NULL || deque->size == 0)
+   {
+      return NULL;
+   }
+   return deque->start->next;
+}
+
+int
+pgmoneta_deque_poll_int(struct deque* deque)
+{
+   int res = 0;
+   struct deque_node* node = pgmoneta_deque_poll(deque);
+   if (node == NULL || node->type != NodeInt)
+   {
+      return 0;
+   }
+   res = *((int*)node->data);
+   deque_node_destroy(node);
+   return res;
+}
+
+int
+pgmoneta_deque_peek_int(struct deque* deque)
+{
+   int res = 0;
+   struct deque_node* node = pgmoneta_deque_peek(deque);
+   if (node == NULL || node->type != NodeInt)
+   {
+      return 0;
+   }
+   res = *((int*)node->data);
+   return res;
+}
+
+char*
+pgmoneta_deque_poll_string(struct deque* deque)
+{
+   char* res = NULL;
+   struct deque_node* node = pgmoneta_deque_poll(deque);
+   if (node == NULL || node->type != NodeString)
+   {
+      return NULL;
+   }
+   if (node->data != NULL)
+   {
+      res = malloc(strlen((char*)node->data) + 1);
+      strcpy(res, (char*)node->data);
+   }
+   deque_node_destroy(node);
+   return res;
+}
+
+char*
+pgmoneta_deque_peek_string(struct deque* deque)
+{
+   struct deque_node* node = pgmoneta_deque_peek(deque);
+   if (node == NULL || node->type != NodeString)
+   {
+      return NULL;
+   }
+   return (char*)node->data;
+}
+
+bool
+pgmoneta_deque_poll_bool(struct deque* deque)
+{
+   bool res = 0;
+   struct deque_node* node = pgmoneta_deque_poll(deque);
+   if (node == NULL || node->type != NodeBool)
+   {
+      return false;
+   }
+   res = *((bool*)node->data);
+   deque_node_destroy(node);
+   return res;
+}
+
+bool
+pgmoneta_deque_peek_bool(struct deque* deque)
+{
+   bool res = 0;
+   struct deque_node* node = pgmoneta_deque_peek(deque);
+   if (node == NULL || node->type != NodeBool)
+   {
+      return false;
+   }
+   res = *((bool*)node->data);
+   return res;
+}
+
+void*
+pgmoneta_deque_poll_ref(struct deque* deque)
+{
+   void* res = NULL;
+   struct deque_node* node = pgmoneta_deque_poll(deque);
+   if (node == NULL || node->type != NodeRef)
+   {
+      return false;
+   }
+   res = node->data;
+   deque_node_destroy(node);
+   return res;
+}
+
+void*
+pgmoneta_deque_peek_ref(struct deque* deque)
+{
+   void* res = NULL;
+   struct deque_node* node = pgmoneta_deque_peek(deque);
+   if (node == NULL || node->type != NodeRef)
+   {
+      return false;
+   }
+   res = node->data;
+   deque_node_destroy(node);
+   return res;
+}
+
+bool
+pgmoneta_deque_empty(struct deque* deque)
+{
+   return deque->size == 0;
+}
+
+void
+pgmoneta_deque_destroy(struct deque* deque)
+{
+   struct deque_node* n = NULL;
+   struct deque_node* next = NULL;
+   if (deque == NULL)
+   {
+      return;
+   }
+   n = deque->start;
+   while (n != NULL)
+   {
+      next = n->next;
+      deque_node_destroy(n);
+      n = next;
+   }
+   free(deque);
+}
+
+struct deque_node*
+pgmoneta_deque_node_remove(struct deque* deque, struct deque_node* node)
+{
+   if (deque == NULL || node == NULL || node == deque->start || node == deque->end)
+   {
+      return NULL;
+   }
+   struct deque_node* prev = node->prev;
+   struct deque_node* next = node->next;
+   prev->next = next;
+   next->prev = prev;
+   deque_node_destroy(node);
+   deque->size--;
+   return next;
+}
+
+static void
+deque_offer(struct deque* deque, void* data, char* tag, enum node_type type)
+{
+   struct deque_node* n = NULL;
+   struct deque_node* last = NULL;
+   deque_node_create(&n, data, tag, type);
+   deque->size++;
+   last = deque->end->prev;
+   last->next = n;
+   n->prev = last;
+   n->next = deque->end;
+   deque->end->prev = n;
+}
+
+static void
+deque_node_create(struct deque_node** node, void* data, char* tag, enum node_type type)
+{
+   struct deque_node* n = NULL;
+   n = malloc(sizeof(struct deque_node));
+   n->type = type;
+   n->data = data;
+   n->prev = NULL;
+   n->next = NULL;
+   if (tag != NULL)
+   {
+      n->tag = malloc(strlen(tag) + 1);
+      strcpy(n->tag, tag);
+   }
+   else
+   {
+      n->tag = NULL;
+   }
+   *node = n;
+}
+
+static void
+deque_node_destroy(struct deque_node* node)
+{
+   if (node == NULL)
+   {
+      return;
+   }
+   if (node->type != NodeRef)
+   {
+      free(node->data);
+   }
+   free(node->tag);
+   free(node);
+}

--- a/src/libpgmoneta/gzip_compression.c
+++ b/src/libpgmoneta/gzip_compression.c
@@ -214,6 +214,11 @@ pgmoneta_gzip_wal(char* directory)
 
    while ((entry = readdir(dir)) != NULL)
    {
+      if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
+          pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+      {
+         continue;
+      }
       if (entry->d_type == DT_REG)
       {
          if (pgmoneta_is_file_archive(entry->d_name) ||

--- a/src/libpgmoneta/lz4_compression.c
+++ b/src/libpgmoneta/lz4_compression.c
@@ -83,6 +83,11 @@ pgmoneta_lz4c_data(char* directory, struct workers* workers)
       else if (entry->d_type == DT_REG)
       {
          from = NULL;
+         if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
+             pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+         {
+            continue;
+         }
 
          from = pgmoneta_append(from, directory);
          from = pgmoneta_append(from, "/");

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -1115,6 +1115,41 @@ pgmoneta_remove_whitespace(char* orig)
    return result;
 }
 
+char*
+pgmoneta_remove_prefix(char* orig, char* prefix)
+{
+   char* res = NULL;
+   int idx = 0;
+   int len1 = strlen(orig);
+   int len2 = strlen(prefix);
+   int len = 0;
+   if (orig == NULL)
+   {
+      return NULL;
+   }
+   // make a copy of the original one
+   if (prefix == NULL)
+   {
+      res = pgmoneta_append(res, orig);
+      return res;
+   }
+   while (idx < len1 && idx < len2)
+   {
+      if (orig[idx] == prefix[idx])
+      {
+         idx++;
+      }
+   }
+   len = len1 - idx + 1;
+   res = malloc(len);
+   res[len - 1] = 0;
+   if (len > 1)
+   {
+      strcpy(res, orig + idx);
+   }
+   return res;
+}
+
 unsigned long
 pgmoneta_directory_size(char* directory)
 {

--- a/src/libpgmoneta/zstandard_compression.c
+++ b/src/libpgmoneta/zstandard_compression.c
@@ -115,6 +115,11 @@ pgmoneta_zstandardc_data(char* directory, struct workers* workers)
       }
       else if (entry->d_type == DT_REG)
       {
+         if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
+             pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+         {
+            continue;
+         }
          if (!pgmoneta_is_file_archive(entry->d_name))
          {
             from = NULL;


### PR DESCRIPTION
1. Implemented an adaptive radix tree for kv store
2. Use chunk loading during manifest comparison to ensure bounded memory usage
3. Use ART for quick insert/lookup during manifest comparison
4. Use manifest comparison instead of direct file comparison during link
5. Added a general deque for future usage

Currently our manifest comparison has a time complexity of O(ANlogk), supposing the manifests are of almost the same length, where A is the number of chunks inside manifest, N is number of entries inside manifest, and k being the length of the file path.
Usually the manifest fits in < 5 chunks or so, and k is bounded by maximum file path length, so the time complexity is near linear.