### PR TITLE
[#267] CLI Verify - Minimal viable implementation

### DIFF
--- a/src/include/management.h
+++ b/src/include/management.h
@@ -56,6 +56,7 @@ extern "C" {
 #define MANAGEMENT_DECRYPT        14
 #define MANAGEMENT_ENCRYPT        15
 #define MANAGEMENT_INFO           16
+#define MANAGEMENT_VERIFY         17 
 
 /**
  * Available command output formats
@@ -363,6 +364,33 @@ pgmoneta_management_read_info(SSL* ssl, int socket, char* server, char* backup, 
  */
 int
 pgmoneta_management_write_info(int socket, char* server, char* backup);
+
+/**
+ * Management operation: Verify checksums of backup files against backup_manifest
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The server name
+ * @param backup_id The backup id
+ * @param option Which files to report: all or only the ones whose calculated checksum does not match the checksum reported in manifest file (default)
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_verify_data(SSL* ssl, int socket, char* server, char *backup_id, char* option);
+
+
+/**
+ * Management operation: Read checksum verification info for a backup 
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param option Which files to report: all or only the ones whose calculated checksum does not match the checksum reported in manifest file (default)
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_read_verify_data(SSL* ssl, int socket, char* server, char* backup_id, char* option);
+
+//TODO documentation
+int
+pgmoneta_management_write_verify_data(int socket, int srv, char* backup_id, char* option) ;
 
 /**
  * Management: Read int32

--- a/src/include/manifest.h
+++ b/src/include/manifest.h
@@ -35,6 +35,7 @@ extern "C" {
 
 #include <pgmoneta.h>
 #include <art.h>
+#include <json.h>
 
 #define MANIFEST_CHUNK_SIZE 8192
 
@@ -69,6 +70,18 @@ pgmoneta_manifest_checksum_verify(char* root);
  */
 int
 pgmoneta_compare_manifests(char* old_manifest, char* new_manifest, struct art** deleted_files, struct art** changed_files, struct art** added_files);
+
+/**
+ * Verify files' checksum against backup_manifest
+ * @param reader The json reader
+ * @param output Array of strings to store output
+ * @param srv The number of the server
+ * @param backup_label The backup label 
+ * @param bool Report_all. True if all checksums should be reported. False if only failed checks.
+ * @return 0 upon success, otherwise 1.
+ */
+int
+pgmoneta_verify_data(struct json_reader* reader, char** output, int srv, char* backup_label, bool report_all);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hello,

this draft pull request contains a minimal viable implementation of `pgmoneta-cli` feature called `verify`. The feature compares backup files checksums reported in backup_manifest to checksums computed from files on disk.

As of now, the command returns 0 in case reported checksums match with computed ones, 1 if an error occur, 2 if no errors occur but there is at least one file that computed checksum does not match the reported one. 

The command receives two inputs: a server name and a backup_id.
Usage: `pgmoneta-cli -c <config_file> verify <server_name> <backup_id>`

I have some questions for further development:
- Do I need to call `shutdown_ports()` after the `fork()` is created?
- Is it a good idea to code a pgmoneta_get_server_backup_identifier_backup_manifest in src/libpgmoneta/utils.c ?
- Should more log messages be issued?
- Should I already extend the function to consider other checksum-algorithms? For the MVP I'm assuming SHA-256.

@jesperpedersen Any guidance on references to JSON output and use of workers?

Appreciate any comments. Thank you

---
TODO

- [ ] Output to JSON
- [x] help_verify()
- [ ] Use of workers
- [ ] crustify