### PR TITLE
[#316][#313] Link tablespaces with csv format manifest

### DIFF
--- a/src/include/csv.h
+++ b/src/include/csv.h
@@ -26,48 +26,89 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PGMONETA_LINK_H
-#define PGMONETA_LINK_H
+#ifndef PGMONETA_CSV_H
+#define PGMONETA_CSV_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <art.h>
-#include <workers.h>
-
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 
-/**
- * Create link between two directories with processed manifest info
- * @param base_from The base from directory (newer)
- * @param base_from_data The base from data directory
- * @param base_to The base to directory
- * @param from The current from directory
- * @param changed The changed files
- * @param added The added files
- * @param workers The optional workers
- */
-void
-pgmoneta_link_manifest(char* base_from, char* base_from_data, char* base_to, char* from, struct art* changed, struct art* added, struct workers* workers);
+struct csv_reader
+{
+   FILE* file;
+   char line[512];
+};
+
+struct csv_writer
+{
+   FILE* file;
+};
 
 /**
- * Relink link two directories
- * @param from The from directory
- * @param to The to directory
- * @param workers The optional workers
+ * Initialize a csv reader
+ * @param path The path to the csv file
+ * @param reader The reader
+ * @return 0 on success, 1 if otherwise
  */
-void
-pgmoneta_relink(char* from, char* to, struct workers* workers);
+int
+pgmoneta_csv_reader_init(char* path, struct csv_reader** reader);
 
 /**
- * Create link between two equal files
- * @param from The from directory
- * @param to The to directory
- * @param workers The optional workers
+ * Reset the reader pointer to the head of the file
+ * @param reader The reader
+ * @return 0 on success, 1 if otherwise
  */
-void
-pgmoneta_link_comparefiles(char* from, char* to, struct workers* workers);
+int
+pgmoneta_csv_reader_reset(struct csv_reader* reader);
+
+/**
+ * Initialize a csv writer
+ * @param path The path to the csv file
+ * @param writer The writer
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_csv_writer_init(char* path, struct csv_writer** writer);
+
+/**
+ * Write a row to csv file
+ * @param num_col The number of columns
+ * @param cols The columns of the row
+ * @param writer The csv writer
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_csv_write(int num_col, char** cols, struct csv_writer* writer);
+
+/**
+ * Get the next row in csv file
+ * @param num_col [out] The number of columns in the row
+ * @param cols [out] The columns in the row
+ * @param reader The reader
+ * @return true if has next row, false if otherwise
+ */
+bool
+pgmoneta_csv_next_row(int* num_col, char*** cols, struct csv_reader* reader);
+
+/**
+ * Destroy a csv reader
+ * @param reader The reader
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_csv_reader_destroy(struct csv_reader* reader);
+
+/**
+ * Destroy a csv writer
+ * @param writer The writer
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_csv_writer_destroy(struct csv_writer* writer);
 
 #ifdef __cplusplus
 }

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -122,6 +122,11 @@ extern "C" {
 #define SLOT_NOT_FOUND        1
 #define INCORRECT_SLOT_TYPE       2
 
+// simple manifest csv structure definition in case we want to change later
+#define MANIFEST_COLUMN_COUNT 2
+#define MANIFEST_PATH_INDEX 0
+#define MANIFEST_CHECKSUM_INDEX 1
+
 #define likely(x)    __builtin_expect (!!(x), 1)
 #define unlikely(x)  __builtin_expect (!!(x), 0)
 

--- a/src/include/security.h
+++ b/src/include/security.h
@@ -151,9 +151,10 @@ pgmoneta_generate_string_sha256_hash(char* string, char** sha256);
  * @param hmac_length The length of the digest.
  * @return 0 upon success, otherwise 1.
  */
-int pgmoneta_generate_string_hmac_sha256_hash(char* key, int key_length, char* value,
-                                              int value_length, unsigned char** hmac,
-                                              int* hmac_length);
+int
+pgmoneta_generate_string_hmac_sha256_hash(char* key, int key_length, char* value,
+                                          int value_length, unsigned char** hmac,
+                                          int* hmac_length);
 
 /**
  * Generate CRC32C for a buffer
@@ -162,14 +163,26 @@ int pgmoneta_generate_string_hmac_sha256_hash(char* key, int key_length, char* v
  * @param crc_buff The hash value
  * @return 0 upon success, otherwise 1
  */
-int pgmoneta_create_crc32c_buffer(void* buffer, size_t size, uint32_t* crc_buf);
+int
+pgmoneta_create_crc32c_buffer(void* buffer, size_t size, uint32_t* crc_buf);
 
 /**
  * @param path The file path.
  * @param crc The hash value.
  * @return 0 upon success, otherwise 1.
  */
-int pgmoneta_create_crc32c_file(char* path, char** crc);
+int
+pgmoneta_create_crc32c_file(char* path, char** crc);
+
+/**
+ * Create file hash with given algorithm
+ * @param algorithm The algorithm represented by index
+ * @param file_path The file path
+ * @param hash [out] The hash value
+ * @return 0 upon success, otherwise 1.
+ */
+int
+pgmoneta_create_file_hash(int algorithm, char* file_path, char** hash);
 
 /**
  * Close a SSL structure
@@ -177,6 +190,14 @@ int pgmoneta_create_crc32c_file(char* path, char** crc);
  */
 void
 pgmoneta_close_ssl(SSL* ssl);
+
+/**
+ * Convert an algorithm string into algorithm enum index
+ * @param algorithm The algorithm, case insensitive
+ * @return The algorithm index
+ */
+int
+pgmoneta_get_hash_algorithm(char* algorithm);
 
 #ifdef __cplusplus
 }

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -198,6 +198,13 @@ pgmoneta_workflow_create_cleanup(int type);
  */
 struct workflow*
 pgmoneta_workflow_encryption(bool encrypt);
