### PR TITLE
[#345] CLI: Compress / decompress

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -142,6 +142,7 @@ Command
 ``` sh
 pgmoneta-cli encrypt <file>
 ```
+
 ## decrypt
 
 Decrypt the file in place, remove encrypted file after successful decryption.
@@ -150,6 +151,26 @@ Command
 
 ``` sh
 pgmoneta-cli decrypt <file>
+```
+
+## compress
+
+Compress the file in place, remove uncompressed file after successful compression.
+
+Command
+
+``` sh
+pgmoneta-cli compress <file>
+```
+
+## decompress
+
+Decompress the file in place, remove compressed file after successful decompression.
+
+Command
+
+``` sh
+pgmoneta-cli decompress <file>
 ```
 
 ## info

--- a/doc/man/pgmoneta-cli.1.rst
+++ b/doc/man/pgmoneta-cli.1.rst
@@ -93,6 +93,12 @@ decrypt
 encrypt
   Encrypt the file in place, remove unencrypted file after successful encryption.
 
+decompress
+  Decompress the file in place, remove compressed file after successful decompression.
+
+compress
+  Compress the file in place, remove uncompressed file after successful compression.
+
 REPORTING BUGS
 ==============
 

--- a/doc/manual/user-10-cli.md
+++ b/doc/manual/user-10-cli.md
@@ -144,6 +144,7 @@ Command
 ``` sh
 pgmoneta-cli encrypt <file>
 ```
+
 ## decrypt
 
 Decrypt the file in place, remove encrypted file after successful decryption.
@@ -152,6 +153,26 @@ Command
 
 ``` sh
 pgmoneta-cli decrypt <file>
+```
+
+## compress
+
+Compress the file in place, remove uncompressed file after successful compression.
+
+Command
+
+``` sh
+pgmoneta-cli compress <file>
+```
+
+## decompress
+
+Decompress the file in place, remove compressed file after successful decompression.
+
+Command
+
+``` sh
+pgmoneta-cli decompress <file>
 ```
 
 ## info

--- a/src/include/bzip2_compression.h
+++ b/src/include/bzip2_compression.h
@@ -76,6 +76,15 @@ pgmoneta_bunzip2_data(char* directory, struct workers* workers);
 int
 pgmoneta_bzip2_file(char* from, char* to);
 
+/**
+ * BUNZip a file
+ * @param from The from file
+ * @param to The to file
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_bunzip2_file(char* from, char* to);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -55,7 +55,9 @@ extern "C" {
 #define MANAGEMENT_EXPUNGE        13
 #define MANAGEMENT_DECRYPT        14
 #define MANAGEMENT_ENCRYPT        15
-#define MANAGEMENT_INFO           16
+#define MANAGEMENT_DECOMPRESS     16
+#define MANAGEMENT_COMPRESS       17
+#define MANAGEMENT_INFO           18
 
 /**
  * Available command output formats
@@ -336,6 +338,26 @@ pgmoneta_management_decrypt(SSL* ssl, int socket, char* path);
  */
 int
 pgmoneta_management_encrypt(SSL* ssl, int socket, char* path);
+
+/**
+ * Management operation: Decompress a file on server
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param path The file path
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_decompress(SSL* ssl, int socket, char* path);
+
+/**
+ * Management operation: Compress a file on server
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param path The file path
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_compress(SSL* ssl, int socket, char* path);
 
 /**
  * Management operation: Information about a back

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -152,6 +152,8 @@ pgmoneta_management_read_payload(int socket, signed char id, char** payload_s1, 
       case MANAGEMENT_LIST_BACKUP:
       case MANAGEMENT_DECRYPT:
       case MANAGEMENT_ENCRYPT:
+      case MANAGEMENT_DECOMPRESS:
+      case MANAGEMENT_COMPRESS:
          read_string("pgmoneta_management_read_payload", NULL, socket, payload_s1);
          break;
       case MANAGEMENT_RESTORE:
@@ -1312,6 +1314,50 @@ pgmoneta_management_encrypt(SSL* ssl, int socket, char* path)
    }
 
    if (write_string("pgmoneta_management_encrypt", ssl, socket, path))
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+int
+pgmoneta_management_decompress(SSL* ssl, int socket, char* path)
+{
+   if (write_header(ssl, socket, MANAGEMENT_DECOMPRESS))
+   {
+      pgmoneta_log_warn("pgmoneta_management_decompress: write: %d", socket);
+      errno = 0;
+      goto error;
+   }
+
+   if (write_string("pgmoneta_management_decompress", ssl, socket, path))
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+int
+pgmoneta_management_compress(SSL* ssl, int socket, char* path)
+{
+   if (write_header(ssl, socket, MANAGEMENT_COMPRESS))
+   {
+      pgmoneta_log_warn("pgmoneta_management_compress: write: %d", socket);
+      errno = 0;
+      goto error;
+   }
+
+   if (write_string("pgmoneta_management_compress", ssl, socket, path))
    {
       goto error;
    }


### PR DESCRIPTION
Add a new CLI function to perform `compress` and `decompress` using the configured compression method.

- Conduct tests to understand the encryption and decryption process.
- Simulate encryption and decryption to write the source code for compressing and decompressing.
- Perform tests to ensure the process works successfully.
- All compression methods work except `bzip2`. There is an error in the source code, so I added a new function to make it work for me without changing the source code.

If there are any problems, please let me know. Thanks!