### PR TITLE
[#350] Universal value types

### DIFF
--- a/src/include/csv.h
+++ b/src/include/csv.h
@@ -65,7 +65,7 @@ pgmoneta_csv_reader_init(char* path, struct csv_reader** reader);
 
 /**
  * Get the next row in csv file.
- * You need to do free(cols) as the structure is allocated by the function 
+ * You need to do free(cols) as the structure is allocated by the function
  * @param reader The reader
  * @param num_col [out] The number of columns in the row
  * @param cols [out] The columns in the row

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -121,7 +121,9 @@ extern "C" {
 
 #define VALID_SLOT            0
 #define SLOT_NOT_FOUND        1
-#define INCORRECT_SLOT_TYPE       2
+#define INCORRECT_SLOT_TYPE   2
+
+#define INDENT_PER_LEVEL      2
 
 #define likely(x)    __builtin_expect (!!(x), 1)
 #define unlikely(x)  __builtin_expect (!!(x), 0)

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1133,6 +1133,16 @@ pgmoneta_token_bucket_once(struct token_bucket* tb, unsigned long tokens);
 int
 pgmoneta_atoi(const char* input);
 
+/**
+ * Indent a string
+ * @param str The string
+ * @param tag [Optional] The tag, which will be applied after indentation if not NULL
+ * @param indent The indent
+ * @return The indented string
+ */
+char*
+pgmoneta_indent(char* str, char* tag, int indent);
+
 #ifdef DEBUG
 
 /**

--- a/src/include/value.h
+++ b/src/include/value.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_VALUE_H
+#define PGMONETA_VALUE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+typedef void (*data_destroy_cb)(uintptr_t data);
+typedef char* (*data_to_string_cb)(uintptr_t data, char* tag, int indent);
+
+enum value_type {
+   ValueInt8,
+   ValueUInt8,
+   ValueInt16,
+   ValueUInt16,
+   ValueInt32,
+   ValueUInt32,
+   ValueInt64,
+   ValueUInt64,
+   ValueBool,
+   ValueString,
+   ValueFloat,
+   ValueDouble,
+   ValueJSON,
+   ValueDeque,
+   ValueART,
+   ValueRef,
+   ValueVerifyEntry,
+};
+
+/**
+ * @struct value
+ * Defines a universal value
+ */
+struct value
+{
+   enum value_type type;          /**< The type of value data */
+   uintptr_t data;                /**< The data, could be passed by value or by reference */
+   data_destroy_cb destroy_data;  /**< The callback to destroy data */
+   data_to_string_cb to_string;   /**< The callback to convert data to string */
+};
+
+/**
+ * Create a value based on the data and value type
+ * @param type The value type, use ValueRef if you are only storing pointers without the need to manage memory
+ * @param data The value data, type cast it to uintptr_t before passing into function
+ * @param value [out] The value
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_value_create(enum value_type type, uintptr_t data, struct value** value);
+
+/**
+ * Destroy a value along with the data within
+ * @param value The value
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_value_destroy(struct value* value);
+
+/**
+ * Get the raw data from the value, which can be casted back to its original type
+ * @param value The value
+ * @return The value data within
+ */
+uintptr_t
+pgmoneta_value_data(struct value* value);
+
+/**
+ * Convert a value to string
+ * @param value The value
+ * @param tag The optional tag
+ * @param indent The indent
+ * @return The string
+ */
+char*
+pgmoneta_value_to_string(struct value* value, char* tag, int indent);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/verify.h
+++ b/src/include/verify.h
@@ -33,6 +33,8 @@
 extern "C" {
 #endif
 
+#include <value.h>
+
 #include <ev.h>
 #include <stdlib.h>
 
@@ -62,6 +64,16 @@ struct verify_entry
  */
 void
 pgmoneta_verify(SSL* ssl, int client_fd, int server, char* backup_id, char* directory, char* files, char** argv);
+
+/**
+ * Convert a verify entry to string
+ * @param entry The entry
+ * @param tag The optional tag
+ * @param indent The indent
+ * @return The string in json format
+ */
+char*
+pgmoneta_verify_entry_to_string(struct verify_entry* entry, char* tag, int indent);
 
 #ifdef __cplusplus
 }

--- a/src/libpgmoneta/archive.c
+++ b/src/libpgmoneta/archive.c
@@ -134,22 +134,22 @@ pgmoneta_archive(SSL* ssl, int client_fd, int server, char* backup_id, char* pos
    {
       result = 0;
 
-      if (pgmoneta_deque_put(nodes, "directory", real_directory, strlen(real_directory) + 1))
+      if (pgmoneta_deque_add(nodes, "directory", (uintptr_t)real_directory, ValueString))
       {
          goto error;
       }
 
-      if (pgmoneta_deque_put(nodes, "id", id, strlen(id) + 1))
+      if (pgmoneta_deque_add(nodes, "id", (uintptr_t)id, ValueString))
       {
          goto error;
       }
 
-      if (pgmoneta_deque_put(nodes, "output", output, strlen(output) + 1))
+      if (pgmoneta_deque_add(nodes, "output", (uintptr_t)output, ValueString))
       {
          goto error;
       }
 
-      if (pgmoneta_deque_put(nodes, "destination", directory, strlen(directory) + 1))
+      if (pgmoneta_deque_add(nodes, "destination", (uintptr_t)directory, ValueString))
       {
          goto error;
       }

--- a/src/libpgmoneta/info.c
+++ b/src/libpgmoneta/info.c
@@ -65,7 +65,7 @@ pgmoneta_create_info(char* directory, char* label, int status)
    fputs(&buffer[0], sfile);
 
    memset(&buffer[0], 0, sizeof(buffer));
-   snprintf(&buffer[0], sizeof(buffer), "%s=%s\n",INFO_PGMONETA_VERSION,  VERSION);
+   snprintf(&buffer[0], sizeof(buffer), "%s=%s\n", INFO_PGMONETA_VERSION, VERSION);
    fputs(&buffer[0], sfile);
 
    memset(&buffer[0], 0, sizeof(buffer));
@@ -277,7 +277,7 @@ pgmoneta_update_info_annotate(SSL* ssl, int socket, char* server, char* backup, 
       pgmoneta_log_error("Annotate: No server defined by %s", server);
       goto error;
    }
-   
+
    d = pgmoneta_get_server_backup(srv);
 
    if (pgmoneta_get_backups(d, &number_of_backups, &backups))
@@ -309,7 +309,7 @@ pgmoneta_update_info_annotate(SSL* ssl, int socket, char* server, char* backup, 
       pgmoneta_log_error("Annotate: No backup for %s/%s", config->servers[srv].name, backup);
       goto error;
    }
-   
+
    if (pgmoneta_get_info_string(bck, INFO_COMMENTS, &old_comments))
    {
       goto error;
@@ -496,7 +496,7 @@ pgmoneta_update_info_annotate(SSL* ssl, int socket, char* server, char* backup, 
    if (!strcmp(new_comments, ",") || pgmoneta_starts_with(new_comments, ","))
    {
       new_comments = pgmoneta_remove_first(new_comments);
-      
+
       if (new_comments == NULL)
       {
          fail = true;
@@ -506,7 +506,7 @@ pgmoneta_update_info_annotate(SSL* ssl, int socket, char* server, char* backup, 
    if (pgmoneta_ends_with(new_comments, ","))
    {
       new_comments = pgmoneta_remove_last(new_comments);
-      
+
       if (new_comments == NULL)
       {
          fail = true;
@@ -533,7 +533,7 @@ pgmoneta_update_info_annotate(SSL* ssl, int socket, char* server, char* backup, 
    dir = pgmoneta_append(dir, "/");
 
    pgmoneta_update_info_string(dir, INFO_COMMENTS, new_comments != NULL && strlen(new_comments) > 0 ? new_comments : "");
-   
+
    pgmoneta_management_write_annotate(ssl, socket, server, bck->label, new_comments != NULL && strlen(new_comments) > 0 ? new_comments : "");
 
    for (int i = 0; i < number_of_backups; i++)
@@ -552,7 +552,7 @@ pgmoneta_update_info_annotate(SSL* ssl, int socket, char* server, char* backup, 
    free(command);
    free(key);
    free(comment);
-   
+
    return 0;
 
 error:
@@ -575,7 +575,7 @@ error:
    free(command);
    free(key);
    free(comment);
-   
+
    return 1;
 }
 

--- a/src/libpgmoneta/link.c
+++ b/src/libpgmoneta/link.c
@@ -88,8 +88,8 @@ pgmoneta_link_manifest(char* base_from, char* base_to, char* from, struct art* c
             from_file = pgmoneta_remove_prefix(from_entry, base_from);
             from_file_trimmed = trim_suffix(from_file);
             // file in newer dir is not added nor changed
-            if (pgmoneta_art_search(added, (unsigned char*)from_file_trimmed, strlen(from_file_trimmed) + 1) == NULL &&
-                pgmoneta_art_search(changed, (unsigned char*)from_file_trimmed, strlen(from_file_trimmed) + 1) == NULL)
+            if (!pgmoneta_art_contains_key(added, (unsigned char*)from_file_trimmed, strlen(from_file_trimmed) + 1) &&
+                !pgmoneta_art_contains_key(changed, (unsigned char*)from_file_trimmed, strlen(from_file_trimmed) + 1))
             {
                to_entry = pgmoneta_append(to_entry, base_to);
                if (!pgmoneta_ends_with(to_entry, "/"))

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -36,6 +36,7 @@
 #include <restore.h>
 #include <string.h>
 #include <utils.h>
+#include <value.h>
 #include <workflow.h>
 
 /* system */
@@ -135,12 +136,12 @@ pgmoneta_restore_backup(int server, char* backup_id, char* position, char* direc
 
    pgmoneta_deque_create(false, &nodes);
 
-   if (pgmoneta_deque_put(nodes, "position", position, position != NULL ? strlen(position) + 1 : 0))
+   if (pgmoneta_deque_add(nodes, "position", (uintptr_t)position, ValueString))
    {
       goto error;
    }
 
-   if (pgmoneta_deque_put(nodes, "directory", directory, strlen(directory) + 1))
+   if (pgmoneta_deque_add(nodes, "directory", (uintptr_t)directory, ValueString))
    {
       goto error;
    }

--- a/src/libpgmoneta/se_ssh.c
+++ b/src/libpgmoneta/se_ssh.c
@@ -323,7 +323,7 @@ ssh_storage_backup_execute(int server, char* identifier,
       }
    }
 
-   if (pgmoneta_art_init(&tree_map, NULL))
+   if (pgmoneta_art_init(&tree_map))
    {
       goto error;
    }
@@ -636,7 +636,7 @@ sftp_copy_file(char* local_root, char* remote_root, char* relative_path)
       latest_backup_path = pgmoneta_append(latest_backup_path, latest_remote_root);
       latest_backup_path = pgmoneta_append(latest_backup_path, relative_path);
 
-      if ((latest_sha256 = pgmoneta_art_search(tree_map, (unsigned char*)relative_path, strlen(relative_path) + 1)) != NULL)
+      if ((latest_sha256 = (char*)pgmoneta_art_search(tree_map, (unsigned char*)relative_path, strlen(relative_path) + 1)) != NULL)
       {
          if (!strcmp(latest_sha256, sha256))
          {
@@ -792,7 +792,7 @@ read_latest_backup_sha256(char* path)
       memset(hash, 0, strlen(ptr));
       memcpy(hash, ptr, strlen(ptr) - 1);
 
-      pgmoneta_art_insert(tree_map, (unsigned char*)file_path, strlen(file_path) + 1, hash);
+      pgmoneta_art_insert(tree_map, (unsigned char*)file_path, strlen(file_path) + 1, (uintptr_t)hash, ValueString);
       free(file_path);
    }
 

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -2886,9 +2886,9 @@ char*
 pgmoneta_remove_first(char* str)
 {
    char* new_str = NULL;
-   
+
    new_str = (char*)malloc(strlen(str));
-   
+
    if (new_str == NULL)
    {
       goto error;
@@ -2910,9 +2910,9 @@ char*
 pgmoneta_remove_last(char* str)
 {
    char* new_str = NULL;
-   
+
    new_str = (char*)malloc(strlen(str));
-   
+
    if (new_str == NULL)
    {
       goto error;
@@ -3897,6 +3897,22 @@ pgmoneta_atoi(const char* input)
    }
 
    return atoi(input);
+}
+
+char*
+pgmoneta_indent(char* str, char* tag, int indent)
+{
+   for (int i = 0; i < indent; i++)
+   {
+      str = pgmoneta_append(str, " ");
+   }
+   if (tag != NULL)
+   {
+      str = pgmoneta_append(str, "\"");
+      str = pgmoneta_append(str, tag);
+      str = pgmoneta_append(str, "\": ");
+   }
+   return str;
 }
 
 #ifdef DEBUG

--- a/src/libpgmoneta/value.c
+++ b/src/libpgmoneta/value.c
@@ -1,0 +1,414 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/* pgmoneta */
+#include <art.h>
+#include <deque.h>
+#include <json.h>
+#include <utils.h>
+#include <value.h>
+#include <verify.h>
+
+/* System */
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void noop_destroy_cb(uintptr_t data);
+static void free_destroy_cb(uintptr_t data);
+static void art_destroy_cb(uintptr_t data);
+static void deque_destroy_cb(uintptr_t data);
+static void json_destroy_cb(uintptr_t data);
+static char* noop_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* int8_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* uint8_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* int16_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* uint16_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* int32_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* uint32_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* int64_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* uint64_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* float_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* double_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* string_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* bool_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* deque_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* art_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* json_to_string_cb(uintptr_t data, char* tag, int indent);
+static char* verify_entry_to_string_cb(uintptr_t data, char* tag, int indent);
+
+int
+pgmoneta_value_create(enum value_type type, uintptr_t data, struct value** value)
+{
+   struct value* val = NULL;
+   val = (struct value*) malloc(sizeof(struct value));
+   if (val == NULL)
+   {
+      goto error;
+   }
+   val->data = 0;
+   val->type = type;
+   switch (type)
+   {
+      case ValueInt8:
+         val->to_string = int8_to_string_cb;
+         break;
+      case ValueUInt8:
+         val->to_string = uint8_to_string_cb;
+         break;
+      case ValueInt16:
+         val->to_string = int16_to_string_cb;
+         break;
+      case ValueUInt16:
+         val->to_string = uint16_to_string_cb;
+         break;
+      case ValueInt32:
+         val->to_string = int32_to_string_cb;
+         break;
+      case ValueUInt32:
+         val->to_string = uint32_to_string_cb;
+         break;
+      case ValueInt64:
+         val->to_string = int64_to_string_cb;
+         break;
+      case ValueUInt64:
+         val->to_string = uint64_to_string_cb;
+         break;
+      case ValueFloat:
+         val->to_string = float_to_string_cb;
+         break;
+      case ValueDouble:
+         val->to_string = double_to_string_cb;
+         break;
+      case ValueBool:
+         val->to_string = bool_to_string_cb;
+         break;
+      case ValueString:
+         val->to_string = string_to_string_cb;
+         break;
+      case ValueJSON:
+         val->to_string = json_to_string_cb;
+         break;
+      case ValueDeque:
+         val->to_string = deque_to_string_cb;
+         break;
+      case ValueART:
+         val->to_string = art_to_string_cb;
+         break;
+      case ValueVerifyEntry:
+         val->to_string = verify_entry_to_string_cb;
+         break;
+      default:
+         val->to_string = noop_to_string_cb;
+         break;
+   }
+   switch (type)
+   {
+      case ValueString:
+      {
+         char* orig = NULL;
+         char* str = NULL;
+
+         orig = (char*) data;
+         if (orig != NULL)
+         {
+            str = pgmoneta_append(str, orig);
+         }
+
+         val->data = (uintptr_t) str;
+         val->destroy_data = free_destroy_cb;
+         break;
+      }
+      case ValueVerifyEntry:
+         val->data = data;
+         val->destroy_data = free_destroy_cb;
+         break;
+      case ValueJSON:
+         val->data = data;
+         val->destroy_data = json_destroy_cb;
+         break;
+      case ValueDeque:
+         val->data = data;
+         val->destroy_data = deque_destroy_cb;
+         break;
+      case ValueART:
+         val->data = data;
+         val->destroy_data = art_destroy_cb;
+         break;
+      default:
+         val->data = data;
+         val->destroy_data = noop_destroy_cb;
+         break;
+   }
+   *value = val;
+   return 0;
+
+error:
+   return 1;
+}
+
+int
+pgmoneta_value_destroy(struct value* value)
+{
+   if (value == NULL)
+   {
+      return 0;
+   }
+   value->destroy_data(value->data);
+   free(value);
+   return 0;
+}
+
+uintptr_t
+pgmoneta_value_data(struct value* value)
+{
+   if (value == NULL)
+   {
+      return 0;
+   }
+   return value->data;
+}
+
+char*
+pgmoneta_value_to_string(struct value* value, char* tag, int indent)
+{
+   return value->to_string(value->data, tag, indent);
+}
+
+static void
+noop_destroy_cb(uintptr_t data)
+{
+   (void) data;
+}
+
+static void
+free_destroy_cb(uintptr_t data)
+{
+   free((void*) data);
+}
+
+static void
+art_destroy_cb(uintptr_t data)
+{
+   pgmoneta_art_destroy((struct art*) data);
+}
+
+static void
+deque_destroy_cb(uintptr_t data)
+{
+   pgmoneta_deque_destroy((struct deque*) data);
+}
+
+static void
+json_destroy_cb(uintptr_t data)
+{
+   pgmoneta_json_free((struct json*) data);
+}
+
+static char*
+noop_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   (void) data;
+   (void) tag;
+   (void) indent;
+   return NULL;
+}
+
+static char*
+int8_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRId8, (int8_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+uint8_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRIu8, (uint8_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+int16_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRId16, (int16_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+uint16_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRIu16, (uint16_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+int32_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRId32, (int32_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+uint32_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRIu32, (uint32_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+int64_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRId64, (int64_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+uint64_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%" PRIu64, (uint64_t)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+float_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%f", (float)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+double_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   snprintf(buf, MISC_LENGTH, "%f", (double)data);
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+string_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   char* str = (char*) data;
+   char buf[MISC_LENGTH];
+   memset(buf, 0, MISC_LENGTH);
+   if (str == NULL)
+   {
+      snprintf(buf, MISC_LENGTH, "(null)");
+   }
+   else
+   {
+      snprintf(buf, MISC_LENGTH, "\"%s\"", str);
+   }
+   ret = pgmoneta_append(ret, buf);
+   return ret;
+}
+
+static char*
+bool_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   char* ret = NULL;
+   ret = pgmoneta_indent(ret, tag, indent);
+   bool val = (bool) data;
+   ret = pgmoneta_append(ret, val?"true":"false");
+   return ret;
+}
+
+static char*
+deque_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   return pgmoneta_deque_to_string((struct deque*)data, tag, indent);
+}
+
+static char*
+art_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   return pgmoneta_art_to_string((struct art*) data, tag, indent);
+}
+
+static char*
+json_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   return pgmoneta_json_to_string((struct json*)data, tag, indent);
+}
+
+static char*
+verify_entry_to_string_cb(uintptr_t data, char* tag, int indent)
+{
+   return pgmoneta_verify_entry_to_string((struct verify_entry*)data, tag, indent);
+}

--- a/src/libpgmoneta/wf_archive.c
+++ b/src/libpgmoneta/wf_archive.c
@@ -98,7 +98,7 @@ archive_setup(int server, char* identifier, struct deque* nodes)
    tarfile = pgmoneta_append(tarfile, id);
    tarfile = pgmoneta_append(tarfile, ".tar");
 
-   if (pgmoneta_deque_put(nodes, "tarfile", tarfile, strlen(tarfile) + 1))
+   if (pgmoneta_deque_add(nodes, "tarfile", (uintptr_t)tarfile, ValueString))
    {
       goto error;
    }
@@ -129,7 +129,7 @@ archive_execute(int server, char* identifier, struct deque* nodes)
    pgmoneta_log_debug("Archive (execute): %s/%s", config->servers[server].name, identifier);
    pgmoneta_deque_list(nodes);
 
-   output = (char*)pgmoneta_deque_get(nodes, "output");
+   output = (char*)(pgmoneta_deque_get(nodes, "output"));
 
    if (output == NULL)
    {

--- a/src/libpgmoneta/wf_backup.c
+++ b/src/libpgmoneta/wf_backup.c
@@ -333,12 +333,12 @@ basebackup_execute(int server, char* identifier, struct deque* nodes)
    pgmoneta_read_wal(d, &wal);
    pgmoneta_read_checkpoint_info(d, &chkptpos);
 
-   if (pgmoneta_deque_put(nodes, "root", root, strlen(root) + 1))
+   if (pgmoneta_deque_add(nodes, "root", (uintptr_t)root, ValueString))
    {
       goto error;
    }
 
-   if (pgmoneta_deque_put(nodes, "to", d, strlen(d) + 1))
+   if (pgmoneta_deque_add(nodes, "to", (uintptr_t)d, ValueString))
    {
       goto error;
    }

--- a/src/libpgmoneta/wf_manifest.c
+++ b/src/libpgmoneta/wf_manifest.c
@@ -126,9 +126,9 @@ manifest_execute_build(int server, char* identifier, struct deque* nodes)
    while (pgmoneta_json_next_array_item(reader, &entry))
    {
       memset(file_path, 0, MAX_PATH);
-      snprintf(file_path, MAX_PATH, "%s", pgmoneta_json_get_string(entry, "Path"));
+      snprintf(file_path, MAX_PATH, "%s", (char*)pgmoneta_json_get(entry, "Path"));
       info[MANIFEST_PATH_INDEX] = file_path;
-      info[MANIFEST_CHECKSUM_INDEX] = pgmoneta_json_get_string(entry, "Checksum");
+      info[MANIFEST_CHECKSUM_INDEX] = (char*)pgmoneta_json_get(entry, "Checksum");
       pgmoneta_csv_write(writer, MANIFEST_COLUMN_COUNT, info);
       pgmoneta_json_free(entry);
       entry = NULL;

--- a/src/libpgmoneta/wf_restore.c
+++ b/src/libpgmoneta/wf_restore.c
@@ -249,7 +249,7 @@ restore_execute(int server, char* identifier, struct deque* nodes)
       goto error;
    }
 
-   if (pgmoneta_deque_put(nodes, "root", directory, strlen(directory) + 1))
+   if (pgmoneta_deque_add(nodes, "root", (uintptr_t)directory, ValueString))
    {
       goto error;
    }
@@ -342,18 +342,18 @@ restore_execute(int server, char* identifier, struct deque* nodes)
 
          pgmoneta_get_backup(root, id, &backup);
 
-         if (pgmoneta_deque_put(nodes, "primary", primary ? "true" : "false", (primary ? strlen("true") : strlen("false")) + 1))
+         if (pgmoneta_deque_add(nodes, "primary", primary, ValueBool))
          {
             goto error;
          }
 
          snprintf(&ver[0], sizeof(ver), "%d", backup->version);
-         if (pgmoneta_deque_put(nodes, "version", ver, strlen(ver) + 1))
+         if (pgmoneta_deque_add(nodes, "version", (uintptr_t)ver, ValueString))
          {
             goto error;
          }
 
-         if (pgmoneta_deque_put(nodes, "recovery info", "true", strlen("true") + 1))
+         if (pgmoneta_deque_add(nodes, "recovery info", true, ValueBool))
          {
             goto error;
          }
@@ -375,13 +375,13 @@ restore_execute(int server, char* identifier, struct deque* nodes)
       }
       else
       {
-         if (pgmoneta_deque_put(nodes, "recovery info", "false", strlen("false") + 1))
+         if (pgmoneta_deque_add(nodes, "recovery info", false, ValueBool))
          {
             goto error;
          }
       }
 
-      if (pgmoneta_deque_put(nodes, "to", to, strlen(to) + 1))
+      if (pgmoneta_deque_add(nodes, "to", (uintptr_t)to, ValueString))
       {
          goto error;
       }
@@ -398,12 +398,12 @@ restore_execute(int server, char* identifier, struct deque* nodes)
 
    ident = pgmoneta_append(ident, id);
 
-   if (pgmoneta_deque_put(nodes, "output", o, strlen(o) + 1))
+   if (pgmoneta_deque_add(nodes, "output", (uintptr_t)o, ValueString))
    {
       goto error;
    }
 
-   if (pgmoneta_deque_put(nodes, "identifier", ident, strlen(ident) + 1))
+   if (pgmoneta_deque_add(nodes, "identifier", (uintptr_t)ident, ValueString))
    {
       goto error;
    }
@@ -509,7 +509,7 @@ recovery_info_execute(int server, char* identifier, struct deque* nodes)
    pgmoneta_log_debug("Recovery (execute): %s/%s", config->servers[server].name, identifier);
    pgmoneta_deque_list(nodes);
 
-   is_recovery_info = !strcmp((char*)pgmoneta_deque_get(nodes, "recovery info"), "true");
+   is_recovery_info = (bool)pgmoneta_deque_get(nodes, "recovery info");
 
    if (!is_recovery_info)
    {
@@ -524,7 +524,7 @@ recovery_info_execute(int server, char* identifier, struct deque* nodes)
    }
 
    position = (char*)pgmoneta_deque_get(nodes, "position");
-   primary = !strcmp((char*)pgmoneta_deque_get(nodes, "primary"), "true");
+   primary = (bool)pgmoneta_deque_get(nodes, "primary");
 
    if (!primary)
    {

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -110,14 +110,14 @@ verify_execute(int server, char* identifier, struct deque* nodes)
       info_file = pgmoneta_append(info_file, "/");
    }
    info_file = pgmoneta_append(info_file, "backup.info");
-   
+
    manifest_file = pgmoneta_append(manifest_file, base);
    if (!pgmoneta_ends_with(manifest_file, "/"))
    {
       manifest_file = pgmoneta_append(manifest_file, "/");
    }
    manifest_file = pgmoneta_append(manifest_file, "backup.manifest");
-   
+
    pgmoneta_get_backup_file(info_file, &backup);
 
    if (pgmoneta_deque_create(true, &failed_deque))
@@ -151,10 +151,10 @@ verify_execute(int server, char* identifier, struct deque* nodes)
       ve = (struct verify_entry*)malloc(sizeof(struct verify_entry));
 
       memset(ve, 0, sizeof(struct verify_entry));
-      memcpy(ve->directory, (char*)pgmoneta_deque_get(nodes, "to"), strlen(pgmoneta_deque_get(nodes, "to")));
+      memcpy(ve->directory, (char*)pgmoneta_deque_get(nodes, "to"),
+             strlen((char*)pgmoneta_deque_get(nodes, "to")));
       memcpy(ve->filename, columns[0], strlen(columns[0]));
       memcpy(ve->original, columns[1], strlen(columns[1]));
-
       ve->hash_algoritm = backup->hash_algoritm;
 
       ve->failed = failed_deque;
@@ -182,8 +182,8 @@ verify_execute(int server, char* identifier, struct deque* nodes)
    pgmoneta_deque_list(failed_deque);
    pgmoneta_deque_list(all_deque);
 
-   pgmoneta_deque_add(nodes, "failed", failed_deque);
-   pgmoneta_deque_add(nodes, "all", all_deque);
+   pgmoneta_deque_add(nodes, "failed", (uintptr_t)failed_deque, ValueDeque);
+   pgmoneta_deque_add(nodes, "all", (uintptr_t)all_deque, ValueDeque);
 
    pgmoneta_csv_reader_destroy(csv);
 
@@ -333,17 +333,16 @@ do_verify(void* arg)
 
    if (failed)
    {
-      pgmoneta_deque_put(ve->failed, f, ve, sizeof(struct verify_entry));
+      pgmoneta_deque_add(ve->failed, f, (uintptr_t)ve, ValueVerifyEntry);
    }
    else
    {
       if (ve->all != NULL)
       {
-         pgmoneta_deque_put(ve->all, f, ve, sizeof(struct verify_entry));
+         pgmoneta_deque_add(ve->all, f, (uintptr_t)ve, ValueVerifyEntry);
       }
    }
 
-   free(ve);
    free(hash_cal);
    free(f);
 


### PR DESCRIPTION
Add a universal typed `value` struct that can be shared across `ART`, `deque` and `json`. It has two callbacks - `to_string` for printing and `destroy_data` for memory reclaim. With all types (almost) equipped with to_string() method, logging is more clearer than ever before. The system is also easy to extend to include other types.

Redesign `deque` and `ART` on basis of `value` struct, which are now able to hold ANY type of values without the memory leak nightmare.

Redesign `json` on basis of `deque` and `json`, now able to put and look up a kv pair in O(k) time where k is the length of the key, and append an array entry in O(1) time, and, you guessed it, no worries about memory leak :)

Add iterator for `json` and `deque`.