### PR TITLE
[#319] Test suite for pgmoneta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 
 project(pgmoneta VERSION ${VERSION_STRING} LANGUAGES  C)
 
+include(CTest)
+enable_testing()
+
 set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH})
@@ -33,6 +36,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 message(STATUS "pgmoneta ${VERSION_STRING}")
 
 set(generation TRUE)
+set(check TRUE)
+set(container FALSE)
 
 include(CheckCCompilerFlag)
 include(CheckCSourceCompiles)
@@ -104,6 +109,27 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         OUTPUT_STRIP_TRAILING_WHITESPACE
         COMMAND_ERROR_IS_FATAL ANY
     )
+endif()
+
+find_package(Check)
+if (CHECK_FOUND)
+  message(STATUS "check found")
+  add_library(Check::check SHARED IMPORTED)
+  set_target_properties(Check::check PROPERTIES
+    IMPORTED_LOCATION ${CHECK_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${CHECK_INCLUDE_DIR})
+else ()
+  set(check FALSE)
+  message(STATUS "check needed. The test suite process will be skipped.")
+endif()
+
+find_package(Docker)
+find_package(Podman)
+if (DOCKER_FOUND OR PODMAN_FOUND)
+  set(container TRUE)
+  message(STATUS "Docker or podman found")
+else ()
+  message(STATUS "Docker or podman needed. The test suite will be skipped.")
 endif()
 
 find_package(Pandoc)
@@ -225,3 +251,4 @@ file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/")
 
 add_subdirectory(doc)
 add_subdirectory(src)
+add_subdirectory(test)

--- a/cmake/FindCheck.cmake
+++ b/cmake/FindCheck.cmake
@@ -1,0 +1,29 @@
+#
+# check support
+#
+
+find_package(PkgConfig)
+pkg_check_modules(PC_CHECK check)
+
+find_path(CHECK_INCLUDE_DIR
+  NAMES check.h
+  PATHS ${PC_CHECK_INCLUDE_DIRS}
+  PATH_SUFFIXES check
+)
+
+find_library(CHECK_LIBRARY
+  NAMES check
+  PATHS ${PC_CHECK_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Check DEFAULT_MSG CHECK_INCLUDE_DIR CHECK_LIBRARY)
+
+if (CHECK_FOUND)
+  set(CHECK_LIBRARIES ${CHECK_LIBRARY})
+  set(CHECK_INCLUDE_DIRS ${CHECK_INCLUDE_DIR})
+else ()
+  set(check FALSE)
+endif ()
+
+mark_as_advanced(CHECK_INCLUDE_DIR CHECK_LIBRARY)

--- a/cmake/FindDocker.cmake
+++ b/cmake/FindDocker.cmake
@@ -1,0 +1,18 @@
+#
+# Check for Docker
+#
+
+find_program(DOCKER_EXECUTABLE
+  NAMES docker
+  PATHS /usr/local/bin /usr/bin /bin
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Docker DEFAULT_MSG DOCKER_EXECUTABLE)
+
+if (DOCKER_FOUND)
+  set(container TRUE)
+  set(DOCKER_EXECUTABLE ${DOCKER_EXECUTABLE})
+endif ()
+
+mark_as_advanced(DOCKER_EXECUTABLE)

--- a/cmake/FindPodman.cmake
+++ b/cmake/FindPodman.cmake
@@ -1,0 +1,18 @@
+#
+# Check for Podman
+#
+
+find_program(PODMAN_EXECUTABLE
+  NAMES podman
+  PATHS /usr/local/bin /usr/bin /bin
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Podman DEFAULT_MSG PODMAN_EXECUTABLE)
+
+if (PODMAN_FOUND)
+  set(container TRUE)
+  set(PODMAN_EXECUTABLE ${PODMAN_EXECUTABLE})
+endif ()
+
+mark_as_advanced(PODMAN_EXECUTABLE)

--- a/doc/TEST.md
+++ b/doc/TEST.md
@@ -1,0 +1,84 @@
+# Test
+
+## Container Environment
+
+To ensure the test suite works well, please make sure you have installed `Docker` or `podman` on your OS. If neither `Docker` nor `podman` is installed, the test suite compilation will be skipped.
+
+### Docker
+
+First, ensure your system is up to date.
+
+```sh
+dnf update
+```
+
+Install the necessary packages for Docker.
+
+```sh
+dnf -y install dnf-plugins-core
+```
+
+Add the Docker repository to your system.
+
+``` sh
+sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+```
+
+Install Docker Engine, Docker CLI, and Containerd.
+
+```sh
+sudo dnf install docker-ce docker-ce-cli containerd.io
+```
+
+Start the Docker service and enable it to start on boot.
+
+```sh
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
+Verify that Docker is installed correctly.
+
+```sh
+docker --version
+```
+
+If you see the Docker version, then you have successfully installed Docker on Fedora.
+
+### Podman
+
+Install Podman and the Docker alias package.
+
+```sh
+dnf install podman podman-docker.noarch
+```
+
+Verify that Podman is installed correctly.
+
+```sh
+podman --version
+```
+
+If you see the Podman version, then you have successfully installed Podman on Fedora.
+
+The `podman-docker.noarch` package simplifies the use of `Podman` for users accustomed to Docker.
+
+## Test suite
+
+Before you test, you need to install the `check` library. If there is no package for `check`, the `CMakeLists.txt` will not compile the test suite. Only after you have installed `check` will it compile the test suite.
+
+``` sh
+dnf install -y check check-devel check-static
+```
+
+You can simply use `CTest` to test all PostgreSQL versions from 13 to 16. It will automatically run `testsuite.sh` to test `pgmoneta` and `pgmoneta_ext` for each version. The script will automatically create the Docker container, run it, and then use the `check` framework to test their functions inside it. After that, it will automatically clean up everything for you.
+
+After you follow the [DEVELOPERS.md](https://github.com/pgmoneta/pgmoneta_ext/blob/main/doc/DEVELOPERS.md#developer-guide) to install `pgmoneta`, go to the directory `/pgmoneta/build` and run the test.
+
+``` sh
+make test
+```
+
+`CTest` will output logs into `/pgmoneta/build/Testing/Temporary/LastTest.log`. If you want to check the specific process, you can review that log file.
+
+`testsuite.sh` accepts three variables. The first one is `dir`, which specifies the `/test` directory location, with a default value of `./`. The second one is `dockerfile`, with a default value of `Dockerfile.rocky8`. The third one is the PostgreSQL `version`, with a default value of `13`.

--- a/doc/manual/99-references.md
+++ b/doc/manual/99-references.md
@@ -37,10 +37,12 @@
   [aes_ni]: https://en.wikipedia.org/wiki/AES_instruction_set
   [ART_paper]: http://www-db.in.tum.de/~leis/papers/ART.pdf
   [libart]: https://github.com/armon/libart
+  [pgsqlrepo]: https://github.com/postgres/postgres
 
 <!-- doc/ -->
   [rpm]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/RPM.md
   [configuration]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/CONFIGURATION.md
+  [developers]: https://github.com/pgmoneta/pgmoneta_ext/blob/main/doc/DEVELOPERS.md#developer-guide
 <!-- doc/tutorial -->
   [t_install]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/01_install.md
   [t_remote_management]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/02_remote_management.md

--- a/doc/manual/dev-05-test.md
+++ b/doc/manual/dev-05-test.md
@@ -1,0 +1,84 @@
+\newpage
+
+# Test
+
+## Container Environment
+
+### Docker
+
+First, ensure your system is up to date.
+
+```sh
+dnf update
+```
+
+Install the necessary packages for Docker.
+
+```sh
+dnf -y install dnf-plugins-core
+```
+
+Add the Docker repository to your system.
+
+``` sh
+sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+```
+
+Install Docker Engine, Docker CLI, and Containerd.
+
+```sh
+sudo dnf install docker-ce docker-ce-cli containerd.io
+```
+
+Start the Docker service and enable it to start on boot.
+
+```sh
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
+Verify that Docker is installed correctly.
+
+```sh
+docker --version
+```
+
+If you see the Docker version, then you have successfully installed Docker on Fedora.
+
+### Podman
+
+Install Podman and the Docker alias package.
+
+```sh
+dnf install podman podman-docker.noarch
+```
+
+Verify that Podman is installed correctly.
+
+```sh
+podman --version
+```
+
+If you see the Podman version, then you have successfully installed Podman on Fedora.
+
+The `podman-docker.noarch` package simplifies the use of `Podman` for users accustomed to Docker.
+
+## Test suite
+
+You can simply use `CTest` to test all PostgreSQL versions from 13 to 16. It will automatically run `testsuite.sh` to test `pgmoneta` and `pgmoneta_ext` for each version. The script will automatically create the Docker container, run it, and then use the `check` framework to test their functions inside it. After that, it will automatically clean up everything for you.
+
+Go to the directory `/pgmoneta/test`, and give permission to `testsuite.sh` using:
+
+``` sh
+chmod +x testsuite.sh
+```
+
+After you follow the [DEVELOPERS.md][developers] to install `pgmoneta`, go to the directory `/pgmoneta/build` and run the test.
+
+``` sh
+make test
+```
+
+`CTest` will output logs into `/pgmoneta/build/Testing/Temporary/LastTest.log`. If you want to check the specific process, you can review that log file.
+
+`testsuite.sh` accepts three variables. The first one is `dir`, which specifies the `/test` directory location, with a default value of `./`. The second one is `dockerfile`, with a default value of `Dockerfile.rocky8`. The third one is the PostgreSQL `version`, with a default value of `13`.

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -2890,7 +2890,11 @@ create_hash_file(char* filename, const char* algorithm, char** hash)
 
    md_ctx = EVP_MD_CTX_new();
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
    if (!EVP_DigestInit_ex2(md_ctx, md, NULL))
+#else
+   if (!EVP_DigestInit_ex(md_ctx, md, NULL))
+#endif
    {
       pgmoneta_log_error("Message digest initialization failed");
       EVP_MD_CTX_free(md_ctx);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,68 @@
+# 
+#  Copyright (C) 2024 The pgmoneta community
+# 
+#  Redistribution and use in source and binary forms, with or without modification,
+#  are permitted provided that the following conditions are met:
+# 
+#  1. Redistributions of source code must retain the above copyright notice, this list
+#  of conditions and the following disclaimer.
+# 
+#  2. Redistributions in binary form must reproduce the above copyright notice, this
+#  list of conditions and the following disclaimer in the documentation and/or other
+#  materials provided with the distribution.
+# 
+#  3. Neither the name of the copyright holder nor the names of its contributors may
+#  be used to endorse or promote products derived from this software without specific
+#  prior written permission.
+# 
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+#  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+#  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+#  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+#  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+#  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# 
+if (check)
+  set(SOURCES
+    lib/pgmoneta_test.c
+    lib/pgmoneta_ext_test.c
+    lib/runner.c
+  )
+
+  add_executable(pgmoneta_test ${SOURCES})
+
+  if(EXISTS "/etc/debian_version")
+    target_link_libraries(pgmoneta_test Check::check subunit pthread rt m)
+  else()
+    target_link_libraries(pgmoneta_test Check::check pthread rt m)
+  endif()
+
+  add_custom_target(custom_clean
+    COMMAND ${CMAKE_COMMAND} -E remove -f *.o pgmoneta_test
+    COMMENT "Cleaning up..."
+  )
+endif()
+
+if(container)
+
+  add_test(test_version_13_rocky9 "${CMAKE_CURRENT_SOURCE_DIR}/../test/testsuite.sh" "${CMAKE_CURRENT_SOURCE_DIR}/../test" "Dockerfile.rocky9" 13)
+  add_test(test_version_14_rocky9 "${CMAKE_CURRENT_SOURCE_DIR}/../test/testsuite.sh" "${CMAKE_CURRENT_SOURCE_DIR}/../test" "Dockerfile.rocky9" 14)
+  add_test(test_version_15_rocky9 "${CMAKE_CURRENT_SOURCE_DIR}/../test/testsuite.sh" "${CMAKE_CURRENT_SOURCE_DIR}/../test" "Dockerfile.rocky9" 15)
+  add_test(test_version_16_rocky9 "${CMAKE_CURRENT_SOURCE_DIR}/../test/testsuite.sh" "${CMAKE_CURRENT_SOURCE_DIR}/../test" "Dockerfile.rocky9" 16)
+
+  set(failRegex 
+      "Failures: [1-9][0-9]*"
+  )
+
+  set_property (TEST test_version_13_rocky9
+                PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
+  set_property (TEST test_version_14_rocky9
+                PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
+  set_property (TEST test_version_15_rocky9
+                PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")        
+  set_property (TEST test_version_16_rocky9
+                PROPERTY FAIL_REGULAR_EXPRESSION "${failRegex}")
+endif()

--- a/test/Dockerfile.rocky9
+++ b/test/Dockerfile.rocky9
@@ -1,0 +1,114 @@
+# 
+#  Copyright (C) 2024 The pgmoneta community
+# 
+#  Redistribution and use in source and binary forms, with or without modification,
+#  are permitted provided that the following conditions are met:
+# 
+#  1. Redistributions of source code must retain the above copyright notice, this list
+#  of conditions and the following disclaimer.
+# 
+#  2. Redistributions in binary form must reproduce the above copyright notice, this
+#  list of conditions and the following disclaimer in the documentation and/or other
+#  materials provided with the distribution.
+# 
+#  3. Neither the name of the copyright holder nor the names of its contributors may
+#  be used to endorse or promote products derived from this software without specific
+#  prior written permission.
+# 
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+#  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+#  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+#  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+#  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+#  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# 
+
+FROM rockylinux:9
+
+ARG PGVERSION
+
+ENV PGVERSION=${PGVERSION}
+ENV PGPASSWORD="secretpassword"
+ENV PATH=/pgsql/bin:$PATH
+ENV LD_LIBRARY_PATH=/pgsql/lib
+
+RUN yum clean all && \
+    yum update -y && \
+    yum install -y epel-release && \
+    yum install -y --allowerasing \
+    git gcc cmake make bison readline-devel zlib-devel openssl-devel \
+    wget ccache libicu-devel flex libxml2-devel libxslt-devel perl libev libev-devel \
+    openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel \
+    lz4 lz4-devel libssh libssh-devel libcurl libcurl-devel python3-pip libatomic \
+    bzip2 bzip2-devel libarchive libarchive-devel check check-devel && \
+    yum groupinstall -y 'Development Tools' && \
+    yum clean all && \
+    pip3 install docutils
+
+RUN useradd -m postgres && echo "postgres:${PGPASSWORD}" | chpasswd
+RUN useradd -m pgmoneta && echo "pgmoneta:${PGPASSWORD}" | chpasswd
+
+COPY conf/ /conf
+
+RUN chmod -R 777 /conf && \
+    mkdir -p /pgsql && \
+    chown -R postgres:postgres /pgsql
+
+# Install PostgreSQL 
+RUN git clone --branch "REL_${PGVERSION}_STABLE" --single-branch --depth 1 https://github.com/postgres/postgres.git && \
+    cd postgres && \
+    ./configure --prefix=/pgsql && \
+    make && \
+    make install
+
+RUN su - postgres -c "/pgsql/bin/initdb -D /pgsql/data" && \
+    su - postgres -c "sed -i 's/^#\s*password_encryption\s*=\s*\(md5\|scram-sha-256\)/password_encryption = scram-sha-256/' /pgsql/data/postgresql.conf" && \
+    su - postgres -c "sed -i 's/#wal_level = replica/wal_level = replica/' /pgsql/data/postgresql.conf && \
+    cp -f /conf/pg_hba.conf /pgsql/data" && \
+    chown -R postgres:postgres /pgsql/data && \
+    su - postgres -c "/pgsql/bin/pg_ctl -D /pgsql/data -l /pgsql/logfile start" && \
+    su - postgres -c "/pgsql/bin/psql -U postgres -c \"CREATE ROLE repl WITH LOGIN REPLICATION PASSWORD '${PGPASSWORD}';\"" && \
+    su - postgres -c "/pgsql/bin/psql -U postgres -c \"SELECT pg_create_physical_replication_slot('repl', true, false);\"" && \
+    su - postgres -c "/pgsql/bin/psql -c \"CREATE USER myuser WITH PASSWORD '${PGPASSWORD}';\"" && \
+    su - postgres -c "/pgsql/bin/psql -c \"CREATE DATABASE mydb WITH OWNER myuser ENCODING 'UTF8';\"" && \
+    su - postgres -c "/pgsql/bin/pg_ctl -D /pgsql/data -l /pgsql/logfile stop"
+
+# Install pgmoneta
+RUN git clone --branch "main" --single-branch --depth 1 https://github.com/pgmoneta/pgmoneta && \
+    cd pgmoneta && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install && \
+    cp -rf /conf/pgmoneta.conf /pgmoneta && \
+    mkdir -p /pgmoneta/backup && \
+    chown -R pgmoneta:pgmoneta /pgmoneta && \
+    su - pgmoneta -c "/pgmoneta/build/src/pgmoneta-admin master-key -P ${PGPASSWORD}" && \
+    su - pgmoneta -c "/pgmoneta/build/src/pgmoneta-admin -f /pgmoneta/pgmoneta_users.conf -U repl -P ${PGPASSWORD} user add"
+
+# Install pgmoneta_ext
+RUN git clone --branch "main" --single-branch --depth 1 https://github.com/pgmoneta/pgmoneta_ext && \
+    cd pgmoneta_ext && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install && \
+    echo "/pgsql/lib" >> /etc/ld.so.conf && \
+    ldconfig && \
+    su - postgres -c "/pgsql/bin/pg_ctl -D /pgsql/data -l /pgsql/logfile start" && \
+    su - postgres -c "/pgsql/bin/psql -U postgres -c \"DROP EXTENSION IF EXISTS pgmoneta_ext;\"" && \
+    su - postgres -c "/pgsql/bin/psql -U postgres -c \"CREATE EXTENSION pgmoneta_ext;\"" && \
+    su - postgres -c "/pgsql/bin/pg_ctl -D /pgsql/data -l /pgsql/logfile stop"
+
+CMD ["sh", "-c", "\
+    su - postgres -c '/pgsql/bin/pg_ctl -D /pgsql/data -l /pgsql/logfile start' && \
+    su - pgmoneta -c '/pgmoneta/build/src/pgmoneta -c /pgmoneta/pgmoneta.conf -u /pgmoneta/pgmoneta_users.conf -d' && \
+    su - pgmoneta -c '/pgmoneta/build/src/pgmoneta-cli -c /pgmoneta/pgmoneta.conf details' && \
+    /pgmoneta/build/test/pgmoneta_test && \
+    su - pgmoneta -c '/pgmoneta/build/src/pgmoneta-cli -c /pgmoneta/pgmoneta.conf stop' \
+"]

--- a/test/conf/pg_hba.conf
+++ b/test/conf/pg_hba.conf
@@ -1,0 +1,101 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local         DATABASE  USER  METHOD  [OPTIONS]
+# host          DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl     DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostgssenc    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnogssenc  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# non-SSL TCP/IP socket.  Similarly, "hostgssenc" uses a
+# GSSAPI-encrypted TCP/IP socket, while "hostnogssenc" uses a
+# non-GSSAPI socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
+# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
+# Note that "password" sends passwords in clear text; "md5" or
+# "scram-sha-256" are preferred since they send encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the server receives a
+# SIGHUP signal.  If you edit the file on a running system, you have to
+# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
+# or execute "SELECT pg_reload_conf()".
+#
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+# CAUTION: Configuring the system for local "trust" authentication
+# allows any local user to connect as any PostgreSQL user, including
+# the database superuser.  If you do not trust all your local users,
+# use another authentication method.
+
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+#host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+#host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    mydb             myuser          127.0.0.1/32            scram-sha-256
+host    mydb             myuser          ::1/128                 scram-sha-256
+host    postgres         repl            127.0.0.1/32            scram-sha-256
+host    postgres         repl            ::1/128                 scram-sha-256
+host    replication      repl            127.0.0.1/32            scram-sha-256
+host    replication      repl            ::1/128                 scram-sha-256

--- a/test/conf/pgmoneta.conf
+++ b/test/conf/pgmoneta.conf
@@ -1,0 +1,29 @@
+[pgmoneta]
+host = *
+metrics = 5001
+create_slot = yes
+
+base_dir = /pgmoneta/backup
+
+compression = zstd
+
+storage_engine = local
+
+retention = 7
+
+log_type = file
+log_level = info
+log_path = /tmp/pgmoneta.log
+
+unix_socket_dir = /tmp/
+
+tls = off
+tls_cert_file = /pgmoneta/server.crt
+tls_key_file = /pgmoneta/server.key
+tls_ca_file = /pgmoneta/root.crt
+
+[primary]
+host = localhost
+port = 5432
+user = repl
+wal_slot = repl

--- a/test/lib/pgmoneta_ext_test.c
+++ b/test/lib/pgmoneta_ext_test.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "pgmoneta_ext_test.h"
+
+#define BUFFER_SIZE 8192
+
+#define PGMONETA_EXT_VERSION_RESULT      "0.1.0"
+#define PGMONETA_EXT_SWITCH_WAL_RESULT   "(f,)"
+#define PGMONETA_EXT_CHECKPOINT_RESULT   "(f,)"
+
+static int
+execute_command(const char* command, char* output, size_t output_size)
+{
+   FILE* fp;
+   fp = popen(command, "r");
+   if (fp == NULL)
+   {
+      return -1;
+   }
+
+   if (fgets(output, output_size, fp) == NULL)
+   {
+      pclose(fp);
+      return -1;
+   }
+
+   pclose(fp);
+   return 0;
+}
+
+START_TEST(test_pgmoneta_ext_version)
+{
+   char output[BUFFER_SIZE];
+   int result = execute_command("psql -h localhost -p 5432 -U repl -d postgres -t -c 'SELECT pgmoneta_ext_version();'", output, BUFFER_SIZE);
+   ck_assert_int_eq(result, 0);
+   ck_assert_msg(strstr(output, PGMONETA_EXT_VERSION_RESULT) != NULL, "Expected version string not found in output: %s", output);
+}
+END_TEST
+START_TEST(test_pgmoneta_ext_switch_wal)
+{
+   char output[BUFFER_SIZE];
+   int result = execute_command("psql -h localhost -p 5432 -U repl -d postgres -t -c 'SELECT pgmoneta_ext_switch_wal();'", output, BUFFER_SIZE);
+   ck_assert_int_eq(result, 0);
+   ck_assert_msg(strstr(output, PGMONETA_EXT_SWITCH_WAL_RESULT) != NULL, "Expected WAL switch result not found in output: %s", output);
+}
+END_TEST
+START_TEST(test_pgmoneta_ext_checkpoint)
+{
+   char output[BUFFER_SIZE];
+   int result = execute_command("psql -h localhost -p 5432 -U repl -d postgres -t -c 'SELECT pgmoneta_ext_checkpoint();'", output, BUFFER_SIZE);
+   ck_assert_int_eq(result, 0);
+   ck_assert_msg(strstr(output, PGMONETA_EXT_CHECKPOINT_RESULT) != NULL, "Expected checkpoint result not found in output: %s", output);
+}
+END_TEST
+
+Suite*
+pgmoneta_ext_suite(void)
+{
+   Suite* s;
+   TCase* tc_core;
+
+   s = suite_create("pgmoneta_ext");
+
+   tc_core = tcase_create("Core");
+
+   tcase_add_test(tc_core, test_pgmoneta_ext_version);
+   tcase_add_test(tc_core, test_pgmoneta_ext_switch_wal);
+   tcase_add_test(tc_core, test_pgmoneta_ext_checkpoint);
+   suite_add_tcase(s, tc_core);
+
+   return s;
+}

--- a/test/lib/pgmoneta_ext_test.h
+++ b/test/lib/pgmoneta_ext_test.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGMONETA_EXT_TEST_H
+#define PGMONETA_EXT_TEST_H
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Execute a shell command and capture its output
+ * @param command The shell command to execute
+ * @param output A buffer to store the command's output
+ * @param output_size The size of the output buffer
+ * @return 0 on success, -1 on error
+ */
+static int
+execute_command(const char* command, char* output, size_t output_size);
+
+/**
+ * Set up a suite of test cases for pgmoneta_ext
+ * @return The result
+ */
+Suite*
+pgmoneta_ext_suite(void);
+
+#endif // PGMONETA_EXT_TEST_H

--- a/test/lib/pgmoneta_test.c
+++ b/test/lib/pgmoneta_test.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "pgmoneta_test.h"
+
+#define BUFFER_SIZE 8192
+
+#define PGMONETA_LOG_FILE_PATH     "/tmp/pgmoneta.log"
+#define PGMONETA_BACKUP_LOG     "INFO  backup.c:140 Backup: primary/"
+#define PGMONETA_RESTORE_LOG     "INFO  restore.c:106 Restore: primary/"
+
+// test backup
+START_TEST(test_pgmoneta_backup)
+{
+   FILE* log_file;
+   char log_entry[BUFFER_SIZE];
+   int found = 0;
+
+   int result = system("su - pgmoneta -c '/pgmoneta/build/src/pgmoneta-cli -c /pgmoneta/pgmoneta.conf backup primary'");
+   ck_assert_int_eq(result, 0);
+
+   log_file = fopen(PGMONETA_LOG_FILE_PATH, "r");
+   ck_assert_msg(log_file != NULL, "Log file could not be opened");
+
+   while (fgets(log_entry, sizeof(log_entry), log_file) != NULL)
+   {
+      if (strstr(log_entry, PGMONETA_BACKUP_LOG) != NULL)
+      {
+         found = 1;
+         break;
+      }
+   }
+   fclose(log_file);
+
+   ck_assert_msg(found, "Expected log entry not found in the log file");
+}
+END_TEST
+// test restore
+START_TEST(test_pgmoneta_restore)
+{
+   FILE* log_file;
+   char log_entry[BUFFER_SIZE];
+   int found = 0;
+
+   int result = system("su - pgmoneta -c '/pgmoneta/build/src/pgmoneta-cli -c /pgmoneta/pgmoneta.conf restore primary newest current /pgmoneta/'");
+   ck_assert_int_eq(result, 0);
+
+   log_file = fopen(PGMONETA_LOG_FILE_PATH, "r");
+   ck_assert_msg(log_file != NULL, "Log file could not be opened");
+
+   while (fgets(log_entry, sizeof(log_entry), log_file) != NULL)
+   {
+      if (strstr(log_entry, PGMONETA_RESTORE_LOG) != NULL)
+      {
+         found = 1;
+         break;
+      }
+   }
+   fclose(log_file);
+
+   ck_assert_msg(found, "Expected log entry not found in the log file");
+}
+END_TEST
+
+Suite*
+pgmoneta_suite(void)
+{
+   Suite* s;
+   TCase* tc_core;
+
+   s = suite_create("pgmoneta");
+
+   tc_core = tcase_create("Core");
+
+   tcase_add_test(tc_core, test_pgmoneta_backup);
+   tcase_add_test(tc_core, test_pgmoneta_restore);
+   suite_add_tcase(s, tc_core);
+
+   return s;
+}

--- a/test/lib/pgmoneta_test.h
+++ b/test/lib/pgmoneta_test.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGMONETA_TEST_H
+#define PGMONETA_TEST_H
+
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Set up a suite of test cases for pgmoneta
+ * @return The result
+ */
+Suite*
+pgmoneta_suite(void);
+
+#endif // PGMONETA_TEST_H

--- a/test/lib/runner.c
+++ b/test/lib/runner.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "pgmoneta_test.h"
+#include "pgmoneta_ext_test.h"
+
+int
+main(void)
+{
+   int number_failed;
+   Suite* s1;
+   Suite* s2;
+   SRunner* sr;
+
+   s1 = pgmoneta_suite();
+   s2 = pgmoneta_ext_suite();
+
+   sr = srunner_create(s1);
+   srunner_add_suite(sr, s2);
+
+   // Run the tests in verbose mode
+   srunner_run_all(sr, CK_VERBOSE);
+   number_failed = srunner_ntests_failed(sr);
+   srunner_free(sr);
+
+   return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/testsuite.sh
+++ b/test/testsuite.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 The pgmoneta community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set -e
+
+check_podman_installed() {
+  if command -v podman &> /dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+run_podman(){
+  local dockerfile=${1:-'Dockerfile.rocky8'}
+  local version=${2:-13}
+
+  if ! podman build -f "$dockerfile" --build-arg PGVERSION="$version" -t postgres_pgmoneta_image .; then
+    echo "Podman build failed."
+    clean_podman
+    exit 1
+  fi
+
+  podman run -d --name postgres_pgmoneta_container postgres_pgmoneta_image
+
+  sleep 5
+
+  podman logs -f postgres_pgmoneta_container
+
+  clean_podman
+  
+}
+
+clean_podman(){
+  podman stop postgres_pgmoneta_container || true
+  podman rm postgres_pgmoneta_container || true
+  podman rmi postgres_pgmoneta_image || true
+  podman builder prune -f || true
+}
+
+check_docker_installed() {
+  if command -v docker &> /dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+run_docker(){
+  local dockerfile=${1:-'Dockerfile.rocky8'}
+  local version=${2:-13}
+
+  if ! systemctl restart docker; then
+    echo "Failed to restart Docker. Please ensure Docker is installed and running."
+    clean_docker
+    exit 1
+  fi
+
+  if ! docker build -f "$dockerfile" --build-arg PGVERSION="$version" -t postgres_pgmoneta_image .; then
+    echo "Docker build failed."
+    clean_docker
+    exit 1
+  fi
+
+  docker run --name postgres_pgmoneta_container postgres_pgmoneta_image & container_id=$!
+
+  wait $container_id
+
+  clean_docker
+}
+
+clean_docker(){
+  docker stop postgres_pgmoneta_container || true
+  docker rm postgres_pgmoneta_container || true
+  docker rmi postgres_pgmoneta_image || true
+  docker builder prune -f || true
+}
+
+run_tests() {
+  local dir=$1
+  local dockerfile=$2
+  local version=$3
+
+  valid_versions=("13" "14" "15" "16")
+  if [[ ! " ${valid_versions[@]} " =~ " ${version} " ]]; then
+    echo "Invalid version. Please provide a version of 13, 14, 15, or 16."
+    exit 1
+  fi
+
+  cd "$dir"
+
+  if check_podman_installed; then
+    echo "Podman is installed."
+    run_podman "$dockerfile" "$version"
+  else
+    echo "Podman is not installed."
+    if check_docker_installed; then
+      echo "Docker is installed."
+      run_docker "$dockerfile" "$version"
+    else
+      echo "Please install Podman or Docker to proceed."
+      exit 1
+    fi
+  fi
+}
+
+dir=${1:-'./'}
+dockerfile=${2:-'Dockerfile.rocky8'}
+version=${3:-13}
+
+run_tests "$dir" "$dockerfile" "$version"


### PR DESCRIPTION
This is the initial version of the test suite for `pgmoneta`. It is not yet complete and still has a long way to go.

Currently, I am facing a decision: should we separate the tests into several scripts, or use just one script for everything?

If we separate them, I envision the structure as follows:

- test
  - script
    - `installation.sh`: Installs all dependencies, `PostgreSQL`, `pgmoneta`, and `pgmoneta_ext`.
    - `test_pgmoneta.sh`: Tests `pgmoneta` backup and restore, and will include more tests once `extension.h|.c` is complete.
    - `test_pgmoneta_ext.sh`: Tests extension functions independently, such as those in our `pgmoneta_ext` project.
  - c code
    - `pgmoneta.c`: Tests `pgmoneta` by calling the extension.
    - `pgmoneta_ext.c`: Tests extension functions.

Is this a better approach, or should we combine everything into one script that automates the entire process from start to finish?