+
+/**
+ * Create a workflow for manifest building
+ * @return The workflow
+ */
+struct workflow*
+pgmoneta_workflow_create_manifest(void);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgmoneta/bzip2_compression.c
+++ b/src/libpgmoneta/bzip2_compression.c
@@ -98,8 +98,7 @@ pgmoneta_bzip2_data(char* directory, struct workers* workers)
       }
       else if (entry->d_type == DT_REG)
       {
-         if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
-             pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+         if (pgmoneta_ends_with(entry->d_name, "backup_label"))
          {
             continue;
          }

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -72,7 +72,6 @@ static int as_seconds(char* str, int* age, int default_age);
 static int as_bytes(char* str, int* bytes, int default_bytes);
 static int as_retention(char* str, int* days, int* weeks, int* months, int* years);
 static int as_create_slot(char* str, int* create_slot);
-static int as_manifest(char* str);
 
 static int transfer_configuration(struct configuration* config, struct configuration* reload);
 static void copy_server(struct server* dst, struct server* src);
@@ -1235,11 +1234,11 @@ pgmoneta_read_configuration(void* shm, char* filename)
                {
                   if (!strcmp(section, "pgmoneta"))
                   {
-                     config->manifest = as_manifest(value);
+                     config->manifest = pgmoneta_get_hash_algorithm(value);
                   }
                   else if (strlen(section) > 0)
                   {
-                     srv.manifest = as_manifest(value);
+                     srv.manifest = pgmoneta_get_hash_algorithm(value);
                   }
                   else
                   {
@@ -2996,34 +2995,6 @@ as_create_slot(char* str, int* create_slot)
    *create_slot = CREATE_SLOT_UNDEFINED;
 
    return 1;
-}
-
-static int
-as_manifest(char* str)
-{
-
-   if (!strcasecmp(str, "crc32c"))
-   {
-      return HASH_ALGORITHM_CRC32C;
-   }
-   else if (!strcasecmp(str, "sha224"))
-   {
-      return HASH_ALGORITHM_SHA224;
-   }
-   else if (!strcasecmp(str, "sha256"))
-   {
-      return HASH_ALGORITHM_SHA256;
-   }
-   else if (!strcasecmp(str, "sha384"))
-   {
-      return HASH_ALGORITHM_SHA384;
-   }
-   else if (!strcasecmp(str, "sha512"))
-   {
-      return HASH_ALGORITHM_SHA512;
-   }
-
-   return HASH_ALGORITHM_SHA256;
 }
 
 static int

--- a/src/libpgmoneta/csv.c
+++ b/src/libpgmoneta/csv.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <utils.h>
+
+#include <csv.h>
+#include <stdlib.h>
+#include <string.h>
+
+int
+pgmoneta_csv_reader_init(char* path, struct csv_reader** reader)
+{
+   struct csv_reader* r = malloc(sizeof(struct csv_reader));
+   r->file = fopen(path, "r");
+   memset(r->line, 0, sizeof(r->line));
+   if (r->file == NULL)
+   {
+      goto error;
+   }
+   *reader = r;
+   return 0;
+error:
+   if (r->file != NULL)
+   {
+      fclose(r->file);
+   }
+   free(r);
+   return 1;
+}
+
+int
+pgmoneta_csv_reader_reset(struct csv_reader* reader)
+{
+   if (reader == NULL || reader->file == NULL)
+   {
+      goto error;
+   }
+   rewind(reader->file);
+   return 0;
+error:
+   return 1;
+}
+
+int
+pgmoneta_csv_writer_init(char* path, struct csv_writer** writer)
+{
+   struct csv_writer* w = malloc(sizeof(struct csv_writer));
+   w->file = fopen(path, "w+");
+   if (w->file == NULL)
+   {
+      goto error;
+   }
+   *writer = w;
+   return 0;
+error:
+   if (w->file != NULL)
+   {
+      fclose(w->file);
+   }
+   free(w);
+   return 1;
+}
+
+int
+pgmoneta_csv_write(int num_col, char** cols, struct csv_writer* writer)
+{
+   char* row = NULL;
+   if (writer == NULL || writer->file == NULL)
+   {
+      goto error;
+   }
+   for (int i = 0; i < num_col; i++)
+   {
+      row = pgmoneta_append(row, cols[i]);
+      if (i != num_col - 1)
+      {
+         row = pgmoneta_append(row, ",");
+      }
+      else
+      {
+         row = pgmoneta_append(row, "\n");
+      }
+   }
+   fwrite(row, 1, strlen(row), writer->file);
+   fflush(writer->file);
+   free(row);
+   return 0;
+error:
+   free(row);
+   return 1;
+}
+
+bool
+pgmoneta_csv_next_row(int* num_col, char*** cols, struct csv_reader* reader)
+{
+   char** cs = NULL;
+   char* col = NULL;
+   char* last_tok = NULL;
+   int num = 0;
+   if (reader == NULL || reader->file == NULL)
+   {
+      goto error;
+   }
+   memset(reader->line, 0, sizeof(reader->line));
+   if (fgets(reader->line, sizeof(reader->line), reader->file) == NULL)
+   {
+      goto error;
+   }
+   col = strtok(reader->line, ",");
+   while (col != NULL)
+   {
+      cs = realloc(cs, (num + 1) * sizeof(char*));
+      cs[num] = col;
+      num++;
+      col = strtok(NULL, ",");
+   }
+   // trim the new line from the last token
+   if (num > 0)
+   {
+      last_tok = cs[num - 1];
+      last_tok[strlen(last_tok) - 1] = '\0';
+   }
+   *cols = cs;
+   *num_col = num;
+   return true;
+error:
+   free(cs);
+   return false;
+}
+
+int
+pgmoneta_csv_reader_destroy(struct csv_reader* reader)
+{
+   if (reader == NULL)
+   {
+      return 0;
+   }
+   if (reader->file != NULL)
+   {
+      fclose(reader->file);
+   }
+   free(reader);
+   return 0;
+}
+
+int
+pgmoneta_csv_writer_destroy(struct csv_writer* writer)
+{
+   if (writer == NULL)
+   {
+      return 0;
+   }
+   if (writer->file != NULL)
+   {
+      fclose(writer->file);
+   }
+   free(writer);
+   return 0;
+}

--- a/src/libpgmoneta/gzip_compression.c
+++ b/src/libpgmoneta/gzip_compression.c
@@ -214,8 +214,7 @@ pgmoneta_gzip_wal(char* directory)
 
    while ((entry = readdir(dir)) != NULL)
    {
-      if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
-          pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+      if (pgmoneta_ends_with(entry->d_name, "backup_label"))
       {
          continue;
       }

--- a/src/libpgmoneta/lz4_compression.c
+++ b/src/libpgmoneta/lz4_compression.c
@@ -83,8 +83,7 @@ pgmoneta_lz4c_data(char* directory, struct workers* workers)
       else if (entry->d_type == DT_REG)
       {
          from = NULL;
-         if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
-             pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+         if (pgmoneta_ends_with(entry->d_name, "backup_label"))
          {
             continue;
          }

--- a/src/libpgmoneta/message.c
+++ b/src/libpgmoneta/message.c
@@ -894,27 +894,27 @@ pgmoneta_create_base_backup_message(int server_version, char* label, bool includ
       options = pgmoneta_append(options, "MANIFEST_CHECKSUMS '");
       switch (checksum_algorithm)
       {
-          case HASH_ALGORITHM_DEFAULT:
-             options = pgmoneta_append(options, "SHA256");
-             break;
-          case HASH_ALGORITHM_CRC32C:
-             options = pgmoneta_append(options, "CRC32C");
-             break;
-          case HASH_ALGORITHM_SHA224:
-             options = pgmoneta_append(options, "SHA224");
-             break;
-          case HASH_ALGORITHM_SHA256:
-             options = pgmoneta_append(options, "SHA256");
-             break;
-          case HASH_ALGORITHM_SHA384:
-             options = pgmoneta_append(options, "SHA384");
-             break;
-          case HASH_ALGORITHM_SHA512:
-             options = pgmoneta_append(options, "SHA512");
-             break;
-          default:
-             options = pgmoneta_append(options, "SHA256");
-             break;
+         case HASH_ALGORITHM_DEFAULT:
+            options = pgmoneta_append(options, "SHA256");
+            break;
+         case HASH_ALGORITHM_CRC32C:
+            options = pgmoneta_append(options, "CRC32C");
+            break;
+         case HASH_ALGORITHM_SHA224:
+            options = pgmoneta_append(options, "SHA224");
+            break;
+         case HASH_ALGORITHM_SHA256:
+            options = pgmoneta_append(options, "SHA256");
+            break;
+         case HASH_ALGORITHM_SHA384:
+            options = pgmoneta_append(options, "SHA384");
+            break;
+         case HASH_ALGORITHM_SHA512:
+            options = pgmoneta_append(options, "SHA512");
+            break;
+         default:
+            options = pgmoneta_append(options, "SHA256");
+            break;
       }
       options = pgmoneta_append(options, "'");
 
@@ -940,27 +940,27 @@ pgmoneta_create_base_backup_message(int server_version, char* label, bool includ
       options = pgmoneta_append(options, "MANIFEST_CHECKSUMS '");
       switch (checksum_algorithm)
       {
-          case HASH_ALGORITHM_DEFAULT:
-             options = pgmoneta_append(options, "SHA256");
-             break;
-          case HASH_ALGORITHM_CRC32C:
-             options = pgmoneta_append(options, "CRC32C");
-             break;
-          case HASH_ALGORITHM_SHA224:
-             options = pgmoneta_append(options, "SHA224");
-             break;
-          case HASH_ALGORITHM_SHA256:
-             options = pgmoneta_append(options, "SHA256");
-             break;
-          case HASH_ALGORITHM_SHA384:
-             options = pgmoneta_append(options, "SHA384");
-             break;
-          case HASH_ALGORITHM_SHA512:
-             options = pgmoneta_append(options, "SHA512");
-             break;
-          default:
-             options = pgmoneta_append(options, "SHA256");
-             break;
+         case HASH_ALGORITHM_DEFAULT:
+            options = pgmoneta_append(options, "SHA256");
+            break;
+         case HASH_ALGORITHM_CRC32C:
+            options = pgmoneta_append(options, "CRC32C");
+            break;
+         case HASH_ALGORITHM_SHA224:
+            options = pgmoneta_append(options, "SHA224");
+            break;
+         case HASH_ALGORITHM_SHA256:
+            options = pgmoneta_append(options, "SHA256");
+            break;
+         case HASH_ALGORITHM_SHA384:
+            options = pgmoneta_append(options, "SHA384");
+            break;
+         case HASH_ALGORITHM_SHA512:
+            options = pgmoneta_append(options, "SHA512");
+            break;
+         default:
+            options = pgmoneta_append(options, "SHA256");
+            break;
       }
       options = pgmoneta_append(options, "' ");
 

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -3227,6 +3227,36 @@ error:
    return 1;
 }
 
+int
+pgmoneta_create_file_hash(int algorithm, char* file_path, char** hash)
+{
+   int stat = 0;
+   switch (algorithm)
+   {
+      case HASH_ALGORITHM_CRC32C:
+         pgmoneta_create_crc32c_file(file_path, hash);
+         break;
+      case HASH_ALGORITHM_SHA224:
+         stat = pgmoneta_create_sha224_file(file_path, hash);
+         break;
+      case HASH_ALGORITHM_DEFAULT:
+      case HASH_ALGORITHM_SHA256:
+         stat = pgmoneta_create_sha256_file(file_path, hash);
+         break;
+      case HASH_ALGORITHM_SHA384:
+         stat = pgmoneta_create_sha384_file(file_path, hash);
+         break;
+      case HASH_ALGORITHM_SHA512:
+         stat = pgmoneta_create_sha512_file(file_path, hash);
+         break;
+      default:
+         pgmoneta_log_error("Unrecognized hash algorithm: %s", algorithm);
+         stat = 1;
+         break;
+   }
+   return stat;
+}
+
 void
 pgmoneta_close_ssl(SSL* ssl)
 {
@@ -3244,4 +3274,31 @@ pgmoneta_close_ssl(SSL* ssl)
       SSL_free(ssl);
       SSL_CTX_free(ctx);
    }
+}
+
+int
+pgmoneta_get_hash_algorithm(char* algorithm)
+{
+   if (!strcasecmp(algorithm, "crc32c"))
+   {
+      return HASH_ALGORITHM_CRC32C;
+   }
+   else if (!strcasecmp(algorithm, "sha224"))
+   {
+      return HASH_ALGORITHM_SHA224;
+   }
+   else if (!strcasecmp(algorithm, "sha256"))
+   {
+      return HASH_ALGORITHM_SHA256;
+   }
+   else if (!strcasecmp(algorithm, "sha384"))
+   {
+      return HASH_ALGORITHM_SHA384;
+   }
+   else if (!strcasecmp(algorithm, "sha512"))
+   {
+      return HASH_ALGORITHM_SHA512;
+   }
+
+   return HASH_ALGORITHM_SHA256;
 }

--- a/src/libpgmoneta/wf_manifest.c
+++ b/src/libpgmoneta/wf_manifest.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <csv.h>
+#include <json.h>
+#include <logging.h>
+#include <utils.h>
+#include <workflow.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int manifest_setup(int, char*, struct node*, struct node**);
+static int manifest_execute_build(int, char*, struct node*, struct node**);
+static int manifest_teardown(int, char*, struct node*, struct node**);
+
+struct workflow*
+pgmoneta_workflow_create_manifest(void)
+{
+   struct workflow* wf = NULL;
+
+   wf = (struct workflow*)malloc(sizeof(struct workflow));
+
+   if (wf == NULL)
+   {
+      return NULL;
+   }
+
+   wf->setup = &manifest_setup;
+   wf->execute = &manifest_execute_build;
+   wf->teardown = &manifest_teardown;
+   wf->next = NULL;
+
+   return wf;
+}
+
+static int
+manifest_setup(int server, char* identifier, struct node* i_nodes, struct node** o_nodes)
+{
+   return 0;
+}
+
+static int
+manifest_execute_build(int server, char* identifier, struct node* i_nodes, struct node** o_nodes)
+{
+   char* root = NULL;
+   char* data = NULL;
+   char* manifest_orig = NULL;
+   char* manifest = NULL;
+   char* key_path[1] = {"Files"};
+   char* backup_dir = NULL;
+   struct backup* backup = NULL;
+   struct json_reader* reader = NULL;
+   struct json* entry = NULL;
+   struct csv_writer* writer = NULL;
+   char* tblspc = NULL;
+   char file_path[MAX_PATH];
+   char* info[MANIFEST_COLUMN_COUNT];
+
+   backup_dir = pgmoneta_get_server_backup(server);
+   root = pgmoneta_get_server_backup_identifier(server, identifier);
+   data = pgmoneta_get_server_backup_identifier_data(server, identifier);
+   manifest = pgmoneta_append(manifest, root);
+   manifest = pgmoneta_append(manifest, "backup.manifest");
+   manifest_orig = pgmoneta_append(manifest_orig, data);
+   manifest_orig = pgmoneta_append(manifest_orig, "backup_manifest");
+
+   pgmoneta_get_backup(backup_dir, identifier, &backup);
+
+   if (pgmoneta_csv_writer_init(manifest, &writer))
+   {
+      pgmoneta_log_error("Could not create csv writer for %s", manifest);
+      goto error;
+   }
+
+   if (pgmoneta_json_reader_init(manifest_orig, &reader))
+   {
+      goto error;
+   }
+   if (pgmoneta_json_locate(reader, key_path, 1))
+   {
+      pgmoneta_log_error("Could not locate files array in manifest %s", manifest_orig);
+      goto error;
+   }
+
+   // convert original manifest file
+   while (pgmoneta_json_next_array_item(reader, &entry))
+   {
+      memset(file_path, 0, MAX_PATH);
+      snprintf(file_path, MAX_PATH, "data/%s", pgmoneta_json_get_string_value(entry, "Path"));
+      info[MANIFEST_PATH_INDEX] = file_path;
+      info[MANIFEST_CHECKSUM_INDEX] = pgmoneta_json_get_string_value(entry, "Checksum");
+      pgmoneta_csv_write(MANIFEST_COLUMN_COUNT, info, writer);
+      pgmoneta_json_free(entry);
+      entry = NULL;
+   }
+
+   pgmoneta_json_close_reader(reader);
+   pgmoneta_csv_writer_destroy(writer);
+   pgmoneta_json_free(entry);
+   free(root);
+   free(data);
+   free(manifest);
+   free(manifest_orig);
+   free(backup_dir);
+   free(backup);
+   free(tblspc);
+   return 0;
+
+error:
+   pgmoneta_json_close_reader(reader);
+   pgmoneta_csv_writer_destroy(writer);
+   pgmoneta_json_free(entry);
+   free(root);
+   free(data);
+   free(manifest);
+   free(manifest_orig);
+   free(backup_dir);
+   free(backup);
+   free(tblspc);
+   return 1;
+}
+
+static int
+manifest_teardown(int server, char* identifier, struct node* i_nodes, struct node** o_nodes)
+{
+   return 0;
+}

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -104,6 +104,9 @@ wf_backup(void)
    head = pgmoneta_workflow_create_basebackup();
    current = head;
 
+   current->next = pgmoneta_workflow_create_manifest();
+   current = current->next;
+
    current->next = pgmoneta_storage_create_local();
    current = current->next;
 

--- a/src/libpgmoneta/zstandard_compression.c
+++ b/src/libpgmoneta/zstandard_compression.c
@@ -115,8 +115,7 @@ pgmoneta_zstandardc_data(char* directory, struct workers* workers)
       }
       else if (entry->d_type == DT_REG)
       {
-         if (pgmoneta_ends_with(entry->d_name, "backup_label") ||
-             pgmoneta_ends_with(entry->d_name, "backup_manifest"))
+         if (pgmoneta_ends_with(entry->d_name, "backup_label"))
          {
             continue;
          }


### PR DESCRIPTION
1. Convert backup_manifest from json format to simplified csv format named as backup.manifest. This is originally for extending the manifest from recording data directory only to also include tablespaces. Upon deeper investigation we found that the manifest includes tablespaces in the first place. But having a csv format manifest is still important for us, since in the future extension side will most likely build manifest as well, having a csv infrastructure is much easier and memory efficient than dealing with json directly.
2. Use the new manifest to link data and tablespaces directory.
3. Fix the bug that files are not linked correctly because of lack of compression suffix handling

New backup.manifest sits in the parent directory of data and tablespaces, the same as backup.info. This brings some extra complexity -- all files in the data directory are prefixed with `data/` for instance, and only data directory should be traversed when linking, tablespaces are traversed through `data/pg_tblspc`. But I still don't think it's a good idea for us to add files directly into user's data directory. 

Note that we could replace `data/pg_tblspc/tblspc_oid` with `tablespace_name/`, but we won't guarantee our manifest works on the server side this way, since tablespaces could be anywhere on the server side. Thus we still use symlinks. Though this only works when pg_tblspc is linked to each table spaces correctly. So some extra work must be done on the hotstandby side, which this patch will not touch.