### PR TITLE
Parse WAL file into WAL records

### DIFF
--- a/doc/WAL.md
+++ b/doc/WAL.md
@@ -1,0 +1,4 @@
+
+# WAL Reader
+
+Please refer to [WAL developer guide](./manual/dev-06-wal.md) for all information about how to read WAL files and the WAL format.

--- a/doc/manual/dev-06-wal.md
+++ b/doc/manual/dev-06-wal.md
@@ -1,0 +1,987 @@
+
+\newpage
+# WAL Reader
+
+## Overview
+
+This document provides an overview of the `wal_reader` tool, with a focus on the `parse_wal_file` function, which serves as the main entry point for parsing Write-Ahead Log (WAL) files. Currently, the function only parses the given WAL file and prints the description of each record. In the future, it will be integrated with other parts of the code.
+
+## Function Overview
+
+### parse_wal_file
+
+This function is responsible for reading and parsing a PostgreSQL Write-Ahead Log (WAL) file.
+
+#### Parameters
+
+- **path**: The file path to the WAL file that needs to be parsed.
+- **server_info**: A pointer to a `server` structure containing information about the server.
+
+#### Description
+
+The `parse_wal_file` function opens the WAL file specified by the `path` parameter in binary mode and reads the WAL records. It processes these records, handling various cases such as records that cross page boundaries, while ensuring correct memory management throughout the process.
+
+### Usage Example
+
+```c
+parse_wal_file("/path/to/wal/file", &my_server);
+```
+
+
+### WAL File Structure
+The image illustrates the structure of a WAL (Write-Ahead Logging) file in PostgreSQL, focusing on how XLOG records are organized within WAL segments.
+
+Source: [https://www.interdb.jp/pg/pgsql09/03.html](https://www.interdb.jp/pg/pgsql09/03.html)
+
+![WAL File Structure](https://www.interdb.jp/pg/pgsql09/fig-9-07.png)
+
+A WAL segment, by default, is a 16 MB file, divided into pages of 8192 bytes (8 KB) each. The first page contains a header defined by the XLogLongPageHeaderData structure, while all subsequent pages have headers described by the XLogPageHeaderData structure. XLOG records are written sequentially in each page, starting at the beginning and moving downward.
+
+The figure highlights how the WAL ensures data consistency by sequentially writing XLOG records in pages, structured within larger 16 MB WAL segments.
+
+
+## Resource Managers
+
+In the context of the WAL reader, resource managers (rm) are responsible for handling different types of records found within a WAL file. Each record in the WAL file is associated with a specific resource manager, which determines how that record is processed.
+
+### Resource Manager Definitions
+
+Each resource manager is defined in the `rm_[name].h` header file and implemented in the corresponding `rm_[name].c` source file.
+
+In the `rmgr.h` header file, the resource managers are declared as an enum, with each resource manager having a unique identifier.
+
+### Resource Manager Functions
+
+Each resource manager implements the `rm_desc` function, which provides a description of the record type associated with that resource manager. In the future, they will be extended to implement the `rm_redo` function to apply the changes to another server.
+
+
+### Supporting Various WAL Structures in PostgreSQL Versions 13 to 17
+The WAL structure has evolved across PostgreSQL versions 13 to 17, requiring different handling for each version. To accommodate these differences, we have implemented a wrapper-based approach, such as the factory pattern, to handle varying WAL structures.
+
+Below are the commit hashes for the officially supported magic values in each PostgreSQL version:
+
+1. PostgreSQL 13 - 0xD106: [https://github.com/postgres/postgres/commit/c6b92041d38512a4176ed76ad06f713d2e6c01a8](https://github.com/postgres/postgres/commit/c6b92041d38512a4176ed76ad06f713d2e6c01a8)  
+2. PostgreSQL 14 - 0xD10D: [https://github.com/postgres/postgres/commit/08aa89b326261b669648df97d4f2a6edba22d26a](https://github.com/postgres/postgres/commit/08aa89b326261b669648df97d4f2a6edba22d26a)  
+3. PostgreSQL 15 - 0xD110: [https://github.com/postgres/postgres/commit/8b1dccd37c71ed2ff016294d8f9053a32b02b19e](https://github.com/postgres/postgres/commit/8b1dccd37c71ed2ff016294d8f9053a32b02b19e)  
+4. PostgreSQL 16 - 0xD113: [https://github.com/postgres/postgres/commit/6af1793954e8c5e753af83c3edb37ed3267dd179](https://github.com/postgres/postgres/commit/6af1793954e8c5e753af83c3edb37ed3267dd179)  
+5. PostgreSQL 17 - 0xD116: [https://github.com/postgres/postgres/commit/402b586d0a9caae9412d25fcf1b91dae45375833](https://github.com/postgres/postgres/commit/402b586d0a9caae9412d25fcf1b91dae45375833)
+
+
+`xl_end_of_recovery` is an example of how we handle different versions of structures with a wrapper struct and a factory pattern.
+
+```c
+struct xl_end_of_recovery_v16 {
+    timestamp_tz end_time;
+    timeline_id this_timeline_id;
+    timeline_id prev_timeline_id;
+};
+
+struct xl_end_of_recovery_v17 {
+    timestamp_tz end_time;
+    timeline_id this_timeline_id;
+    timeline_id prev_timeline_id;
+    int wal_level;
+};
+
+struct xl_end_of_recovery {
+    int pg_version;
+    union {
+        struct xl_end_of_recovery_v16 v16;
+        struct xl_end_of_recovery_v17 v17;
+    } data;
+    void (*parse)(struct xl_end_of_recovery* wrapper, const void* rec);
+    char* (*format)(struct xl_end_of_recovery* wrapper, char* buf);
+};
+
+xl_end_of_recovery* create_xl_end_of_recovery(int pg_version) {
+    xl_end_of_recovery* wrapper = malloc(sizeof(xl_end_of_recovery));
+    wrapper->pg_version = pg_version;
+    
+    if (pg_version >= 17) {
+        wrapper->parse = parse_v17;
+        wrapper->format = format_v17;
+    } else {
+        wrapper->parse = parse_v16;
+        wrapper->format = format_v16;
+    }
+    
+    return wrapper;
+}
+
+void parse_v16(xl_end_of_recovery* wrapper, const void* rec) {
+    memcpy(&wrapper->data.v16, rec, sizeof(struct xl_end_of_recovery_v16));
+}
+
+void parse_v17(xl_end_of_recovery* wrapper, const void* rec) {
+    memcpy(&wrapper->data.v17, rec, sizeof(struct xl_end_of_recovery_v17));
+}
+
+char* format_v16(xl_end_of_recovery* wrapper, char* buf) {
+    struct xl_end_of_recovery_v16* xlrec = &wrapper->data.v16;
+    return pgmoneta_format_and_append(buf, "tli %u; prev tli %u; time %s",
+                                      xlrec->this_timeline_id, xlrec->prev_timeline_id,
+                                      pgmoneta_wal_timestamptz_to_str(xlrec->end_time));
+}
+
+char* format_v17(xl_end_of_recovery* wrapper, char* buf) {
+    struct xl_end_of_recovery_v17* xlrec = &wrapper->data.v17;
+    return pgmoneta_format_and_append(buf, "tli %u; prev tli %u; time %s; wal_level %d",
+                                      xlrec->this_timeline_id, xlrec->prev_timeline_id,
+                                      pgmoneta_wal_timestamptz_to_str(xlrec->end_time),
+                                      xlrec->wal_level);
+}
+```
+
+
+
+## WAL Change List
+
+This section lists the changes in the WAL format between different versions of PostgreSQL.
+
+### xl_clog_truncate
+
+17
+
+```c
+struct xl_clog_truncate
+{
+   int64 pageno;              /**< The page number of the clog to truncate */
+   transaction_id oldestXact;  /**< The oldest transaction ID to retain */
+   oid oldestXactDb;        /**< The database ID of the oldest transaction */
+};
+```
+
+16
+
+```c
+struct xl_clog_truncate
+{
+   int64 pageno;              /**< The page number of the clog to truncate */
+   transaction_id oldestXact;  /**< The oldest transaction ID to retain */
+   oid oldestXactDb;        /**< The database ID of the oldest transaction */
+};
+```
+
+### xl_commit_ts_truncate
+
+17:
+
+```c
+typedef struct xl_commit_ts_truncate
+{
+	int64		pageno;
+	TransactionId oldestXid;
+} xl_commit_ts_truncate;
+```
+
+16:
+
+```c
+typedef struct xl_commit_ts_truncate
+{
+	int			pageno;
+	TransactionId oldestXid;
+} xl_commit_ts_truncate;
+```
+
+### xl_heap_prune
+
+17:
+
+```c
+typedef struct xl_heap_prune
+{
+	uint8		reason;
+	uint8		flags;
+
+	/*
+	 * If XLHP_HAS_CONFLICT_HORIZON is set, the conflict horizon XID follows,
+	 * unaligned
+	 */
+} xl_heap_prune;
+#define SizeOfHeapPrune (offsetof(xl_heap_prune, flags) + sizeof(uint8))
+
+```
+
+16:
+
+```c
+typedef struct xl_heap_prune
+{
+	TransactionId snapshotConflictHorizon;
+	uint16		nredirected;
+	uint16		ndead;
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+	/* OFFSET NUMBERS are in the block reference 0 */
+} xl_heap_prune;
+#define SizeOfHeapPrune (offsetof(xl_heap_prune, isCatalogRel) + sizeof(bool))
+
+```
+
+### xlhp_freeze_plan
+
+Removed `xl_heap_freeze_page`
+
+17:
+
+```c
+typedef struct xlhp_freeze_plan
+{
+	TransactionId xmax;
+	uint16		t_infomask2;
+	uint16		t_infomask;
+	uint8		frzflags;
+
+	/* Length of individual page offset numbers array for this plan */
+	uint16		ntuples;
+} xlhp_freeze_plan;
+```
+
+### spgxlogState
+(Doesn’t need to be changed)
+
+17:
+
+```c
+typedef struct spgxlogState
+{
+	TransactionId redirectXid;
+	bool		isBuild;
+} spgxlogState;
+```
+
+16:
+
+```c
+typedef struct spgxlogState
+{
+	TransactionId myXid;
+	bool		isBuild;
+} spgxlogState;
+```
+
+### xl_end_of_recovery
+
+```c
+typedef struct xl_end_of_recovery
+{
+	TimestampTz end_time;
+	TimeLineID	ThisTimeLineID; /* new TLI */
+	TimeLineID	PrevTimeLineID; /* previous TLI we forked off from */
+	int			wal_level;
+} xl_end_of_recovery;
+```
+
+16:
+
+```c
+typedef struct xl_end_of_recovery
+{
+	TimestampTz end_time;
+	TimeLineID	ThisTimeLineID; /* new TLI */
+	TimeLineID	PrevTimeLineID; /* previous TLI we forked off from */
+} xl_end_of_recovery;
+```
+
+---
+
+16 → 15
+
+### gingxlogSplit
+16: same for `gin_xlog_update_meta`
+
+```c
+typedef struct ginxlogSplit
+{
+	RelFileLocator locator;
+	BlockNumber rrlink;			/* right link, or root's blocknumber if root
+								 * split */
+	BlockNumber leftChildBlkno; /* valid on a non-leaf split */
+	BlockNumber rightChildBlkno;
+	uint16		flags;			/* see below */
+} ginxlogSplit;
+```
+
+15:
+
+```c
+typedef struct ginxlogSplit
+{
+	RelFileNode node;
+	BlockNumber rrlink;			/* right link, or root's blocknumber if root
+								 * split */
+	BlockNumber leftChildBlkno; /* valid on a non-leaf split */
+	BlockNumber rightChildBlkno;
+	uint16		flags;			/* see below */
+} ginxlogSplit;
+```
+
+### gistxlogDelete
+
+16:
+
+```c
+typedef struct gistxlogDelete
+{
+	TransactionId snapshotConflictHorizon;
+	uint16		ntodelete;		/* number of deleted offsets */
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+
+	/* TODELETE OFFSET NUMBERS */
+	OffsetNumber offsets[FLEXIBLE_ARRAY_MEMBER];
+} gistxlogDelete;
+#define SizeOfGistxlogDelete	offsetof(gistxlogDelete, offsets)
+```
+
+15:
+
+```c
+typedef struct gistxlogDelete
+{
+	TransactionId latestRemovedXid;
+	uint16		ntodelete;		/* number of deleted offsets */
+
+	/*
+	 * In payload of blk 0 : todelete OffsetNumbers
+	 */
+} gistxlogDelete;
+#define SizeOfGistxlogDelete	(offsetof(gistxlogDelete, ntodelete) + sizeof(uint16))
+```
+
+### gistxlogPageReuse
+
+16:
+
+```c
+typedef struct gistxlogPageReuse
+{
+	RelFileLocator locator;
+	BlockNumber block;
+	FullTransactionId snapshotConflictHorizon;
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+} gistxlogPageReuse;
+#define SizeOfGistxlogPageReuse	(offsetof(gistxlogPageReuse, isCatalogRel) + sizeof(bool))
+```
+
+15:
+
+```c
+typedef struct gistxlogPageReuse
+{
+	RelFileNode node;
+	BlockNumber block;
+	FullTransactionId latestRemovedFullXid;
+} gistxlogPageReuse;
+
+#define SizeOfGistxlogPageReuse	(offsetof(gistxlogPageReuse, latestRemovedFullXid) + sizeof(FullTransactionId))
+```
+
+### xl_hash_vacuum_one_page
+
+16:
+
+```c
+typedef struct xl_hash_vacuum_one_page
+{
+	TransactionId snapshotConflictHorizon;
+	uint16		ntuples;
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+
+	/* TARGET OFFSET NUMBERS */
+	OffsetNumber offsets[FLEXIBLE_ARRAY_MEMBER];
+} xl_hash_vacuum_one_page;
+#define SizeOfHashVacuumOnePage offsetof(xl_hash_vacuum_one_page, offsets)
+```
+
+15:
+
+```c
+typedef struct xl_hash_vacuum_one_page
+{
+	TransactionId latestRemovedXid;
+	int			ntuples;
+
+	/* TARGET OFFSET NUMBERS FOLLOW AT THE END */
+} xl_hash_vacuum_one_page;
+#define SizeOfHashVacuumOnePage \
+	(offsetof(xl_hash_vacuum_one_page, ntuples) + sizeof(int))
+```
+
+### xl_heap_prune
+
+16:
+
+```c
+typedef struct xl_heap_prune
+{
+	TransactionId snapshotConflictHorizon;
+	uint16		nredirected;
+	uint16		ndead;
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+	/* OFFSET NUMBERS are in the block reference 0 */
+} xl_heap_prune;
+#define SizeOfHeapPrune (offsetof(xl_heap_prune, isCatalogRel) + sizeof(bool))
+```
+
+15:
+
+```c
+typedef struct xl_heap_prune
+{
+	TransactionId latestRemovedXid;
+	uint16		nredirected;
+	uint16		ndead;
+	/* OFFSET NUMBERS are in the block reference 0 */
+} xl_heap_prune;
+#define SizeOfHeapPrune (offsetof(xl_heap_prune, ndead) + sizeof(uint16))
+```
+
+### xl_heap_freeze_plan
+
+16:
+
+```c
+typedef struct xl_heap_freeze_plan
+{
+	TransactionId xmax;
+	uint16		t_infomask2;
+	uint16		t_infomask;
+	uint8		frzflags;
+
+	/* Length of individual page offset numbers array for this plan */
+	uint16		ntuples;
+} xl_heap_freeze_plan;
+```
+
+15:
+
+```c
+typedef struct xl_heap_freeze_tuple
+{
+	TransactionId xmax;
+	OffsetNumber offset;
+	uint16		t_infomask2;
+	uint16		t_infomask;
+	uint8		frzflags;
+} xl_heap_freeze_tuple;
+```
+
+### xl_heap_freeze_page
+
+16:
+
+```c
+typedef struct xl_heap_freeze_page
+{
+	TransactionId snapshotConflictHorizon;
+	uint16		nplans;
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+
+	/*
+	 * In payload of blk 0 : FREEZE PLANS and OFFSET NUMBER ARRAY
+	 */
+} xl_heap_freeze_page;
+```
+
+15:
+
+```c
+typedef struct xl_heap_freeze_page
+{
+	TransactionId cutoff_xid;
+	uint16		ntuples;
+} xl_heap_freeze_page;
+```
+
+### xl_btree_reuse_page
+
+16:
+
+```c
+typedef struct xl_btree_reuse_page
+{
+	RelFileLocator locator;
+	BlockNumber block;
+	FullTransactionId snapshotConflictHorizon;
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+} xl_btree_reuse_page;
+```
+
+15:
+
+```c
+typedef struct xl_btree_reuse_page
+{
+	RelFileNode node;
+	BlockNumber block;
+	FullTransactionId latestRemovedFullXid;
+} xl_btree_reuse_page;
+```
+
+### xl_btree_delete
+
+16:
+
+```c
+typedef struct xl_btree_delete
+{
+	TransactionId snapshotConflictHorizon;
+	uint16		ndeleted;
+	uint16		nupdated;
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+
+	/*----
+	 * In payload of blk 0 :
+	 * - DELETED TARGET OFFSET NUMBERS
+	 * - UPDATED TARGET OFFSET NUMBERS
+	 * - UPDATED TUPLES METADATA (xl_btree_update) ARRAY
+	 *----
+	 */
+} xl_btree_delete;
+```
+
+15:
+
+```c
+typedef struct xl_btree_delete
+{
+	TransactionId latestRemovedXid;
+	uint16		ndeleted;
+	uint16		nupdated;
+
+	/* DELETED TARGET OFFSET NUMBERS FOLLOW */
+	/* UPDATED TARGET OFFSET NUMBERS FOLLOW */
+	/* UPDATED TUPLES METADATA (xl_btree_update) ARRAY FOLLOWS */
+} xl_btree_delete;
+```
+
+### spgxlogVacuumRedirect
+
+16:
+
+```c
+typedef struct spgxlogVacuumRedirect
+{
+	uint16		nToPlaceholder; /* number of redirects to make placeholders */
+	OffsetNumber firstPlaceholder;	/* first placeholder tuple to remove */
+	TransactionId snapshotConflictHorizon;	/* newest XID of removed redirects */
+	bool		isCatalogRel;	/* to handle recovery conflict during logical
+								 * decoding on standby */
+
+	/* offsets of redirect tuples to make placeholders follow */
+	OffsetNumber offsets[FLEXIBLE_ARRAY_MEMBER];
+} spgxlogVacuumRedirect;
+```
+
+15:
+
+```c
+typedef struct spgxlogVacuumRedirect
+{
+	uint16		nToPlaceholder; /* number of redirects to make placeholders */
+	OffsetNumber firstPlaceholder;	/* first placeholder tuple to remove */
+	TransactionId newestRedirectXid;	/* newest XID of removed redirects */
+
+	/* offsets of redirect tuples to make placeholders follow */
+	OffsetNumber offsets[FLEXIBLE_ARRAY_MEMBER];
+} spgxlogVacuumRedirect;
+```
+
+---
+
+15 → 14
+
+### xl_xact_prepare
+
+15:
+
+```c
+ctypedef struct xl_xact_prepare
+{
+	uint32		magic;			/* format identifier */
+	uint32		total_len;		/* actual file length */
+	TransactionId xid;			/* original transaction XID */
+	Oid			database;		/* OID of database it was in */
+	TimestampTz prepared_at;	/* time of preparation */
+	Oid			owner;			/* user running the transaction */
+	int32		nsubxacts;		/* number of following subxact XIDs */
+	int32		ncommitrels;	/* number of delete-on-commit rels */
+	int32		nabortrels;		/* number of delete-on-abort rels */
+	int32		ncommitstats;	/* number of stats to drop on commit */
+	int32		nabortstats;	/* number of stats to drop on abort */
+	int32		ninvalmsgs;		/* number of cache invalidation messages */
+	bool		initfileinval;	/* does relcache init file need invalidation? */
+	uint16		gidlen;			/* length of the GID - GID follows the header */
+	XLogRecPtr	origin_lsn;		/* lsn of this record at origin node */
+	TimestampTz origin_timestamp;	/* time of prepare at origin node */
+} xl_xact_prepare;
+```
+
+14:
+
+```c
+typedef struct xl_xact_prepare
+{
+	uint32		magic;			/* format identifier */
+	uint32		total_len;		/* actual file length */
+	TransactionId xid;			/* original transaction XID */
+	Oid			database;		/* OID of database it was in */
+	TimestampTz prepared_at;	/* time of preparation */
+	Oid			owner;			/* user running the transaction */
+	int32		nsubxacts;		/* number of following subxact XIDs */
+	int32		ncommitrels;	/* number of delete-on-commit rels */
+	int32		nabortrels;		/* number of delete-on-abort rels */
+	int32		ninvalmsgs;		/* number of cache invalidation messages */
+	bool		initfileinval;	/* does relcache init file need invalidation? */
+	uint16		gidlen;			/* length of the GID - GID follows the header */
+	XLogRecPtr	origin_lsn;		/* lsn of this record at origin node */
+	TimestampTz origin_timestamp;	/* time of prepare at origin node */
+} xl_xact_prepare;
+```
+
+### xl_xact_parsed_commit
+
+15:
+
+```c
+typedef struct xl_xact_parsed_commit
+{
+	TimestampTz xact_time;
+	uint32		xinfo;
+
+	Oid			dbId;			/* MyDatabaseId */
+	Oid			tsId;			/* MyDatabaseTableSpace */
+
+	int			nsubxacts;
+	TransactionId *subxacts;
+
+	int			nrels;
+	RelFileNode *xnodes;
+
+	int			nstats;
+	xl_xact_stats_item *stats;
+
+	int			nmsgs;
+	SharedInvalidationMessage *msgs;
+
+	TransactionId twophase_xid; /* only for 2PC */
+	char		twophase_gid[GIDSIZE];	/* only for 2PC */
+	int			nabortrels;		/* only for 2PC */
+	RelFileNode *abortnodes;	/* only for 2PC */
+	int			nabortstats;		/* only for 2PC */
+	xl_xact_stats_item *abortstats; /* only for 2PC */
+
+	XLogRecPtr	origin_lsn;
+	TimestampTz origin_timestamp;
+} xl_xact_parsed_commit;
+```
+
+14:
+
+```c
+typedef struct xl_xact_parsed_commit
+{
+	TimestampTz xact_time;
+	uint32		xinfo;
+
+	Oid			dbId;			/* MyDatabaseId */
+	Oid			tsId;			/* MyDatabaseTableSpace */
+
+	int			nsubxacts;
+	TransactionId *subxacts;
+
+	int			nrels;
+	RelFileNode *xnodes;
+
+	int			nmsgs;
+	SharedInvalidationMessage *msgs;
+
+	TransactionId twophase_xid; /* only for 2PC */
+	char		twophase_gid[GIDSIZE];	/* only for 2PC */
+	int			nabortrels;		/* only for 2PC */
+	RelFileNode *abortnodes;	/* only for 2PC */
+
+	XLogRecPtr	origin_lsn;
+	TimestampTz origin_timestamp;
+} xl_xact_parsed_commit;
+```
+
+### xl_xact_parsed_abort
+
+15:
+
+```c
+typedef struct xl_xact_parsed_abort
+{
+	TimestampTz xact_time;
+	uint32		xinfo;
+
+	Oid			dbId;			/* MyDatabaseId */
+	Oid			tsId;			/* MyDatabaseTableSpace */
+
+	int			nsubxacts;
+	TransactionId *subxacts;
+
+	int			nrels;
+	RelFileNode *xnodes;
+
+	int			nstats;
+	xl_xact_stats_item *stats;
+
+	TransactionId twophase_xid; /* only for 2PC */
+	char		twophase_gid[GIDSIZE];	/* only for 2PC */
+
+	XLogRecPtr	origin_lsn;
+	TimestampTz origin_timestamp;
+} xl_xact_parsed_abort;
+```
+
+14:
+
+```c
+typedef struct xl_xact_parsed_abort
+{
+	TimestampTz xact_time;
+	uint32		xinfo;
+
+	Oid			dbId;			/* MyDatabaseId */
+	Oid			tsId;			/* MyDatabaseTableSpace */
+
+	int			nsubxacts;
+	TransactionId *subxacts;
+
+	int			nrels;
+	RelFileNode *xnodes;
+
+	TransactionId twophase_xid; /* only for 2PC */
+	char		twophase_gid[GIDSIZE];	/* only for 2PC */
+
+	XLogRecPtr	origin_lsn;
+	TimestampTz origin_timestamp;
+} xl_xact_parsed_abort;
+```
+
+### xlogrecord.h flags
+
+15:
+
+```c
+#define BKPIMAGE_APPLY			0x02	/* page image should be restored
+										 * during replay */
+/* compression methods supported */
+#define BKPIMAGE_COMPRESS_PGLZ	0x04
+#define BKPIMAGE_COMPRESS_LZ4	0x08
+#define BKPIMAGE_COMPRESS_ZSTD	0x10
+
+#define	BKPIMAGE_COMPRESSED(info) \
+	((info & (BKPIMAGE_COMPRESS_PGLZ | BKPIMAGE_COMPRESS_LZ4 | \
+			  BKPIMAGE_COMPRESS_ZSTD)) != 0)
+			  
+```
+
+14:
+
+```c
+#define BKPIMAGE_IS_COMPRESSED		0x02	/* page image is compressed */
+#define BKPIMAGE_APPLY		0x04	/* page image should be restored during
+									 * replay */
+
+```
+
+---
+
+14 → 13
+
+### xl_heap_prune
+
+14:
+
+```c
+typedef struct xl_heap_prune
+{
+	TransactionId latestRemovedXid;
+	uint16		nredirected;
+	uint16		ndead;
+	/* OFFSET NUMBERS are in the block reference 0 */
+} xl_heap_prune;
+```
+
+13:
+
+```c
+typedef struct xl_heap_clean
+{
+	TransactionId latestRemovedXid;
+	uint16		nredirected;
+	uint16		ndead;
+	/* OFFSET NUMBERS are in the block reference 0 */
+} xl_heap_clean;
+```
+
+### xl_heap_vacuum
+
+14:
+
+```c
+typedef struct xl_heap_vacuum
+{
+	uint16		nunused;
+	/* OFFSET NUMBERS are in the block reference 0 */
+} xl_heap_vacuum;
+```
+
+13:
+
+```c
+typedef struct xl_heap_cleanup_info
+{
+	RelFileNode node;
+	TransactionId latestRemovedXid;
+} xl_heap_cleanup_info;
+```
+
+### xl_btree_metadata
+
+14:
+
+```c
+typedef struct xl_btree_metadata
+{
+	uint32		version;
+	BlockNumber root;
+	uint32		level;
+	BlockNumber fastroot;
+	uint32		fastlevel;
+	uint32		last_cleanup_num_delpages;
+	bool		allequalimage;
+} xl_btree_metadata;
+```
+
+13:
+
+```c
+typedef struct xl_btree_metadata
+{
+	uint32		version;
+	BlockNumber root;
+	uint32		level;
+	BlockNumber fastroot;
+	uint32		fastlevel;
+	TransactionId oldest_btpo_xact;
+	float8		last_cleanup_num_heap_tuples;
+	bool		allequalimage;
+} xl_btree_metadata;
+```
+
+### xl_btree_reuse_page
+
+14:
+
+```c
+typedef struct xl_btree_reuse_page
+{
+	RelFileNode node;
+	BlockNumber block;
+	FullTransactionId latestRemovedFullXid;
+} xl_btree_reuse_page;
+```
+
+13:
+
+```c
+typedef struct xl_btree_reuse_page
+{
+	RelFileNode node;
+	BlockNumber block;
+	TransactionId latestRemovedXid;
+} xl_btree_reuse_page;
+
+```
+
+### xl_btree_delete
+
+14:
+
+```c
+typedef struct xl_btree_delete
+{
+	TransactionId latestRemovedXid;
+	uint16		ndeleted;
+	uint16		nupdated;
+
+	/* DELETED TARGET OFFSET NUMBERS FOLLOW */
+	/* UPDATED TARGET OFFSET NUMBERS FOLLOW */
+	/* UPDATED TUPLES METADATA (xl_btree_update) ARRAY FOLLOWS */
+} xl_btree_delete;
+```
+
+13:
+
+```c
+typedef struct xl_btree_delete
+{
+	TransactionId latestRemovedXid;
+	uint32		ndeleted;
+
+	/* DELETED TARGET OFFSET NUMBERS FOLLOW */
+} xl_btree_delete;
+```
+
+### xl_btree_unlink_page
+
+14:
+
+```c
+typedef struct xl_btree_unlink_page
+{
+	BlockNumber leftsib;		/* target block's left sibling, if any */
+	BlockNumber rightsib;		/* target block's right sibling */
+	uint32		level;			/* target block's level */
+	FullTransactionId safexid;	/* target block's BTPageSetDeleted() XID */
+
+	/*
+	 * Information needed to recreate a half-dead leaf page with correct
+	 * topparent link.  The fields are only used when deletion operation's
+	 * target page is an internal page.  REDO routine creates half-dead page
+	 * from scratch to keep things simple (this is the same convenient
+	 * approach used for the target page itself).
+	 */
+	BlockNumber leafleftsib;
+	BlockNumber leafrightsib;
+	BlockNumber leaftopparent;	/* next child down in the subtree */
+
+	/* xl_btree_metadata FOLLOWS IF XLOG_BTREE_UNLINK_PAGE_META */
+} xl_btree_unlink_page;
+```
+
+13:
+
+```c
+typedef struct xl_btree_unlink_page
+{
+	BlockNumber leftsib;		/* target block's left sibling, if any */
+	BlockNumber rightsib;		/* target block's right sibling */
+
+	/*
+	 * Information needed to recreate the leaf page, when target is an
+	 * internal page.
+	 */
+	BlockNumber leafleftsib;
+	BlockNumber leafrightsib;
+	BlockNumber topparent;		/* next child down in the branch */
+
+	TransactionId btpo_xact;	/* value of btpo.xact for use in recovery */
+	/* xl_btree_metadata FOLLOWS IF XLOG_BTREE_UNLINK_PAGE_META */
+} xl_btree_unlink_page;
+```
+
+## Additional Information
+For more details on the internal workings and additional helper functions used in `parse_wal_file`, refer to the source code in `wal_reader.c`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 #
 # Add files for libpgmoneta
 #
-FILE(GLOB SOURCE_FILES "libpgmoneta/*.c")
-FILE(GLOB HEADER_FILES "include/*.h")
+FILE(GLOB_RECURSE SOURCE_FILES "libpgmoneta/*.c")
+FILE(GLOB_RECURSE HEADER_FILES "include/*.h")
 
 set(SOURCES ${SOURCE_FILES} ${HEADER_FILES})
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1154,6 +1154,16 @@ int
 pgmoneta_token_bucket_once(struct token_bucket* tb, unsigned long tokens);
 
 /**
+ * Format a string and append it to the original string
+ * @param buf original string
+ * @param format The string to be formatted and appended to buf
+ * @param ... The arguments to be formatted
+ * @return The resulting string
+ */
+char*
+pgmoneta_format_and_append(char* buf, const char* format, ...);
+
+/**
  * Wrapper for the atoi() function, which provides NULL input check
  * @param input The string input
  * @return 0 if input is NULL, otherwise what atoi() returns

--- a/src/include/wal/walfile/pg_control.h
+++ b/src/include/wal/walfile/pg_control.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_PG_CONTROL_H
+#define PGMONETA_PG_CONTROL_H
+
+#include <wal/walfile/transaction.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef int64_t pg_time_t;
+
+/* XLOG info values for XLOG rmgr */
+#define XLOG_CHECKPOINT_SHUTDOWN      0x00   /**< XLOG record type for a shutdown checkpoint */
+#define XLOG_CHECKPOINT_ONLINE        0x10   /**< XLOG record type for an online checkpoint */
+#define XLOG_NOOP                     0x20   /**< XLOG record type for a no-op */
+#define XLOG_NEXTOID                  0x30   /**< XLOG record type for the next OID */
+#define XLOG_SWITCH                   0x40   /**< XLOG record type for a switch */
+#define XLOG_BACKUP_END               0x50   /**< XLOG record type for the end of a backup */
+#define XLOG_PARAMETER_CHANGE         0x60   /**< XLOG record type for a parameter change */
+#define XLOG_RESTORE_POINT            0x70   /**< XLOG record type for a restore point */
+#define XLOG_FPW_CHANGE               0x80   /**< XLOG record type for a full-page writes change */
+#define XLOG_END_OF_RECOVERY          0x90   /**< XLOG record type for the end of recovery */
+#define XLOG_FPI_FOR_HINT             0xA0   /**< XLOG record type for a full-page image for hint bits */
+#define XLOG_FPI                      0xB0   /**< XLOG record type for a full-page image */
+#define XLOG_OVERWRITE_CONTRECORD     0xD0   /**< XLOG record type for overwriting a continuation record */
+
+/**
+ * @struct check_point_v16
+ * @brief Represents a checkpoint record for version 16.
+ *
+ * Fields:
+ * - redo: The next available RecPtr when the checkpoint was created (i.e., REDO start point).
+ * - this_timeline_id: Current timeline ID.
+ * - prev_timeline_id: Previous timeline ID, if the record begins a new timeline (equals this_timeline_id otherwise).
+ * - full_page_writes: Indicates the current full_page_writes setting.
+ * - next_xid: The next free transaction ID.
+ * - next_oid: The next free OID.
+ * - next_multi: The next free multi_xact_id.
+ * - next_multi_offset: The next free MultiXact offset.
+ * - oldest_xid: Cluster-wide minimum datfrozenxid.
+ * - oldest_xid_db: Database with minimum datfrozenxid.
+ * - oldest_multi: Cluster-wide minimum datminmxid.
+ * - oldest_multi_db: Database with minimum datminmxid.
+ * - time: The timestamp of the checkpoint.
+ * - oldest_commit_ts_xid: The oldest XID with a valid commit timestamp.
+ * - newest_commit_ts_xid: The newest XID with a valid commit timestamp.
+ * - oldest_active_xid: The oldest XID still running, calculated only for online checkpoints and when wal_level is replica.
+ */
+struct check_point_v16
+{
+    xlog_rec_ptr redo;                     /**< Next RecPtr available when the checkpoint was created (i.e., REDO start point). */
+    timeline_id this_timeline_id;          /**< Current timeline ID. */
+    timeline_id prev_timeline_id;          /**< Previous timeline ID, if the record begins a new timeline (equals this_timeline_id otherwise). */
+    bool full_page_writes;                 /**< Indicates the current full_page_writes setting. */
+    struct full_transaction_id next_xid;   /**< Next free transaction ID. */
+    oid next_oid;                          /**< Next free OID. */
+    multi_xact_id next_multi;              /**< Next free multi_xact_id. */
+    multi_xact_offset next_multi_offset;   /**< Next free MultiXact offset. */
+    transaction_id oldest_xid;             /**< Cluster-wide minimum datfrozenxid. */
+    oid oldest_xid_db;                     /**< Database with minimum datfrozenxid. */
+    multi_xact_id oldest_multi;            /**< Cluster-wide minimum datminmxid. */
+    oid oldest_multi_db;                   /**< Database with minimum datminmxid. */
+    pg_time_t time;                        /**< Timestamp of the checkpoint. */
+    transaction_id oldest_commit_ts_xid;   /**< Oldest XID with a valid commit timestamp. */
+    transaction_id newest_commit_ts_xid;   /**< Newest XID with a valid commit timestamp. */
+    transaction_id oldest_active_xid;      /**< Oldest XID still running, calculated only for online checkpoints and when wal_level is replica. */
+};
+
+/**
+ * @struct check_point_v17
+ * @brief Represents a checkpoint record for version 17.
+ *
+ * Fields:
+ * - redo: The next available RecPtr when the checkpoint was created (i.e., REDO start point).
+ * - this_timeline_id: Current timeline ID.
+ * - prev_timeline_id: Previous timeline ID, if the record begins a new timeline (equals this_timeline_id otherwise).
+ * - full_page_writes: Indicates the current full_page_writes setting.
+ * - wal_level: Current wal_level.
+ * - next_xid: The next free transaction ID.
+ * - next_oid: The next free OID.
+ * - next_multi: The next free multi_xact_id.
+ * - next_multi_offset: The next free MultiXact offset.
+ * - oldest_xid: Cluster-wide minimum datfrozenxid.
+ * - oldest_xid_db: Database with minimum datfrozenxid.
+ * - oldest_multi: Cluster-wide minimum datminmxid.
+ * - oldest_multi_db: Database with minimum datminmxid.
+ * - time: The timestamp of the checkpoint.
+ * - oldest_commit_ts_xid: The oldest XID with a valid commit timestamp.
+ * - newest_commit_ts_xid: The newest XID with a valid commit timestamp.
+ * - oldest_active_xid: The oldest XID still running, calculated only for online checkpoints and when wal_level is replica.
+ */
+struct check_point_v17
+{
+    xlog_rec_ptr redo;                     /**< Next RecPtr available when the checkpoint was created (i.e., REDO start point). */
+    timeline_id this_timeline_id;          /**< Current timeline ID. */
+    timeline_id prev_timeline_id;          /**< Previous timeline ID, if the record begins a new timeline (equals this_timeline_id otherwise). */
+    bool full_page_writes;                 /**< Indicates the current full_page_writes setting. */
+    int wal_level;                         /**< Current wal_level. */
+    struct full_transaction_id next_xid;   /**< Next free transaction ID. */
+    oid next_oid;                          /**< Next free OID. */
+    multi_xact_id next_multi;              /**< Next free multi_xact_id. */
+    multi_xact_offset next_multi_offset;   /**< Next free MultiXact offset. */
+    transaction_id oldest_xid;             /**< Cluster-wide minimum datfrozenxid. */
+    oid oldest_xid_db;                     /**< Database with minimum datfrozenxid. */
+    multi_xact_id oldest_multi;            /**< Cluster-wide minimum datminmxid. */
+    oid oldest_multi_db;                   /**< Database with minimum datminmxid. */
+    pg_time_t time;                        /**< Timestamp of the checkpoint. */
+    transaction_id oldest_commit_ts_xid;   /**< Oldest XID with a valid commit timestamp. */
+    transaction_id newest_commit_ts_xid;   /**< Newest XID with a valid commit timestamp. */
+    transaction_id oldest_active_xid;      /**< Oldest XID still running, calculated only for online checkpoints and when wal_level is replica. */
+};
+
+/**
+ * @struct check_point
+ * @brief Wrapper structure to handle different versions of checkpoint records.
+ *
+ * Fields:
+ * - data: A union containing version-specific checkpoint record data.
+ * - parse: Function pointer to parse the checkpoint record.
+ * - format: Function pointer to format the checkpoint record.
+ */
+struct check_point
+{
+    void (*parse)(struct check_point* wrapper, const void* rec);    /**< Parse function pointer */
+    char* (*format)(struct check_point* wrapper, char* buf);         /**< Format function pointer */
+    union {
+        struct check_point_v16 v16;     /**< Version 16 data */
+        struct check_point_v17 v17;     /**< Version 17 data */
+    } data;  /**< Union holding version-specific checkpoint data */
+};
+
+/**
+ * @brief Creates a new check_point structure.
+ *
+ * @return A pointer to the newly created check_point structure.
+ */
+struct check_point*
+create_check_point(void);
+
+/**
+ * @brief Parses a version 16 checkpoint record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+check_point_parse_v16(struct check_point* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 17 checkpoint record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+check_point_parse_v17(struct check_point* wrapper, const void* rec);
+
+/**
+ * @brief Formats a version 16 checkpoint record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+check_point_format_v16(struct check_point* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 17 checkpoint record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+check_point_format_v17(struct check_point* wrapper, char* buf);
+
+#endif // PGMONETA_PG_CONTROL_H

--- a/src/include/wal/walfile/relpath.h
+++ b/src/include/wal/walfile/relpath.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RELPATH_H
+#define PGMONETA_RELPATH_H
+
+#include <wal/walfile/wal_reader.h>
+
+typedef int backend_id;        /* unique currently active backend identifier */
+
+#define INVALID_BACKEND_ID       (-1)
+
+#define DEFAULTTABLESPACE_OID    1663
+#define GLOBALTABLESPACE_OID     1664
+
+#define RELPATHBACKEND(rnode, backend, forknum) \
+        pgmoneta_wal_get_relation_path((rnode).dbNode, (rnode).spcNode, (rnode).relNode, \
+                                       backend, forknum)
+
+/* First argument is a rel_file_node */
+#define RELPATHPERM(rnode, forknum) \
+        RELPATHBACKEND(rnode, INVALID_BACKEND_ID, forknum)
+
+/**
+ * @brief Generates the filesystem path for a relation file.
+ *
+ * Constructs the path to a relation file using the database OID, tablespace OID,
+ * relation OID, backend ID, and fork number. The path reflects the storage
+ * location in the `global`, `base`, or `pg_tblspc` directories based on the
+ * tablespace and backend ID.
+ *
+ * @param dbNode      OID of the database containing the relation.
+ * @param spcNode     OID of the tablespace where the relation resides.
+ * @param relNode     OID of the relation (table, index, etc.).
+ * @param backendId   Backend ID for temporary relations; use `INVALID_BACKEND_ID` for others.
+ * @param forkNumber  Fork number (e.g., `MAIN_FORKNUM`, `FSM_FORKNUM`).
+ *
+ * @return Dynamically allocated string with the relation file path, or `NULL` on failure.
+ *
+ * @note Caller is responsible for freeing the returned string.
+ */
+char*
+pgmoneta_wal_get_relation_path(oid dbNode, oid spcNode, oid relNode, int backendId, enum fork_number forkNumber);
+
+/**
+ * @brief Get the tablespace version directory.
+ *
+ * This function retrieves the directory where the tablespace version is stored.
+ * It is used to identify the specific location for tablespace versions in the WAL context.
+ *
+ * @return The path to the tablespace version directory as a string.
+ */
+char*
+pgmoneta_wal_get_tablespace_version_directory(void);
+
+/**
+ * @brief Get the catalog version number.
+ *
+ * This function retrieves the catalog version number from the WAL context.
+ * The catalog version number is used to ensure compatibility between different
+ * versions of the catalog during WAL operations.
+ *
+ * @return The catalog version number as a string.
+ */
+char*
+pgmoneta_wal_get_catalog_version_number(void);
+
+#endif // PGMONETA_RELPATH_H

--- a/src/include/wal/walfile/rm.h
+++ b/src/include/wal/walfile/rm.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_H
+#define PGMONETA_RM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+
+typedef uint32_t block_number;
+typedef uint16_t offset_number;
+typedef struct block_id_data* block_id;
+
+// #define Variables
+#define XLR_INFO_MASK           0x0F
+#define XLR_RMGR_INFO_MASK      0xF0
+
+// #define Macros
+/**
+ * @def ITEM_POINTER_GET_OFFSET_NUMBER_NO_CHECK(pointer)
+ * @brief Retrieves the offset number from an item pointer without validation.
+ * @param pointer Pointer to the item.
+ * @return The offset number.
+ */
+#define ITEM_POINTER_GET_OFFSET_NUMBER_NO_CHECK(pointer) \
+        ( \
+           (pointer)->ip_posid \
+        )
+
+/**
+ * @def ITEM_POINTER_GET_OFFSET_NUMBER(pointer)
+ * @brief Retrieves the offset number from an item pointer with validation.
+ * @param pointer Pointer to the item.
+ * @return The offset number.
+ */
+#define ITEM_POINTER_GET_OFFSET_NUMBER(pointer) \
+        ( \
+           ITEM_POINTER_GET_OFFSET_NUMBER_NO_CHECK(pointer) \
+        )
+
+/**
+ * @def ITEM_POINTER_GET_BLOCK_NUMBER_NO_CHECK(pointer)
+ * @brief Retrieves the block number from an item pointer without validation.
+ * @param pointer Pointer to the item.
+ * @return The block number.
+ */
+#define ITEM_POINTER_GET_BLOCK_NUMBER_NO_CHECK(pointer) \
+        ( \
+           BLOCK_ID_GET_BLOCK_NUMBER(&(pointer)->ip_blkid) \
+        )
+
+/**
+ * @def ITEM_POINTER_GET_BLOCK_NUMBER(pointer)
+ * @brief Retrieves the block number from an item pointer with validation.
+ * @param pointer Pointer to the item.
+ * @return The block number.
+ */
+#define ITEM_POINTER_GET_BLOCK_NUMBER(pointer) \
+        ( \
+           ITEM_POINTER_GET_BLOCK_NUMBER_NO_CHECK(pointer) \
+        )
+
+/**
+ * @def BLOCK_ID_GET_BLOCK_NUMBER(blockId)
+ * @brief Retrieves the block number from a block identifier.
+ * @param blockId Pointer to the block identifier.
+ * @return The block number.
+ */
+#define BLOCK_ID_GET_BLOCK_NUMBER(blockId) \
+        ( \
+           ((((block_number) (blockId)->bi_hi) << 16) | ((block_number) (blockId)->bi_lo)) \
+        )
+
+/**
+ * @def POSTING_ITEM_GET_BLOCK_NUMBER(pointer)
+ * @brief Retrieves the block number from a posting item pointer.
+ * @param pointer Pointer to the item.
+ * @return The block number.
+ */
+#define POSTING_ITEM_GET_BLOCK_NUMBER(pointer) \
+        BLOCK_ID_GET_BLOCK_NUMBER(&(pointer)->child_blkno)
+
+/**
+ * @def PostingItemSetBlockNumber(pointer, blockNumber)
+ * @brief Sets the block number in a posting item pointer.
+ * @param pointer Pointer to the item.
+ * @param blockNumber Block number to set.
+ */
+#define PostingItemSetBlockNumber(pointer, blockNumber) \
+        BlockIdSet(&((pointer)->child_blkno), (blockNumber))
+
+// Structs
+/**
+ * @struct block_id_data
+ * @brief Represents a block identifier with high and low parts.
+ * Fields:
+ * - bi_hi: High part of the block identifier.
+ * - bi_lo: Low part of the block identifier.
+ */
+struct block_id_data
+{
+    uint16_t bi_hi;  /**< High part of the block identifier. */
+    uint16_t bi_lo;  /**< Low part of the block identifier. */
+};
+
+/**
+ * @struct item_pointer_data
+ * @brief Represents a pointer to a specific item on a disk.
+ * Fields:
+ * - ip_blkid: Block identifier.
+ * - ip_posid: Offset within the block.
+ */
+struct item_pointer_data
+{
+    struct block_id_data ip_blkid;  /**< Block identifier. */
+    offset_number ip_posid;         /**< Offset within the block. */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_H

--- a/src/include/wal/walfile/rm_brin.h
+++ b/src/include/wal/walfile/rm_brin.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_BRIN_H
+#define PGMONETA_RM_BRIN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/wal_reader.h>
+
+// WAL record definitions for BRIN's WAL operations
+#define XLOG_BRIN_CREATE_INDEX      0x00
+#define XLOG_BRIN_INSERT            0x10
+#define XLOG_BRIN_UPDATE            0x20
+#define XLOG_BRIN_SAMEPAGE_UPDATE   0x30
+#define XLOG_BRIN_REVMAP_EXTEND     0x40
+#define XLOG_BRIN_DESUMMARIZE       0x50
+
+#define XLOG_BRIN_OPMASK            0x70
+
+#define XLOG_BRIN_INIT_PAGE         0x80
+
+/**
+ * @struct xl_brin_createidx
+ * @brief Contains information required to create a BRIN index.
+ *
+ * Fields:
+ * - pagesPerRange: Number of pages per range.
+ * - version: Version of the BRIN index.
+ */
+struct xl_brin_createidx
+{
+    block_number pagesPerRange;  /**< Number of pages per range */
+    uint16_t version;            /**< Version of the BRIN index */
+};
+
+/**
+ * @struct xl_brin_insert
+ * @brief Holds the necessary data for a BRIN tuple insert operation.
+ *
+ * Fields:
+ * - heapBlk: Block number of the heap.
+ * - pagesPerRange: Extra information for revmap update.
+ * - offnum: Offset number for inserting the tuple on the main page.
+ */
+struct xl_brin_insert
+{
+    block_number heapBlk;         /**< Block number of the heap */
+    block_number pagesPerRange;   /**< Pages per range information */
+    offset_number offnum;         /**< Offset number for tuple insertion */
+};
+
+/**
+ * @struct xl_brin_update
+ * @brief Stores information for a BRIN cross-page update, similar to an insert but also includes details about
+ * the old tuple.
+ *
+ * Fields:
+ * - oldOffnum: Offset number of the old tuple on the old page.
+ * - insert: Data for the insert operation.
+ */
+struct xl_brin_update
+{
+    offset_number oldOffnum;  /**< Offset number of old tuple on old page */
+    struct xl_brin_insert insert;  /**< Insert operation data */
+};
+
+/**
+ * @struct xl_brin_samepage_update
+ * @brief Holds data for a BRIN tuple samepage update.
+ *
+ * Fields:
+ * - offnum: Offset number of the updated tuple on the same page.
+ */
+struct xl_brin_samepage_update
+{
+    offset_number offnum;  /**< Offset number of the updated tuple */
+};
+
+/**
+ * @struct xl_brin_revmap_extend
+ * @brief Contains information for a revmap extension.
+ *
+ * Fields:
+ * - targetBlk: Target block number, which is redundant as it is part of backup block 1.
+ */
+struct xl_brin_revmap_extend
+{
+    block_number targetBlk;  /**< Target block number */
+};
+
+
+/**
+ * @struct xl_brin_desummarize
+ * @brief Holds data required for range de-summarization in a BRIN index.
+ *
+ * Fields:
+ * - pagesPerRange: Number of pages per range.
+ * - heapBlk: Page number location to set to invalid.
+ * - regOffset: Offset of the item to delete in the regular index page.
+ */
+struct xl_brin_desummarize
+{
+    block_number pagesPerRange;  /**< Number of pages per range */
+    block_number heapBlk;        /**< Page number location to set to invalid */
+    offset_number regOffset;     /**< Offset of item to delete in the regular index page */
+};
+
+/**
+ * @brief Provides a description of a BRIN operation for logging purposes.
+ *
+ * @param buf A buffer to hold the resulting description.
+ * @param record A pointer to the decoded WAL record structure.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_brin_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_BRIN_H

--- a/src/include/wal/walfile/rm_btree.h
+++ b/src/include/wal/walfile/rm_btree.h
@@ -1,0 +1,632 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_BTREE_H
+#define PGMONETA_RM_BTREE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/transaction.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <stdint.h>
+
+#define INVALID_OFFSET_NUMBER          ((offset_number) 0)
+#define FIRST_OFFSET_NUMBER            ((offset_number) 1)
+#define MAX_OFFSET_NUMBER              ((offset_number) (8192 / sizeof(struct item_id_data))) // TODO: Replace 8192 with block size from pg_control
+
+#define XLOG_BTREE_INSERT_LEAF         0x00  /**< Add index tuple without split */
+#define XLOG_BTREE_INSERT_UPPER        0x10  /**< Same, on a non-leaf page */
+#define XLOG_BTREE_INSERT_META         0x20  /**< Same, plus update metapage */
+#define XLOG_BTREE_SPLIT_L             0x30  /**< Add index tuple with split */
+#define XLOG_BTREE_SPLIT_R             0x40  /**< As above, new item on right */
+#define XLOG_BTREE_INSERT_POST         0x50  /**< Add index tuple with posting split */
+#define XLOG_BTREE_DEDUP               0x60  /**< Deduplicate tuples for a page */
+#define XLOG_BTREE_DELETE              0x70  /**< Delete leaf index tuples for a page */
+#define XLOG_BTREE_UNLINK_PAGE         0x80  /**< Delete a half-dead page */
+#define XLOG_BTREE_UNLINK_PAGE_META    0x90  /**< Same, and update metapage */
+#define XLOG_BTREE_NEWROOT             0xA0  /**< New root page */
+#define XLOG_BTREE_MARK_PAGE_HALFDEAD  0xB0  /**< Mark a leaf as half-dead */
+#define XLOG_BTREE_VACUUM              0xC0  /**< Delete entries on a page during vacuum */
+#define XLOG_BTREE_REUSE_PAGE          0xD0  /**< Old page is about to be reused from FSM */
+#define XLOG_BTREE_META_CLEANUP        0xE0  /**< Update cleanup-related data in the metapage */
+
+#define SIZE_OF_BTREE_UPDATE           (offsetof(struct xl_btree_update, ndeletedtids) + sizeof(uint16_t))
+
+
+#define OFFSET_NUMBER_IS_VALID(offsetNumber) \
+        ((bool) ((offsetNumber != INVALID_OFFSET_NUMBER) && \
+                 (offsetNumber <= MAX_OFFSET_NUMBER)))
+
+/**
+ * @struct item_id_data
+ * @brief Describes a line pointer on a page in a B-tree.
+ *
+ * Fields:
+ * - lp_off: Offset to tuple (from start of page).
+ * - lp_flags: State of line pointer.
+ * - lp_len: Byte length of tuple.
+ */
+struct item_id_data
+{
+    unsigned lp_off: 15;        /**< Offset to tuple (from start of page) */
+    unsigned lp_flags: 2;       /**< State of line pointer */
+    unsigned lp_len: 15;        /**< Byte length of tuple */
+};
+
+/**
+ * @struct xl_btree_metadata_v13
+ * @brief Represents the btree metadata for version 13.
+ *
+ * This data structure is used to store metadata about a btree for version 13.
+ */
+struct xl_btree_metadata_v13
+{
+    uint32_t version;                          /**< Version number. */
+    block_number root;                         /**< Block number of the root. */
+    uint32_t level;                            /**< Level of the btree. */
+    block_number fastroot;                     /**< Fast root block number. */
+    uint32_t fastlevel;                        /**< Fast root level. */
+    transaction_id oldest_btpo_xact;           /**< Oldest B-tree page transaction. */
+    double last_cleanup_num_heap_tuples;       /**< Number of heap tuples after last cleanup. */
+    bool allequalimage;                        /**< All equal image flag. */
+};
+
+/**
+ * @struct xl_btree_metadata_v14
+ * @brief Represents the btree metadata for version 14.
+ *
+ * This data structure is used to store metadata about a btree for version 14.
+ */
+struct xl_btree_metadata_v14
+{
+    uint32_t version;                       /**< Version number. */
+    block_number root;                      /**< Block number of the root. */
+    uint32_t level;                         /**< Level of the btree. */
+    block_number fastroot;                  /**< Fast root block number. */
+    uint32_t fastlevel;                     /**< Fast root level. */
+    uint32_t last_cleanup_num_delpages;     /**< Number of deleted pages after last cleanup. */
+    bool allequalimage;                     /**< All equal image flag. */
+};
+
+/**
+ * @struct xl_btree_metadata
+ * @brief A wrapper struct that holds either version 13 or 14 of btree metadata.
+ *
+ * This structure provides methods to parse and format the metadata.
+ */
+struct xl_btree_metadata
+{
+    void (*parse)(struct xl_btree_metadata* wrapper, const char* rec); /**< Pointer to parse function.*/
+    char* (*format)(struct xl_btree_metadata* wrapper, char* buf);     /**< Pointer to format function.*/
+    union {
+        struct xl_btree_metadata_v13 v13;                              /**< Version 13 of btree metadata.*/
+        struct xl_btree_metadata_v14 v14;                              /**< Version 14 of btree metadata.*/
+    } data;                                                            /**< Union of version-specific metadata.*/
+};
+
+
+/**
+ * @struct xl_btree_insert
+ * @brief Describes a B-tree insert operation without a page split.
+ *
+ * This data structure is used for INSERT_LEAF, INSERT_UPPER, INSERT_META,
+ * and INSERT_POST operations.
+ *
+ * Fields:
+ * - offnum: Offset number where the new tuple is inserted.
+ */
+struct xl_btree_insert
+{
+    offset_number offnum;  /**< Offset number for the new tuple */
+};
+
+#define SizeOfBtreeInsert   (offsetof(xl_btree_insert, offnum) + sizeof(OffsetNumber))
+
+/**
+ * @struct xl_btree_split
+ * @brief Describes a B-tree page split operation.
+ *
+ * This structure handles both left and right splits and includes the necessary
+ * information to fully restore the new right sibling page.
+ *
+ * Fields:
+ * - level: Tree level of the page being split.
+ * - firstrightoff: Offset number of the first item on the right page.
+ * - newitemoff: Offset number of the new item.
+ * - postingoff: Offset inside the original posting tuple.
+ */
+struct xl_btree_split
+{
+    uint32_t level;                     /**< Tree level of the page being split */
+    offset_number firstrightoff;        /**< First original page item on the right page */
+    offset_number newitemoff;           /**< Offset number of the new item */
+    uint16_t postingoff;                /**< Offset inside the original posting tuple */
+};
+
+/**
+ * @struct xl_btree_dedup
+ * @brief Describes a B-tree page deduplication operation.
+ *
+ * This structure represents a deduplication pass on a leaf page.
+ *
+ * Fields:
+ * - nintervals: Number of deduplication intervals.
+ */
+struct xl_btree_dedup
+{
+    uint16_t nintervals;  /**< Number of deduplication intervals */
+};
+
+/**
+ * @struct xl_btree_reuse_page_v13
+ * @brief Represents a reused page in a B-tree index for version 13.
+ *
+ * This structure contains information about a reused B-tree page,
+ * specifically for PostgreSQL version 13.
+ */
+struct xl_btree_reuse_page_v13
+{
+    struct rel_file_node node;                             /**< Identifier for a specific relation. */
+    block_number block;                                    /**< Block number being reused. */
+    transaction_id latest_removed_xid;                     /**< Transaction ID of the latest removed full transaction. */
+};
+
+/**
+ * @struct xl_btree_reuse_page_v15
+ * @brief Represents a reused page in a B-tree index for version 15.
+ *
+ * This structure contains information about a reused B-tree page,
+ * specifically for PostgreSQL version 15.
+ */
+struct xl_btree_reuse_page_v15
+{
+    struct rel_file_node node;                             /**< Identifier for a specific relation. */
+    block_number block;                                    /**< Block number being reused. */
+    struct full_transaction_id latest_removed_full_xid;    /**< Transaction ID of the latest removed full transaction. */
+};
+
+/**
+ * @struct xl_btree_reuse_page_v16
+ * @brief Represents a reused page in a B-tree index for version 16.
+ *
+ * This structure contains information about a reused B-tree page,
+ * specifically for PostgreSQL version 16.
+ */
+struct xl_btree_reuse_page_v16
+{
+    struct rel_file_locator locator;                       /**< Locator for a specific relation. */
+    block_number block;                                    /**< Block number being reused. */
+    struct full_transaction_id snapshot_conflict_horizon_id; /**< Transaction ID for snapshot conflict horizon. */
+    bool is_catalog_rel;                                   /**< Flag indicating if it's a catalog relation. */
+};
+
+/**
+ * @struct xl_btree_reuse_page
+ * @brief Wrapper structure to handle different versions of xl_btree_reuse_page.
+ *
+ * This structure contains a union of the v15 and v16 versions of xl_btree_reuse_page.
+ */
+struct xl_btree_reuse_page
+{
+    void (*parse)(struct xl_btree_reuse_page* wrapper, const void* rec); /**< Function pointer to parse the structure.*/
+    char* (*format)(struct xl_btree_reuse_page* wrapper, char* buf);     /**< Function pointer to format the structure.*/
+    union {
+        struct xl_btree_reuse_page_v13 v13;                              /**< Version 13 of xl_btree_reuse_page.*/
+        struct xl_btree_reuse_page_v15 v15;                              /**< Version 15 of xl_btree_reuse_page.*/
+        struct xl_btree_reuse_page_v16 v16;                              /**< Version 16 of xl_btree_reuse_page.*/
+    } data;                                                              /**< Union of version-specific xl_btree_reuse_page structures.*/
+};
+
+/**
+ * @struct xl_btree_vacuum
+ * @brief Describes a B-tree page vacuum operation.
+ *
+ * This structure is used by VACUUM to represent the deletion of index tuples
+ * on a leaf page.
+ *
+ * Fields:
+ * - ndeleted: Number of deleted tuples.
+ * - nupdated: Number of updated tuples.
+ */
+struct xl_btree_vacuum {
+    uint16_t ndeleted;   /**< Number of deleted tuples */
+    uint16_t nupdated;   /**< Number of updated tuples */
+};
+
+/**
+ * @struct xl_btree_delete_v13
+ * @brief Represents the deletion of btree entries in version 15.
+ *
+ * This data structure is used for storing the deletion information in btree index logs.
+ */
+struct xl_btree_delete_v13 {
+    transaction_id latest_removed_xid;  /**< The latest transaction ID removed by this operation. */
+    uint32_t ndeleted;                 /**< Number of deleted tuples. */
+};
+
+/**
+ * @struct xl_btree_delete_v15
+ * @brief Represents the deletion of btree entries in version 15.
+ *
+ * This data structure is used for storing the deletion information in btree index logs.
+ */
+struct xl_btree_delete_v15 {
+    transaction_id latestRemovedXid;   /**< The latest transaction ID removed by this operation. */
+    uint16_t ndeleted;                 /**< Number of deleted tuples. */
+    uint16_t nupdated;                 /**< Number of updated tuples. */
+    /* DELETED TARGET OFFSET NUMBERS FOLLOW */
+    /* UPDATED TARGET OFFSET NUMBERS FOLLOW */
+    /* UPDATED TUPLES METADATA (xl_btree_update) ARRAY FOLLOWS */
+};
+
+/**
+ * @struct xl_btree_delete_v16
+ * @brief Represents the deletion of btree entries in version 16.
+ *
+ * This data structure is used for storing the deletion information in btree index logs.
+ */
+struct xl_btree_delete_v16 {
+    transaction_id snapshot_conflict_horizon;  /**< Transaction ID snapshot conflict horizon. */
+    uint16_t ndeleted;                         /**< Number of deleted tuples. */
+    uint16_t nupdated;                         /**< Number of updated tuples. */
+    bool is_catalog_rel;                       /**< Indicates if the relation is a catalog relation. */
+    /*----
+     * In payload of blk 0 :
+     * - DELETED TARGET OFFSET NUMBERS
+     * - UPDATED TARGET OFFSET NUMBERS
+     * - UPDATED TUPLES METADATA (xl_btree_update) ARRAY
+     *----
+     */
+};
+
+/**
+ * @struct xl_btree_delete
+ * @brief A wrapper structure for different versions of btree deletion.
+ */
+struct xl_btree_delete {
+    void (*parse)(struct xl_btree_delete* wrapper, const void* rec);   /**< Function pointer to parse the structure. */
+    char* (*format)(struct xl_btree_delete* wrapper, char* buf);       /**< Function pointer to format the structure. */
+    union {
+        struct xl_btree_delete_v13 v13;   /**< Version 13 of the structure. */
+        struct xl_btree_delete_v15 v15;   /**< Version 15 of the structure. */
+        struct xl_btree_delete_v16 v16;   /**< Version 16 of the structure. */
+    } data;                              /**< Union of version-specific structures. */
+};
+
+/**
+ * @struct xl_btree_update
+ * @brief Describes the update of a B-tree posting list tuple.
+ *
+ * The offsets in this structure are offsets into the original posting list
+ * tuple, not page offset numbers.
+ *
+ * Fields:
+ * - ndeletedtids: Number of deleted TIDs in the posting list.
+ */
+struct xl_btree_update {
+    uint16_t ndeletedtids;  /**< Number of deleted TIDs */
+};
+
+
+
+/**
+ * @struct xl_btree_mark_page_halfdead
+ * @brief Describes marking a B-tree page as half-dead.
+ *
+ * This structure is used to mark an empty subtree for deletion.
+ *
+ * Fields:
+ * - poffset: Offset of the deleted tuple in the parent page.
+ * - leafblk: Block number of the leaf page being deleted.
+ * - leftblk: Block number of the left sibling of the leaf page.
+ * - rightblk: Block number of the right sibling of the leaf page.
+ * - topparent: Block number of the topmost internal page in the subtree.
+ */
+struct xl_btree_mark_page_halfdead {
+    offset_number poffset;        /**< Offset of the deleted tuple in the parent page */
+    block_number leafblk;         /**< Leaf block being deleted */
+    block_number leftblk;         /**< Left sibling block of the leaf */
+    block_number rightblk;        /**< Right sibling block of the leaf */
+    block_number topparent;       /**< Topmost internal page in the subtree */
+};
+
+/**
+ * @struct xl_btree_unlink_page_v13
+ * @brief Represents the structure for version 13 of xl_btree_unlink_page.
+ *
+ * This structure holds information needed to handle a page unlink operation
+ * in B-Tree for version 13.
+ */
+struct xl_btree_unlink_page_v13 {
+    block_number leftsib;            /**< Target block's left sibling, if any. */
+    block_number rightsib;           /**< Target block's right sibling. */
+    block_number leafleftsib;        /**< Left sibling of the leaf page. */
+    block_number leafrightsib;       /**< Right sibling of the leaf page. */
+    block_number topparent;          /**< Next child down in the branch. */
+    transaction_id btpo_xact;        /**< Value of btpo.xact for use in recovery. */
+};
+
+/**
+ * @struct xl_btree_unlink_page_v14
+ * @brief Represents the structure for version 14 of xl_btree_unlink_page.
+ *
+ * This structure holds information needed to handle a page unlink operation
+ * in B-Tree for version 14.
+ */
+struct xl_btree_unlink_page_v14 {
+    block_number leftsib;                    /**< Target block's left sibling, if any. */
+    block_number rightsib;                   /**< Target block's right sibling. */
+    uint32_t level;                          /**< Target block's level. */
+    struct full_transaction_id safexid;      /**< XID of BTPageSetDeleted operation. */
+    block_number leafleftsib;                /**< Left sibling of the leaf page. */
+    block_number leafrightsib;               /**< Right sibling of the leaf page. */
+    block_number leaftopparent;              /**< Next child down in the subtree. */
+};
+
+/**
+ * @struct xl_btree_unlink_page
+ * @brief A wrapper struct containing versioned xl_btree_unlink_page data.
+ *
+ * This union allows handling different versions of the xl_btree_unlink_page
+ * structure.
+ */
+struct xl_btree_unlink_page {
+    void (*parse)(struct xl_btree_unlink_page* wrapper, const void* rec);   /**< Function to parse the record.*/
+    char* (*format)(struct xl_btree_unlink_page* wrapper, char* buf);       /**< Function to format the record as a string.*/
+    union {
+        struct xl_btree_unlink_page_v13 v13;                                /**< Version 13 of the structure.*/
+        struct xl_btree_unlink_page_v14 v14;                                /**< Version 14 of the structure.*/
+    } data;                                                                 /**< Union of version-specific structures.*/
+};
+
+/**
+ * @struct xl_btree_newroot
+ * @brief Describes the creation of a new B-tree root page.
+ *
+ * This structure is used when a new root page is established,
+ * typically after a root page split.
+ *
+ * Fields:
+ * - rootblk: Block number of the new root page.
+ * - level: Tree level of the new root.
+ */
+struct xl_btree_newroot {
+    block_number rootblk;  /**< Block number of the new root */
+    uint32_t level;        /**< Tree level of the new root */
+};
+
+/**
+ * Creates an xl_btree_reuse_page wrapper structure.
+ *
+ * @return A pointer to the newly created xl_btree_reuse_page structure.
+ */
+struct xl_btree_reuse_page* pgmoneta_wal_create_xl_btree_reuse_page(void);
+
+/**
+ * Parses a version 13 xl_btree_reuse_page record.
+ *
+ * @param wrapper Pointer to the wrapper structure.
+ * @param rec The raw record data to be parsed.
+ */
+void pgmoneta_wal_parse_xl_btree_reuse_page_v13(struct xl_btree_reuse_page* wrapper, const void* rec);
+
+/**
+ * Parses a version 15 xl_btree_reuse_page record.
+ *
+ * @param wrapper Pointer to the wrapper structure.
+ * @param rec The raw record data to be parsed.
+ */
+void pgmoneta_wal_parse_xl_btree_reuse_page_v15(struct xl_btree_reuse_page* wrapper, const void* rec);
+
+/**
+ * Parses a version 16 xl_btree_reuse_page record.
+ *
+ * @param wrapper Pointer to the wrapper structure.
+ * @param rec The raw record data to be parsed.
+ */
+void pgmoneta_wal_parse_xl_btree_reuse_page_v16(struct xl_btree_reuse_page* wrapper, const void* rec);
+
+/**
+ * Formats a version 13 xl_btree_reuse_page record.
+ *
+ * @param wrapper Pointer to the wrapper structure.
+ * @param buf The buffer where the formatted string will be stored.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_reuse_page_v13(struct xl_btree_reuse_page* wrapper, char* buf);
+
+/**
+ * Formats a version 15 xl_btree_reuse_page record.
+ *
+ * @param wrapper Pointer to the wrapper structure.
+ * @param buf The buffer where the formatted string will be stored.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_reuse_page_v15(struct xl_btree_reuse_page* wrapper, char* buf);
+
+/**
+ * Formats a version 16 xl_btree_reuse_page record.
+ *
+ * @param wrapper Pointer to the wrapper structure.
+ * @param buf The buffer where the formatted string will be stored.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_reuse_page_v16(struct xl_btree_reuse_page* wrapper, char* buf);
+
+/**
+ * Parses the v13 version of xl_btree_delete.
+ *
+ * @param wrapper The wrapper structure.
+ * @param rec The raw record to parse.
+ */
+void pgmoneta_wal_parse_xl_btree_delete_v13(struct xl_btree_delete* wrapper, const void* rec);
+
+/**
+ * Parses the v15 version of xl_btree_delete.
+ *
+ * @param wrapper The wrapper structure.
+ * @param rec The raw record to parse.
+ */
+void pgmoneta_wal_parse_xl_btree_delete_v15(struct xl_btree_delete* wrapper, const void* rec);
+
+/**
+ * Parses the v16 version of xl_btree_delete.
+ *
+ * @param wrapper The wrapper structure.
+ * @param rec The raw record to parse.
+ */
+void pgmoneta_wal_parse_xl_btree_delete_v16(struct xl_btree_delete* wrapper, const void* rec);
+
+/**
+ * Formats the v13 version of xl_btree_delete into a string.
+ *
+ * @param wrapper The wrapper structure.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_delete_v13(struct xl_btree_delete* wrapper, char* buf);
+
+/**
+ * Formats the v15 version of xl_btree_delete into a string.
+ *
+ * @param wrapper The wrapper structure.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_delete_v15(struct xl_btree_delete* wrapper, char* buf);
+
+/**
+ * Formats the v16 version of xl_btree_delete into a string.
+ *
+ * @param wrapper The wrapper structure.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_delete_v16(struct xl_btree_delete* wrapper, char* buf);
+
+/**
+ * Allocates and initializes an xl_btree_metadata structure based on the server version.
+ *
+ * @return A pointer to the initialized xl_btree_metadata structure.
+ */
+struct xl_btree_metadata* pgmoneta_wal_create_xl_btree_metadata(void);
+
+/**
+ * Parses a version 13 xl_btree_metadata record.
+ *
+ * @param wrapper The wrapper containing the metadata.
+ * @param rec The raw record to parse.
+ */
+void pgmoneta_wal_parse_xl_btree_metadata_v13(struct xl_btree_metadata* wrapper, const char* rec);
+
+/**
+ * Parses a version 14 xl_btree_metadata record.
+ *
+ * @param wrapper The wrapper containing the metadata.
+ * @param rec The raw record to parse.
+ */
+void pgmoneta_wal_parse_xl_btree_metadata_v14(struct xl_btree_metadata* wrapper, const char* rec);
+
+/**
+ * Formats a version 13 xl_btree_metadata record as a string.
+ *
+ * @param wrapper The wrapper containing the metadata.
+ * @param buf The buffer to write the formatted string.
+ * @return A pointer to the buffer with the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_metadata_v13(struct xl_btree_metadata* wrapper, char* buf);
+
+/**
+ * Formats a version 14 xl_btree_metadata record as a string.
+ *
+ * @param wrapper The wrapper containing the metadata.
+ * @param buf The buffer to write the formatted string.
+ * @return A pointer to the buffer with the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_metadata_v14(struct xl_btree_metadata* wrapper, char* buf);
+
+/**
+ * Parses a version 13 xl_btree_unlink_page record.
+ *
+ * @param wrapper The wrapper struct.
+ * @param rec The record to parse.
+ */
+void pgmoneta_wal_parse_xl_btree_unlink_page_v13(struct xl_btree_unlink_page* wrapper, const void* rec);
+
+/**
+ * Parses a version 14 xl_btree_unlink_page record.
+ *
+ * @param wrapper The wrapper struct.
+ * @param rec The record to parse.
+ */
+void pgmoneta_wal_parse_xl_btree_unlink_page_v14(struct xl_btree_unlink_page* wrapper, const void* rec);
+
+/**
+ * Formats a version 13 xl_btree_unlink_page record into a string.
+ *
+ * @param wrapper The wrapper struct.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_unlink_page_v13(struct xl_btree_unlink_page* wrapper, char* buf);
+
+/**
+ * Formats a version 14 xl_btree_unlink_page record into a string.
+ *
+ * @param wrapper The wrapper struct.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* pgmoneta_wal_format_xl_btree_unlink_page_v14(struct xl_btree_unlink_page* wrapper, char* buf);
+
+/**
+ * Creates an xl_btree_unlink_page wrapper.
+ *
+ * @return A pointer to the created wrapper.
+ */
+struct xl_btree_unlink_page* pgmoneta_wal_create_xl_btree_unlink_page(void);
+
+/**
+ * @brief Describe a B-tree operation from a decoded XLog record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLog record.
+ * @return A pointer to the description in buf.
+ */
+char*
+pgmoneta_wal_btree_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //PGMONETA_RM_BTREE_H

--- a/src/include/wal/walfile/rm_clog.h
+++ b/src/include/wal/walfile/rm_clog.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_CLOG_H
+#define PGMONETA_RM_CLOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+#define TRANSACTION_STATUS_IN_PROGRESS    0x00    /**< Transaction is in progress */
+#define TRANSACTION_STATUS_COMMITTED      0x01    /**< Transaction has been committed */
+#define TRANSACTION_STATUS_ABORTED        0x02    /**< Transaction has been aborted */
+#define TRANSACTION_STATUS_SUB_COMMITTED  0x03    /**< Transaction is sub-committed */
+
+#define CLOG_ZEROPAGE      0x00    /**< CLOG zero page */
+#define CLOG_TRUNCATE      0x10    /**< CLOG truncate */
+
+/**
+ * @struct xl_clog_truncate_17
+ * @brief Represents a CLOG truncate record for PostgreSQL version 17.
+ *
+ * This structure holds information related to the truncation of the
+ * commit log (CLOG) in PostgreSQL version 17.
+ *
+ * Fields:
+ * - pageno: The page number of the CLOG to truncate.
+ * - oldestXact: The oldest transaction ID to retain.
+ * - oldestXactDb: The database ID of the oldest transaction to retain.
+ */
+struct xl_clog_truncate_17
+{
+    int pageno;                     /**< The page number of the CLOG to truncate */
+    transaction_id oldestXact;      /**< The oldest transaction ID to retain */
+    oid oldestXactDb;               /**< The database ID of the oldest transaction */
+};
+
+/**
+ * @struct xl_clog_truncate_16
+ * @brief Represents a CLOG truncate record for PostgreSQL version 16.
+ *
+ * This structure holds information related to the truncation of the
+ * commit log (CLOG) in PostgreSQL version 16.
+ *
+ * Fields:
+ * - pageno: The page number of the CLOG to truncate.
+ * - oldestXact: The oldest transaction ID to retain.
+ * - oldestXactDb: The database ID of the oldest transaction to retain.
+ */
+struct xl_clog_truncate_16
+{
+    int64_t pageno;                 /**< The page number of the CLOG to truncate */
+    transaction_id oldestXact;      /**< The oldest transaction ID to retain */
+    oid oldestXactDb;               /**< The database ID of the oldest transaction */
+};
+
+/**
+ * @struct xl_clog_truncate
+ * @brief Represents a CLOG truncate record wrapper.
+ *
+ * This structure is a version-agnostic wrapper for the CLOG truncate
+ * records in different PostgreSQL versions. It contains a union of
+ * version-specific structures and function pointers for parsing and
+ * formatting the records.
+ *
+ * Fields:
+ * - pg_version: The PostgreSQL version of the CLOG truncate record.
+ * - data: A union containing version-specific truncate record structures.
+ * - parse: A function pointer to parse the truncate record.
+ * - format: A function pointer to format the truncate record.
+ */
+struct xl_clog_truncate
+{
+    void (*parse)(struct xl_clog_truncate* wrapper, char* rec);     /**< Function pointer to parse the record */
+    char* (*format)(struct xl_clog_truncate* wrapper, char* buf);   /**< Function pointer to format the record */
+    union {
+        struct xl_clog_truncate_16 v16;                             /**< Truncate record for version 16 */
+        struct xl_clog_truncate_17 v17;                             /**< Truncate record for version 17 */
+    } data;                                                         /**< Version-specific truncate record data */
+};
+
+/**
+ * @brief Creates a new xl_clog_truncate structure.
+ *
+ * @return A pointer to the newly created xl_clog_truncate structure.
+ */
+struct xl_clog_truncate* create_xl_clog_truncate(void);
+
+/**
+ * @brief Parses a version 16 CLOG truncate record.
+ *
+ * @param wrapper A pointer to the xl_clog_truncate structure.
+ * @param rec A pointer to the raw record data to parse.
+ */
+void xl_clog_truncate_parse_v16(struct xl_clog_truncate* wrapper, char* rec);
+
+/**
+ * @brief Parses a version 17 CLOG truncate record.
+ *
+ * @param wrapper A pointer to the xl_clog_truncate structure.
+ * @param rec A pointer to the raw record data to parse.
+ */
+void xl_clog_truncate_parse_v17(struct xl_clog_truncate* wrapper, char* rec);
+
+/**
+ * @brief Formats a version 16 CLOG truncate record.
+ *
+ * @param wrapper A pointer to the xl_clog_truncate structure.
+ * @param buf A buffer to store the formatted output.
+ * @return A pointer to the buffer containing the formatted output.
+ */
+char* xl_clog_truncate_format_v16(struct xl_clog_truncate* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 17 CLOG truncate record.
+ *
+ * @param wrapper A pointer to the xl_clog_truncate structure.
+ * @param buf A buffer to store the formatted output.
+ * @return A pointer to the buffer containing the formatted output.
+ */
+char* xl_clog_truncate_format_v17(struct xl_clog_truncate* wrapper, char* buf);
+
+/**
+ * @brief Describes a CLOG WAL record.
+ *
+ * This function generates a human-readable description of a CLOG
+ * Write-Ahead Logging (WAL) record.
+ *
+ * @param buf A buffer to store the description.
+ * @param record The decoded XLOG record to describe.
+ * @return A pointer to the buffer containing the description.
+ */
+char* pgmoneta_wal_clog_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_CLOG_H

--- a/src/include/wal/walfile/rm_commit_ts.h
+++ b/src/include/wal/walfile/rm_commit_ts.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_COMMIT_TS_H
+#define PGMONETA_RM_COMMIT_TS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/wal_reader.h>
+
+/* XLOG stuff */
+#define COMMIT_TS_ZEROPAGE      0x00
+#define COMMIT_TS_TRUNCATE      0x10
+
+/**
+ * @struct xl_commit_ts_set
+ * @brief Represents a commit timestamp set record.
+ *
+ * Fields:
+ * - timestamp: The commit timestamp.
+ * - nodeid: The replication origin node ID.
+ * - mainxid: The main transaction ID.
+ * - subxact Xids follow: Subsequent subtransaction IDs.
+ */
+struct xl_commit_ts_set {
+    timestamp_tz timestamp;       /**< Commit timestamp */
+    rep_origin_id nodeid;         /**< Replication origin node ID */
+    transaction_id mainxid;       /**< Main transaction ID */
+    /* subxact Xids follow */
+};
+
+/**
+ * @struct xl_commit_ts_truncate_17
+ * @brief Represents a commit timestamp truncate record for version 17.
+ *
+ * Fields:
+ * - pageno: The page number to truncate.
+ * - oldestXid: The oldest transaction ID.
+ */
+struct xl_commit_ts_truncate_17 {
+    int64_t pageno;               /**< Page number to truncate */
+    transaction_id oldestXid;     /**< Oldest transaction ID */
+};
+
+/**
+ * @struct xl_commit_ts_truncate_16
+ * @brief Represents a commit timestamp truncate record for version 16.
+ *
+ * Fields:
+ * - pageno: The page number to truncate.
+ * - oldestXid: The oldest transaction ID.
+ */
+struct xl_commit_ts_truncate_16 {
+    int pageno;                   /**< Page number to truncate */
+    transaction_id oldestXid;     /**< Oldest transaction ID */
+};
+
+/**
+ * @struct xl_commit_ts_truncate
+ * @brief Wrapper structure for commit timestamp truncate records.
+ *
+ * Fields:
+ * - data: A union containing version-specific truncate record data.
+ * - parse: Function pointer to parse the record.
+ * - format: Function pointer to format the record.
+ */
+struct xl_commit_ts_truncate {
+    void (*parse)(struct xl_commit_ts_truncate* wrapper, char* rec);    /**< Function pointer to parse the record */
+    char* (*format)(struct xl_commit_ts_truncate* wrapper, char* buf);  /**< Function pointer to format the record */
+    union {
+        struct xl_commit_ts_truncate_16 v16;                            /**< Truncate record for version 16 */
+        struct xl_commit_ts_truncate_17 v17;                            /**< Truncate record for version 17 */
+    } data;                                                             /**< Version-specific truncate record data */
+};
+
+/**
+ * @brief Creates a new xl_commit_ts_truncate structure.
+ *
+ * @return A pointer to the newly created xl_commit_ts_truncate structure.
+ */
+struct xl_commit_ts_truncate*
+create_xl_commit_ts_truncate(void);
+
+/**
+ * @brief Parses a version 16 commit timestamp truncate record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+xl_commit_ts_truncate_parse_v16(struct xl_commit_ts_truncate* wrapper, char* rec);
+
+/**
+ * @brief Parses a version 17 commit timestamp truncate record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+xl_commit_ts_truncate_parse_v17(struct xl_commit_ts_truncate* wrapper, char* rec);
+
+/**
+ * @brief Formats a version 16 commit timestamp truncate record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+xl_commit_ts_truncate_format_v16(struct xl_commit_ts_truncate* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 17 commit timestamp truncate record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+xl_commit_ts_truncate_format_v17(struct xl_commit_ts_truncate* wrapper, char* buf);
+
+/**
+ * @brief Describes a commit timestamp record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record to describe.
+ * @return A pointer to the description string.
+ */
+char*
+pgmoneta_wal_commit_ts_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_COMMIT_TS_H

--- a/src/include/wal/walfile/rm_database.h
+++ b/src/include/wal/walfile/rm_database.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_DATABASE_H
+#define PGMONETA_RM_DATABASE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+// #define variables
+#define XLOG_DBASE_CREATE                    0x00     /**< Create database log type */
+#define XLOG_DBASE_DROP                      0x10     /**< Drop database log type */
+
+// #define macros
+#define MIN_SIZE_OF_DBASE_DROP_REC           offsetof(xl_dbase_drop_rec, tablespace_ids) /**< Minimum size of xl_dbase_drop_rec */
+
+// Structs
+/**
+ * @struct xl_dbase_create_rec
+ * @brief Represents the creation of a database, including the copying of a single subdirectory and its contents.
+ *
+ * Fields:
+ * - db_id: Identifier for the database being created.
+ * - tablespace_id: Identifier for the tablespace of the database.
+ * - src_db_id: Identifier for the source database.
+ * - src_tablespace_id: Identifier for the source tablespace.
+ */
+struct xl_dbase_create_rec {
+    oid db_id;                /**< Database ID */
+    oid tablespace_id;        /**< Tablespace ID */
+    oid src_db_id;            /**< Source Database ID */
+    oid src_tablespace_id;    /**< Source Tablespace ID */
+};
+
+/**
+ * @struct xl_dbase_drop_rec
+ * @brief Represents the dropping of a database, including the removal of associated tablespaces.
+ *
+ * Fields:
+ * - db_id: Identifier for the database being dropped.
+ * - ntablespaces: Number of tablespace IDs associated with the database.
+ * - tablespace_ids: Array of tablespace IDs.
+ */
+struct xl_dbase_drop_rec {
+    oid db_id;                         /**< Database ID */
+    int ntablespaces;                  /**< Number of tablespace IDs */
+    oid tablespace_ids[FLEXIBLE_ARRAY_MEMBER];  /**< Array of tablespace IDs */
+};
+
+// Functions
+/**
+ * @brief Describes a database record in a human-readable format.
+ *
+ * @param buf The buffer to hold the description string.
+ * @param record The decoded XLOG record to be described.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_database_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_DATABASE_H

--- a/src/include/wal/walfile/rm_generic.h
+++ b/src/include/wal/walfile/rm_generic.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_GENERIC_H
+#define PGMONETA_RM_GENERIC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+typedef char* pointer;
+
+/**
+ * @brief Describes a GIN WAL record.
+ *
+ * This function takes a buffer and a decoded WAL record,
+ * and returns a description of the record. The description
+ * is stored in the provided buffer.
+ *
+ * @param buf The buffer to store the description.
+ * @param record A pointer to the decoded WAL record.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_generic_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_GENERIC_H

--- a/src/include/wal/walfile/rm_gin.h
+++ b/src/include/wal/walfile/rm_gin.h
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_GIN_H
+#define PGMONETA_RM_GIN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <stdint.h>
+
+#define GIN_INSERT_ISDATA               0x01  /**< for both insert and split records */
+#define GIN_INSERT_ISLEAF               0x02  /**< ditto */
+#define GIN_SPLIT_ROOT                  0x04  /**< only for split records */
+
+#define GIN_CURRENT_VERSION             2
+
+#define GIN_NDELETE_AT_ONCE             Min(16, XLR_MAX_BLOCK_ID - 1)
+
+#define XLOG_GIN_CREATE_PTREE           0x10  /**< Create a new posting tree */
+#define XLOG_GIN_INSERT                 0x20  /**< Insert record */
+#define XLOG_GIN_SPLIT                  0x30  /**< Split page */
+#define XLOG_GIN_VACUUM_PAGE            0x40  /**< Vacuum page */
+#define XLOG_GIN_VACUUM_DATA_LEAF_PAGE  0x90  /**< Vacuum data leaf page */
+#define XLOG_GIN_DELETE_PAGE            0x50  /**< Delete page */
+#define XLOG_GIN_UPDATE_META_PAGE       0x60  /**< Update metadata page */
+#define XLOG_GIN_INSERT_LISTPAGE        0x70  /**< Insert into list page */
+#define XLOG_GIN_DELETE_LISTPAGE        0x80  /**< Delete from list page */
+
+#define GIN_SEGMENT_UNMODIFIED          0  /**< No action (not used in WAL records) */
+#define GIN_SEGMENT_DELETE              1  /**< A whole segment is removed */
+#define GIN_SEGMENT_INSERT              2  /**< A whole segment is added */
+#define GIN_SEGMENT_REPLACE             3  /**< A segment is replaced */
+#define GIN_SEGMENT_ADDITEMS            4  /**< Items are added to existing segment */
+
+
+
+#define SIZE_OF_GIN_POSTING_LIST(plist) \
+        (offsetof(struct gin_posting_list, bytes) + SHORTALIGN((plist)->nbytes))
+
+/**
+ * @struct index_tuple_data
+ * @brief Structure representing the header of an index tuple.
+ *
+ * Fields:
+ * - t_tid: Reference TID to heap tuple.
+ * - t_info: Various information about the tuple, including size and flags.
+ */
+struct index_tuple_data
+{
+    struct item_pointer_data t_tid;   /**< Reference TID to heap tuple */
+    unsigned short t_info;            /**< Various info about tuple */
+};                                   /* MORE DATA FOLLOWS AT END OF STRUCT */
+
+/**
+ * @struct posting_item
+ * @brief Structure representing a posting item in a non-leaf posting-tree page.
+ *
+ * Fields:
+ * - child_blkno: Block ID for the child node.
+ * - key: Key associated with this posting item.
+ */
+struct posting_item
+{
+    struct block_id_data child_blkno;   /**< Block ID for the child node */
+    struct item_pointer_data key;       /**< Key associated with this posting item */
+};
+
+/**
+ * @struct gin_xlog_create_posting_tree
+ * @brief Structure representing the creation of a posting tree in a GIN index.
+ *
+ * Fields:
+ * - size: Size of the posting list that follows.
+ */
+struct gin_xlog_create_posting_tree
+{
+    uint32_t size;   /**< Size of the posting list that follows */
+};
+
+/**
+ * @struct gin_xlog_insert
+ * @brief Common structure for insertion records in a GIN index.
+ *
+ * Fields:
+ * - flags: Flags indicating whether the page is a leaf or contains data.
+ */
+struct gin_xlog_insert
+{
+    uint16_t flags;   /**< GIN_INSERT_ISLEAF and/or GIN_INSERT_ISDATA flags */
+};
+
+/**
+ * @struct gin_xlog_insert_entry
+ * @brief Structure representing an insertion entry in a GIN index.
+ *
+ * Fields:
+ * - offset: Offset number for the entry.
+ * - isDelete: Flag indicating if the entry is a deletion.
+ * - tuple: The index tuple data associated with this entry.
+ */
+struct gin_xlog_insert_entry
+{
+    offset_number offset;                 /**< Offset number for the entry */
+    bool isDelete;                        /**< Flag indicating if the entry is a deletion */
+    struct index_tuple_data tuple;        /**< Index tuple data (variable length) */
+};
+
+/**
+ * @struct gin_xlog_recompress_data_leaf
+ * @brief Structure representing recompression of a data leaf in a GIN index.
+ *
+ * Fields:
+ * - nactions: Number of actions in the recompression.
+ */
+struct gin_xlog_recompress_data_leaf
+{
+    uint16_t nactions;   /**< Number of actions in the recompression */
+};
+
+/**
+ * @struct gin_xlog_insert_data_internal
+ * @brief Structure representing an internal insertion of data in a GIN index.
+ *
+ * Fields:
+ * - offset: Offset number for the new item.
+ * - newitem: The new posting item to be inserted.
+ */
+struct gin_xlog_insert_data_internal
+{
+    offset_number offset;                /**< Offset number for the new item */
+    struct posting_item newitem;         /**< New posting item to be inserted */
+};
+
+/**
+ * @struct gin_xlog_split
+ * @brief Structure representing a split in a GIN index.
+ *
+ * Fields:
+ * - node: The rel file node of the GIN index.
+ * - rrlink: Right link or root's block number if root split.
+ * - leftChildBlkno: Block number of the left child on a non-leaf split.
+ * - rightChildBlkno: Block number of the right child on a non-leaf split.
+ * - flags: Flags associated with the split.
+ */
+struct gin_xlog_split
+{
+    struct rel_file_node node;          /**< The rel file node of the GIN index */
+    block_number rrlink;                /**< Right link or root's block number if root split */
+    block_number leftChildBlkno;        /**< Block number of the left child (non-leaf split) */
+    block_number rightChildBlkno;       /**< Block number of the right child (non-leaf split) */
+    uint16_t flags;                     /**< Flags associated with the split */
+};
+
+/**
+ * @struct gin_xlog_vacuum_data_leaf_page
+ * @brief Structure representing the vacuuming of a data leaf page in a GIN index.
+ *
+ * Fields:
+ * - data: The recompressed data leaf information.
+ */
+struct gin_xlog_vacuum_data_leaf_page
+{
+    struct gin_xlog_recompress_data_leaf data;   /**< Recompressed data leaf information */
+};
+
+/**
+ * @struct gin_xlog_delete_page
+ * @brief Structure representing the deletion of a page in a GIN index.
+ *
+ * Fields:
+ * - parentOffset: Offset of the parent page.
+ * - rightLink: Right link to the next page.
+ * - deleteXid: Transaction ID of the last Xid that could see this page in a scan.
+ */
+struct gin_xlog_delete_page
+{
+    offset_number parentOffset;     /**< Offset of the parent page */
+    block_number rightLink;         /**< Right link to the next page */
+    transaction_id deleteXid;       /**< Last Xid which could see this page in scan */
+};
+
+/**
+ * @struct gin_meta_page_data
+ * @brief Structure representing metadata for a GIN index.
+ *
+ * Fields:
+ * - head: Pointer to the head of the pending list.
+ * - tail: Pointer to the tail of the pending list.
+ * - tailFreeSize: Free space in bytes in the pending list's tail page.
+ * - nPendingPages: Number of pages in the pending list.
+ * - nPendingHeapTuples: Number of heap tuples in the pending list.
+ * - nTotalPages: Total number of pages in the index.
+ * - nEntryPages: Number of entry pages in the index.
+ * - nDataPages: Number of data pages in the index.
+ * - nEntries: Number of entries in the index.
+ * - ginVersion: Version number of the GIN index.
+ */
+struct gin_meta_page_data
+{
+    block_number head;               /**< Head of the pending list */
+    block_number tail;               /**< Tail of the pending list */
+    uint32_t tailFreeSize;           /**< Free space in bytes in the tail page */
+    block_number nPendingPages;      /**< Number of pages in the pending list */
+    int64_t nPendingHeapTuples;      /**< Number of heap tuples in the pending list */
+    block_number nTotalPages;        /**< Total number of pages in the index */
+    block_number nEntryPages;        /**< Number of entry pages in the index */
+    block_number nDataPages;         /**< Number of data pages in the index */
+    int64_t nEntries;                /**< Number of entries in the index */
+    int32_t ginVersion;              /**< Version number of the GIN index */
+};
+
+/**
+ * @struct gin_xlog_update_meta
+ * @brief Structure representing an update to the metadata of a GIN index.
+ *
+ * Fields:
+ * - node: The rel file node of the GIN index.
+ * - metadata: The updated metadata for the GIN index.
+ * - prevTail: Previous tail of the pending list.
+ * - newRightlink: New right link for the list page.
+ * - ntuples: Number of tuples inserted or updated.
+ */
+struct gin_xlog_update_meta
+{
+    struct rel_file_node node;            /**< The rel file node of the GIN index */
+    struct gin_meta_page_data metadata;   /**< Updated metadata for the GIN index */
+    block_number prevTail;                /**< Previous tail of the pending list */
+    block_number newRightlink;            /**< New right link for the list page */
+    int32_t ntuples;                      /**< Number of tuples inserted or updated */
+};
+
+/**
+ * @struct gin_xlog_insert_list_page
+ * @brief Structure representing an insertion into a list page in a GIN index.
+ *
+ * Fields:
+ * - rightlink: Right link to the next page.
+ * - ntuples: Number of tuples inserted.
+ */
+struct gin_xlog_insert_list_page
+{
+    block_number rightlink;     /**< Right link to the next page */
+    int32_t ntuples;            /**< Number of tuples inserted */
+};
+
+/**
+ * @struct gin_xlog_delete_list_pages
+ * @brief Structure representing the deletion of list pages in a GIN index.
+ *
+ * Fields:
+ * - metadata: Metadata after the deletion of the pages.
+ * - ndeleted: Number of pages deleted.
+ */
+struct gin_xlog_delete_list_pages
+{
+    struct gin_meta_page_data metadata;   /**< Metadata after deletion */
+    int32_t ndeleted;                     /**< Number of pages deleted */
+};
+
+/**
+ * @struct gin_posting_list
+ * @brief Structure representing a posting list in a GIN index.
+ *
+ * Fields:
+ * - first: First item in the posting list (unpacked).
+ * - nbytes: Number of bytes in the posting list.
+ * - bytes: Varbyte encoded items in the posting list.
+ */
+struct gin_posting_list
+{
+    struct item_pointer_data first;   /**< First item in the posting list (unpacked) */
+    uint16_t nbytes;                  /**< Number of bytes in the posting list */
+    unsigned char bytes[FLEXIBLE_ARRAY_MEMBER];   /**< Varbyte encoded items */
+};
+
+/**
+ * @brief Describes a GIN WAL record.
+ *
+ * @param buf Buffer to hold the description.
+ * @param record The decoded WAL record to describe.
+ * @return Pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_gin_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_GIN_H

--- a/src/include/wal/walfile/rm_gist.h
+++ b/src/include/wal/walfile/rm_gist.h
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_GIST_H
+#define PGMONETA_RM_GIST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/wal_reader.h>
+
+typedef xlog_rec_ptr gist_nsn;
+
+#define XLOG_GIST_PAGE_UPDATE  0x00 /**< Update a GIST index page. */
+#define XLOG_GIST_DELETE       0x10 /**< Delete leaf index tuples for a page. */
+#define XLOG_GIST_PAGE_REUSE   0x20 /**< Old page is about to be reused from FSM. */
+#define XLOG_GIST_PAGE_SPLIT   0x30 /**< Split a GIST index page. */
+#define XLOG_GIST_PAGE_DELETE  0x60 /**< Delete a GIST index page. */
+#define XLOG_GIST_ASSIGN_LSN   0x70 /**< Assign a new LSN, no operation. */
+
+/**
+ * @struct gist_xlog_page_update
+ * @brief Represents a page update in a GIST index.
+ *
+ * Contains the number of deleted offsets and the number of inserted tuples.
+ */
+struct gist_xlog_page_update
+{
+    uint16_t ntodelete;   /**< Number of deleted offsets. */
+    uint16_t ntoinsert;   /**< Number of tuples to insert. */
+
+    /* In payload of blk 0: 1. todelete OffsetNumbers, 2. tuples to insert */
+};
+
+/**
+ * @struct gist_xlog_delete_v15
+ * @brief Represents a delete operation in a GIST index (version 15).
+ *
+ * This structure contains information necessary for deleting tuples from a GIST index page.
+ * It includes the ID of the latest removed transaction and the number of offsets to be deleted.
+ *
+ * Fields:
+ * - latestRemovedXid: The transaction ID of the latest transaction that has been removed from the page.
+ *                     This ID is used for conflict resolution during recovery.
+ * - ntodelete: The number of offsets that are marked for deletion within the GIST index page.
+ */
+struct gist_xlog_delete_v15
+{
+    transaction_id latestRemovedXid;     /**< ID of the latest removed transaction */
+    uint16_t ntodelete;                  /**< Number of offsets to delete */
+
+    /*
+     * The offsets to delete will be included in the payload of block 0
+     */
+};
+
+/**
+ * @struct gist_xlog_delete_v16
+ * @brief Represents a delete operation in a GIST index (version 16).
+ *
+ * This structure is used to describe a delete operation in a GIST index page.
+ * It includes fields for handling snapshot conflict horizons, the number of offsets to delete,
+ * and a flag to indicate whether the operation is on a catalog relation. This structure is used
+ * during logical decoding and recovery operations to manage conflicts and ensure data integrity.
+ *
+ * Fields:
+ * - snapshot_conflict_horizon_id: The transaction ID horizon up to which snapshot conflicts need to be handled.
+ *                            This is important for ensuring that the recovery process can detect conflicts
+ *                            between transactions during logical decoding on standby servers.
+ * - ntodelete: The number of offsets that are to be deleted within the GIST index page.
+ * - is_catalog_rel: A flag indicating whether the delete operation involves a catalog relation.
+ *                 This flag is used to handle conflicts during logical decoding on standby servers.
+ * - offsets: An array to store the offset numbers of the tuples that are to be deleted from the GIST index page.
+ *            This field is marked with FLEXIBLE_ARRAY_MEMBER to allow flexibility in the number of offsets.
+ */
+struct gist_xlog_delete_v16
+{
+    transaction_id snapshotConflictHorizon;        /**< Horizon for conflict handling in snapshot */
+    uint16_t ntodelete;                            /**< Number of offsets to delete */
+    uint8_t is_catalog_rel;                        /**< Boolean to handle recovery conflict during logical decoding on standby */
+
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];  /**< Array of offset numbers to delete */
+};
+
+/**
+ * @struct gist_xlog_delete
+ * @brief Wrapper structure for GIST index delete records.
+ *
+ * Contains version-specific delete record data and function pointers for parsing and formatting.
+ */
+struct gist_xlog_delete
+{
+    void (*parse)(struct gist_xlog_delete* wrapper, const void* rec);    /**< Parsing function pointer */
+    char* (*format)(struct gist_xlog_delete* wrapper, char* buf);        /**< Formatting function pointer */
+    union {
+        struct gist_xlog_delete_v15 v15;                                 /**< Version 15 structure */
+        struct gist_xlog_delete_v16 v16;                                 /**< Version 16 structure */
+    } data;                                                              /**< Version-specific delete record data */
+};
+
+
+/**
+ * @struct gist_xlog_page_split
+ * @brief Represents a page split operation in a GIST index.
+ *
+ * Contains information about the original right link, original NSN, and the number of pages in the split.
+ *
+ * Fields:
+ * - origrlink: The original right link of the page before the split.
+ * - orignsn: The original NSN (Next Sequential Number) of the page before the split.
+ * - origleaf: A flag indicating whether the original page was a leaf page.
+ * - npage: The number of pages involved in the split operation.
+ * - markfollowright: A flag to set the F_FOLLOW_RIGHT flag, indicating that the split
+ *                    page should be followed by future inserts or splits.
+ */
+struct gist_xlog_page_split
+{
+    block_number origrlink;          /**< Right link of the page before split. */
+    gist_nsn orignsn;                /**< NSN of the page before split. */
+    bool origleaf;                   /**< Was the split page a leaf page? */
+    uint16_t npage;                  /**< Number of pages in the split. */
+    bool markfollowright;            /**< Set F_FOLLOW_RIGHT flags. */
+
+    /* Follow: 1. gistxlogPage and array of IndexTupleData per page */
+};
+
+/**
+ * @struct gist_xlog_page_delete
+ * @brief Represents a page delete operation in a GIST index.
+ *
+ * Contains the full transaction ID and the offset of the downlink referencing this page.
+ *
+ * Fields:
+ * - deleteXid: The full transaction ID of the last transaction that could see the page during a scan.
+ * - downlinkOffset: The offset of the downlink in the parent page that references this page.
+ */
+struct gist_xlog_page_delete
+{
+    struct full_transaction_id deleteXid;        /**< Last Xid which could see page in scan. */
+    offset_number downlinkOffset;                /**< Offset of downlink referencing this page. */
+};
+
+#define SIZE_OF_GISTXLOG_PAGE_DELETE (offsetof(struct gist_xlog_page_delete, downlinkOffset) + sizeof(OffsetNumber))
+
+/**
+ * @struct gist_xlog_page_reuse_v15
+ * @brief Represents a page reuse operation in a GIST index (version 15).
+ *
+ * Contains information necessary to reuse a page in a GIST index during hot standby.
+ *
+ * Fields:
+ * - node: The RelFileNode identifying the relation.
+ * - block: The block number being reused.
+ * - latestRemovedFullXid: The full transaction ID of the latest removed transaction.
+ */
+struct gist_xlog_page_reuse_v15
+{
+    struct rel_file_node node;                       /**< RelFileNode for the page. */
+    block_number block;                              /**< Block number being reused. */
+    struct full_transaction_id latestRemovedFullXid; /**< Latest removed full transaction ID. */
+};
+
+/**
+ * @struct gist_xlog_page_reuse_v16
+ * @brief Represents a page reuse operation in a GIST index (version 16).
+ *
+ * Contains information necessary to reuse a page in a GIST index during hot standby,
+ * including handling recovery conflicts during logical decoding on standby.
+ *
+ * Fields:
+ * - locator: The RelFileLocator identifying the relation.
+ * - block: The block number being reused.
+ * - snapshot_conflict_horizon_id: The transaction ID horizon for conflict handling in snapshot.
+ * - is_catalog_rel: A flag indicating whether the operation involves a catalog relation,
+ *                 to handle recovery conflict during logical decoding on standby.
+ */
+struct gist_xlog_page_reuse_v16 {
+    struct rel_file_locator locator;                         /**< RelFileLocator for the page. */
+    block_number block;                                      /**< Block number being reused. */
+    struct full_transaction_id snapshot_conflict_horizon;    /**< Horizon for conflict handling in snapshot */
+    bool is_catalog_rel;                                     /**< Boolean to handle recovery conflict during logical decoding on standby */
+};
+
+/**
+ * @struct gist_xlog_page_reuse
+ * @brief Wrapper structure for GIST index page reuse records.
+ *
+ * Contains version-specific page reuse record data and function pointers for parsing and formatting.
+ */
+struct gist_xlog_page_reuse {
+    void (*parse)(struct gist_xlog_page_reuse* wrapper, const void* rec); /**< Parsing function pointer */
+    char* (*format)(struct gist_xlog_page_reuse* wrapper, char* buf);     /**< Formatting function pointer */
+    union {
+        struct gist_xlog_page_reuse_v15 v15;                              /**< Version 15 structure */
+        struct gist_xlog_page_reuse_v16 v16;                              /**< Version 16 structure */
+    } data;                                                               /**< Version-specific page reuse record data */
+};
+
+
+/**
+ * @brief Creates a new gist_xlog_delete structure.
+ *
+ * @return A pointer to the newly created gist_xlog_delete structure.
+ */
+struct gist_xlog_delete*
+create_gist_xlog_delete(void);
+
+/**
+ * @brief Parses a version 15 GIST index delete record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+pgmoneta_wal_parse_gist_xlog_delete_v15(struct gist_xlog_delete* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 16 GIST index delete record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+pgmoneta_wal_parse_gist_xlog_delete_v16(struct gist_xlog_delete* wrapper, const void* rec);
+
+/**
+ * @brief Formats a version 15 GIST index delete record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_gist_xlog_delete_v15(struct gist_xlog_delete* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 16 GIST index delete record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_gist_xlog_delete_v16(struct gist_xlog_delete* wrapper, char* buf);
+
+/**
+ * @brief Describes a GIST index operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the GIST operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_gist_desc(char* buf, struct decoded_xlog_record* record);
+
+/**
+ * @brief Creates a new gist_xlog_page_reuse structure.
+ *
+ * @return A pointer to the newly created gist_xlog_page_reuse structure.
+ */
+struct gist_xlog_page_reuse*
+create_gist_xlog_page_reuse(void);
+
+/**
+ * @brief Parses a version 15 GIST index page reuse record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+pgmoneta_wal_parse_gist_xlog_page_reuse_v15(struct gist_xlog_page_reuse* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 16 GIST index page reuse record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+pgmoneta_wal_parse_gist_xlog_page_reuse_v16(struct gist_xlog_page_reuse* wrapper, const void* rec);
+
+/**
+ * @brief Formats a version 15 GIST index page reuse record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_gist_xlog_page_reuse_v15(struct gist_xlog_page_reuse* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 16 GIST index page reuse record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_gist_xlog_page_reuse_v16(struct gist_xlog_page_reuse* wrapper, char* buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_GIST_H

--- a/src/include/wal/walfile/rm_hash.h
+++ b/src/include/wal/walfile/rm_hash.h
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_HASH_H
+#define PGMONETA_RM_HASH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/wal_reader.h>
+
+typedef oid reg_procedure;
+
+
+/* XLOG records for hash operations */
+#define XLOG_HASH_INIT_META_PAGE               0x00  /**< Initialize the meta page. */
+#define XLOG_HASH_INIT_BITMAP_PAGE             0x10  /**< Initialize the bitmap page. */
+#define XLOG_HASH_INSERT                       0x20  /**< Add index tuple without split. */
+#define XLOG_HASH_ADD_OVFL_PAGE                0x30  /**< Add overflow page. */
+#define XLOG_HASH_SPLIT_ALLOCATE_PAGE          0x40  /**< Allocate new page for split. */
+#define XLOG_HASH_SPLIT_PAGE                   0x50  /**< Split page. */
+#define XLOG_HASH_SPLIT_COMPLETE               0x60  /**< Completion of split operation. */
+#define XLOG_HASH_MOVE_PAGE_CONTENTS           0x70  /**< Remove tuples from one page and add to another page. */
+#define XLOG_HASH_SQUEEZE_PAGE                 0x80  /**< Add tuples to one of the previous pages in chain and free the overflow page. */
+#define XLOG_HASH_DELETE                       0x90  /**< Delete index tuples from a page. */
+#define XLOG_HASH_SPLIT_CLEANUP                0xA0  /**< Clear split-cleanup flag in primary bucket page. */
+#define XLOG_HASH_UPDATE_META_PAGE             0xB0  /**< Update meta page after vacuum. */
+#define XLOG_HASH_VACUUM_ONE_PAGE              0xC0  /**< Remove dead tuples from index page. */
+
+#define XLH_SPLIT_META_UPDATE_MASKS            (1 << 0)
+#define XLH_SPLIT_META_UPDATE_SPLITPOINT       (1 << 1)
+
+/**
+ * @struct xl_hash_insert
+ * @brief Represents a simple insert operation (without split) in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_INSERT operation.
+ */
+struct xl_hash_insert
+{
+    offset_number offnum;  /**< Offset where the tuple is inserted. */
+};
+
+/**
+ * @struct xl_hash_add_ovfl_page
+ * @brief Represents the addition of an overflow page in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_ADD_OVFL_PAGE operation.
+ */
+struct xl_hash_add_ovfl_page
+{
+    uint16_t bmsize;        /**< Size of the bitmap. */
+    bool bmpage_found;      /**< Indicates if a bitmap page was found. */
+};
+
+/**
+ * @struct xl_hash_split_allocate_page
+ * @brief Represents the allocation of a page for a split operation in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_SPLIT_ALLOCATE_PAGE operation.
+ */
+struct xl_hash_split_allocate_page
+{
+    uint32_t new_bucket;        /**< New bucket number. */
+    uint16_t old_bucket_flag;   /**< Flag for the old bucket. */
+    uint16_t new_bucket_flag;   /**< Flag for the new bucket. */
+    uint8_t flags;              /**< Additional flags for the split operation. */
+};
+
+/**
+ * @struct xl_hash_split_complete
+ * @brief Represents the completion of a split operation in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_SPLIT_COMPLETE operation.
+ */
+struct xl_hash_split_complete
+{
+    uint16_t old_bucket_flag;  /**< Flag for the old bucket. */
+    uint16_t new_bucket_flag;  /**< Flag for the new bucket. */
+};
+
+/**
+ * @struct xl_hash_move_page_contents
+ * @brief Represents the movement of page contents during a squeeze operation in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_MOVE_PAGE_CONTENTS operation.
+ */
+struct xl_hash_move_page_contents
+{
+    uint16_t ntups;                    /**< Number of tuples moved. */
+    bool is_prim_bucket_same_wrt;      /**< Indicates if the primary bucket page is the same as the page to which tuples are moved. */
+};
+
+/**
+ * @struct xl_hash_squeeze_page
+ * @brief Represents a squeeze page operation in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_SQUEEZE_PAGE operation.
+ */
+struct xl_hash_squeeze_page
+{
+    block_number prevblkno;             /**< Block number of the previous page. */
+    block_number nextblkno;             /**< Block number of the next page.     */
+    uint16_t ntups;                     /**< Number of tuples moved.            */
+    bool is_prim_bucket_same_wrt;       /**< Indicates if the primary bucket page is the same as the page to which tuples are moved. */
+    bool is_prev_bucket_same_wrt;       /**< Indicates if the previous page is the same as the page to which tuples are moved. */
+};
+
+/**
+ * @struct xl_hash_delete
+ * @brief Represents the deletion of index tuples from a page in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_DELETE operation.
+ */
+struct xl_hash_delete
+{
+    bool clear_dead_marking;      /**< Indicates if the LH_PAGE_HAS_DEAD_TUPLES flag is cleared. */
+    bool is_primary_bucket_page;  /**< Indicates if the operation is for the primary bucket page. */
+};
+
+/**
+ * @struct xl_hash_update_meta_page
+ * @brief Represents an update to the meta page of a hash index.
+ *
+ * This data record is used for the XLOG_HASH_UPDATE_META_PAGE operation.
+ */
+struct xl_hash_update_meta_page
+{
+    double ntuples;  /**< Number of tuples in the meta page. */
+};
+
+/**
+ * @struct xl_hash_init_meta_page
+ * @brief Represents the initialization of the meta page of a hash index.
+ *
+ * This data record is used for the XLOG_HASH_INIT_META_PAGE operation.
+ */
+struct xl_hash_init_meta_page
+{
+    double num_tuples;         /**< Initial number of tuples. */
+    reg_procedure procid;      /**< Procedure ID. */
+    uint16_t ffactor;          /**< Fill factor. */
+};
+
+/**
+ * @struct xl_hash_init_bitmap_page
+ * @brief Represents the initialization of a bitmap page in a hash index.
+ *
+ * This data record is used for the XLOG_HASH_INIT_BITMAP_PAGE operation.
+ */
+struct xl_hash_init_bitmap_page
+{
+    uint16_t bmsize;  /**< Size of the bitmap. */
+};
+
+/**
+ * @struct xl_hash_vacuum_one_page_v15
+ * @brief Represents a vacuum operation on a single page in a hash index for version 15.
+ *
+ * This data record is used for the XLOG_HASH_VACUUM_ONE_PAGE operation in version 15.
+ */
+struct xl_hash_vacuum_one_page_v15
+{
+    transaction_id latestRemovedXid;   /**< Latest removed transaction ID. */
+    int ntuples;                       /**< Number of tuples to vacuum. */
+    /* TARGET OFFSET NUMBERS FOLLOW AT THE END */
+};
+
+/**
+ * @struct xl_hash_vacuum_one_page_v16
+ * @brief Represents a vacuum operation on a single page in a hash index for version 16.
+ *
+ * This data record is used for the XLOG_HASH_VACUUM_ONE_PAGE operation in version 16.
+ */
+struct xl_hash_vacuum_one_page_v16
+{
+    transaction_id snaphost_conflict_horizon;         /**< Snapshot conflict horizon. */
+    uint16_t ntuples;                                 /**< Number of tuples to vacuum. */
+    bool is_catalog_rel;                              /**< Indicates if the relation is a catalog relation. */
+    /* TARGET OFFSET NUMBERS */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];     /**< Array of target offset numbers. */
+};
+
+/**
+ * @struct xl_hash_vacuum_one_page
+ * @brief Wrapper struct to handle different versions of xl_hash_vacuum_one_page.
+ */
+struct xl_hash_vacuum_one_page
+{
+    void (*parse)(struct xl_hash_vacuum_one_page* wrapper, const void* rec);  /**< Function pointer to parse the record */
+    char* (*format)(struct xl_hash_vacuum_one_page* wrapper, char* buf);      /**< Function pointer to format the record */
+    union {
+        struct xl_hash_vacuum_one_page_v15 v15;                               /**< Version 15 */
+        struct xl_hash_vacuum_one_page_v16 v16;                               /**< Version 16 */
+    } data;                                                                   /**< Version-specific data. */
+};
+
+/**
+ * Describes a hash index operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the hash operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_hash_desc(char* buf, struct decoded_xlog_record* record);
+
+/**
+ * Create a new xl_hash_vacuum_one_page structure.
+ *
+ * This function allocates and initializes a new instance of the
+ * xl_hash_vacuum_one_page structure.
+ *
+ * @return A pointer to the newly created xl_hash_vacuum_one_page structure.
+ */
+struct xl_hash_vacuum_one_page*
+pgmoneta_wal_create_xl_hash_vacuum_one_page(void);
+
+/**
+ * Parse a WAL record of type xl_hash_vacuum_one_page for PostgreSQL version 15.
+ *
+ * This function parses the WAL record data and populates the provided
+ * xl_hash_vacuum_one_page structure with the extracted information.
+ *
+ * @param wrapper A pointer to the xl_hash_vacuum_one_page structure to populate.
+ * @param rec A pointer to the raw WAL record data to be parsed.
+ */
+void
+pgmoneta_wal_parse_xl_hash_vacuum_one_page_v15(struct xl_hash_vacuum_one_page* wrapper, const void* rec);
+
+/**
+ * Parse a WAL record of type xl_hash_vacuum_one_page for PostgreSQL version 16.
+ *
+ * This function parses the WAL record data and populates the provided
+ * xl_hash_vacuum_one_page structure with the extracted information.
+ *
+ * @param wrapper A pointer to the xl_hash_vacuum_one_page structure to populate.
+ * @param rec A pointer to the raw WAL record data to be parsed.
+ */
+void
+pgmoneta_wal_parse_xl_hash_vacuum_one_page_v16(struct xl_hash_vacuum_one_page* wrapper, const void* rec);
+
+/**
+ * Format the xl_hash_vacuum_one_page structure for PostgreSQL version 15 into a string.
+ *
+ * This function formats the contents of the provided xl_hash_vacuum_one_page
+ * structure into a human-readable string and stores it in the provided buffer.
+ *
+ * @param wrapper A pointer to the xl_hash_vacuum_one_page structure to format.
+ * @param buf A pointer to the buffer where the formatted string will be stored.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char*
+pgmoneta_wal_format_xl_hash_vacuum_one_page_v15(struct xl_hash_vacuum_one_page* wrapper, char* buf);
+
+/**
+ * Format the xl_hash_vacuum_one_page structure for PostgreSQL version 16 into a string.
+ *
+ * This function formats the contents of the provided xl_hash_vacuum_one_page
+ * structure into a human-readable string and stores it in the provided buffer.
+ *
+ * @param wrapper A pointer to the xl_hash_vacuum_one_page structure to format.
+ * @param buf A pointer to the buffer where the formatted string will be stored.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char*
+pgmoneta_wal_format_xl_hash_vacuum_one_page_v16(struct xl_hash_vacuum_one_page* wrapper, char* buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_HASH_H

--- a/src/include/wal/walfile/rm_heap.h
+++ b/src/include/wal/walfile/rm_heap.h
@@ -1,0 +1,647 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_HEAP_H
+#define PGMONETA_RM_HEAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <stdint.h>
+
+// Typedefs
+/**
+ * @typedef command_id
+ * @brief A type definition for a command ID.
+ */
+typedef uint32_t command_id;
+
+// Define variables
+#define XLOG_HEAP_INSERT                 0x00
+#define XLOG_HEAP_DELETE                 0x10
+#define XLOG_HEAP_UPDATE                 0x20
+#define XLOG_HEAP_TRUNCATE               0x30
+#define XLOG_HEAP_HOT_UPDATE             0x40
+#define XLOG_HEAP_CONFIRM                0x50
+#define XLOG_HEAP_LOCK                   0x60
+#define XLOG_HEAP_INPLACE                0x70
+
+#define XLOG_HEAP_OPMASK                 0x70
+#define XLOG_HEAP_INIT_PAGE              0x80
+
+#define XLOG_HEAP2_REWRITE               0x00
+#define XLOG_HEAP2_PRUNE                 0x10
+#define XLOG_HEAP2_VACUUM                0x20
+#define XLOG_HEAP2_FREEZE_PAGE           0x30
+#define XLOG_HEAP2_VISIBLE               0x40
+#define XLOG_HEAP2_MULTI_INSERT          0x50
+#define XLOG_HEAP2_LOCK_UPDATED          0x60
+#define XLOG_HEAP2_NEW_CID               0x70
+
+#define XLOG_HEAP2_PRUNE_ON_ACCESS       0x10
+#define XLOG_HEAP2_PRUNE_VACUUM_SCAN     0x20
+#define XLOG_HEAP2_PRUNE_VACUUM_CLEANUP  0x30
+#define XLOG_HEAP2_VISIBLE               0x40
+#define XLOG_HEAP2_MULTI_INSERT          0x50
+#define XLOG_HEAP2_LOCK_UPDATED          0x60
+#define XLOG_HEAP2_NEW_CID               0x70
+
+#define XLHL_XMAX_IS_MULTI               0x01
+#define XLHL_XMAX_LOCK_ONLY              0x02
+#define XLHL_XMAX_EXCL_LOCK              0x04
+#define XLHL_XMAX_KEYSHR_LOCK            0x08
+#define XLHL_KEYS_UPDATED                0x10
+
+// Define variables
+#define XLOG_HEAP_INSERT                 0x00
+#define XLOG_HEAP_DELETE                 0x10
+#define XLOG_HEAP_UPDATE                 0x20
+#define XLOG_HEAP_TRUNCATE               0x30
+#define XLOG_HEAP_HOT_UPDATE             0x40
+#define XLOG_HEAP_CONFIRM                0x50
+#define XLOG_HEAP_LOCK                   0x60
+#define XLOG_HEAP_INPLACE                0x70
+
+#define XLOG_HEAP_OPMASK                 0x70
+#define XLOG_HEAP_INIT_PAGE              0x80
+
+#define XLOG_HEAP2_REWRITE               0x00
+#define XLOG_HEAP2_PRUNE                 0x10
+#define XLOG_HEAP2_VACUUM                0x20
+#define XLOG_HEAP2_FREEZE_PAGE           0x30
+#define XLOG_HEAP2_VISIBLE               0x40
+#define XLOG_HEAP2_MULTI_INSERT          0x50
+#define XLOG_HEAP2_LOCK_UPDATED          0x60
+#define XLOG_HEAP2_NEW_CID               0x70
+
+// V17 and later
+#define XLOG_HEAP2_PRUNE_ON_ACCESS       0x10
+#define XLOG_HEAP2_PRUNE_VACUUM_SCAN     0x20
+#define XLOG_HEAP2_PRUNE_VACUUM_CLEANUP  0x30
+#define XLOG_HEAP2_VISIBLE               0x40
+#define XLOG_HEAP2_MULTI_INSERT          0x50
+#define XLOG_HEAP2_LOCK_UPDATED          0x60
+#define XLOG_HEAP2_NEW_CID               0x70
+
+#define XLHL_XMAX_IS_MULTI               0x01
+#define XLHL_XMAX_LOCK_ONLY              0x02
+#define XLHL_XMAX_EXCL_LOCK              0x04
+#define XLHL_XMAX_KEYSHR_LOCK            0x08
+#define XLHL_KEYS_UPDATED                0x10
+
+// To handle recovery conflict during logical decoding on standby
+#define XLHP_IS_CATALOG_REL              (1 << 1)
+
+// Does replaying the record require a cleanup-lock?
+#define XLHP_CLEANUP_LOCK                (1 << 2)
+
+// If we remove or freeze any entries that contain xids, we need to include a snapshot conflict horizon.
+#define XLHP_HAS_CONFLICT_HORIZON        (1 << 3)
+
+// Indicates that an xlhp_freeze_plans sub-record and one or more xlhp_freeze_plan sub-records are present.
+#define XLHP_HAS_FREEZE_PLANS            (1 << 4)
+
+// XLHP_HAS_REDIRECTIONS, XLHP_HAS_DEAD_ITEMS, and XLHP_HAS_NOW_UNUSED_ITEMS indicate that xlhp_prune_items sub-records with redirected, dead, and unused item offsets are present.
+#define XLHP_HAS_REDIRECTIONS            (1 << 5)
+#define XLHP_HAS_DEAD_ITEMS              (1 << 6)
+#define XLHP_HAS_NOW_UNUSED_ITEMS        (1 << 7)
+
+// xlhp_freeze_plan describes how to freeze a group of one or more heap tuples (appears in xl_heap_prune's xlhp_freeze_plans sub-record)
+/* 0x01 was XLH_FREEZE_XMIN */
+#define XLH_FREEZE_XVAC                  0x02
+#define XLH_INVALID_XVAC                 0x04
+
+#define XLH_TRUNCATE_CASCADE             (1 << 0)
+#define XLH_TRUNCATE_RESTART_SEQS        (1 << 1)
+
+
+#define SizeOfHeapPruneV17 (offsetof(struct xl_heap_prune_v17, flags) + sizeof(uint8_t))
+
+// Struct definitions
+/**
+ * @struct xl_heap_insert
+ * @brief Represents an insert operation in the heap.
+ *
+ * Contains the offset number for the inserted tuple and associated flags.
+ */
+struct xl_heap_insert {
+    offset_number offnum;    /**< Inserted tuple's offset. */
+    uint8_t flags;           /**< Flags associated with the insert operation. */
+};
+
+/**
+ * @struct xl_heap_delete
+ * @brief Represents a delete operation in the heap.
+ *
+ * Contains the transaction ID of the deleted tuple, offset number, and associated flags.
+ */
+struct xl_heap_delete {
+    transaction_id xmax;             /**< Transaction ID of the deleted tuple. */
+    offset_number offnum;            /**< Deleted tuple's offset.              */
+    uint8_t infobits_set;            /**< Infomask bits.                       */
+    uint8_t flags;                   /**< Flags associated with the delete operation. */
+};
+
+/**
+ * @struct xl_heap_update
+ * @brief Represents an update operation in the heap.
+ *
+ * Contains the transaction IDs and offsets for both the old and new tuples, along with associated flags.
+ */
+struct xl_heap_update {
+    transaction_id old_xmax;         /**< Transaction ID of the old tuple. */
+    offset_number old_offnum;        /**< Old tuple's offset.              */
+    uint8_t old_infobits_set;        /**< Infomask bits to set on old tuple. */
+    uint8_t flags;                   /**< Flags associated with the update operation. */
+    transaction_id new_xmax;         /**< Transaction ID of the new tuple. */
+    offset_number new_offnum;        /**< New tuple's offset.              */
+};
+
+/**
+ * @struct xl_heap_truncate
+ * @brief Represents a truncate operation in the heap.
+ *
+ * Contains the database ID, number of relation IDs, associated flags, and the array of relation IDs.
+ */
+struct xl_heap_truncate {
+    oid dbId;                          /**< Database ID. */
+    uint32_t nrelids;                  /**< Number of relation IDs. */
+    uint8_t flags;                     /**< Flags associated with the truncate operation. */
+    oid relids[FLEXIBLE_ARRAY_MEMBER]; /**< Array of relation IDs. */
+};
+
+
+/**
+ * @struct xl_heap_confirm
+ * @brief Represents a confirmation of speculative insertion in the heap.
+ *
+ * Contains the offset number for the confirmed tuple.
+ */
+struct xl_heap_confirm {
+    offset_number offnum;    /**< Confirmed tuple's offset on page. */
+};
+
+/**
+ * @struct xl_heap_lock
+ * @brief Represents a lock operation in the heap.
+ *
+ * Contains the locking transaction ID, offset number, infomask bits, and associated flags.
+ */
+struct xl_heap_lock {
+    transaction_id locking_xid;    /**< Transaction ID of the locking operation. */
+    offset_number offnum;          /**< Locked tuple's offset on page.           */
+    int8_t infobits_set;           /**< Infomask and infomask2 bits to set.     */
+    uint8_t flags;                 /**< Flags associated with the lock operation. */
+};
+
+/**
+ * @struct xl_heap_inplace
+ * @brief Represents an in-place update operation in the heap.
+ *
+ * Contains the offset number for the updated tuple.
+ */
+struct xl_heap_inplace {
+    offset_number offnum;    /**< Updated tuple's offset on page. */
+    /* TUPLE DATA FOLLOWS AT END OF STRUCT */
+};
+
+/**
+ * @struct xl_heap_prune_v17
+ * @brief Represents a prune operation in the heap (version 17).
+ *
+ * Contains reason and flags for the prune operation.
+ */
+struct xl_heap_prune_v17 {
+    uint8_t reason;    /**< Reason for pruning. */
+    uint8_t flags;     /**< Flags for pruning operation. */
+    /* If XLHP_HAS_CONFLICT_HORIZON is set, the conflict horizon XID follows, unaligned */
+};
+
+/**
+ * @struct xl_heap_prune_v16
+ * @brief Represents a prune operation in the heap (version 16).
+ *
+ * Contains transaction ID for snapshot conflict horizon, number of redirected and dead tuples, and a flag indicating if it's a catalog relation.
+ */
+struct xl_heap_prune_v16 {
+    transaction_id snapshotConflictHorizon;      /**< Conflict horizon XID. */
+    uint16_t nredirected;                        /**< Number of redirected tuples. */
+    uint16_t ndead;                              /**< Number of dead tuples. */
+    bool is_catalog_rel;                         /**< Is this a catalog relation. */
+    /* OFFSET NUMBERS are in the block reference 0 */
+};
+
+/**
+ * @struct xl_heap_prune_v15
+ * @brief Represents a prune operation in the heap (version 15).
+ *
+ * Contains transaction ID for the latest removed tuple, number of redirected and dead tuples.
+ */
+struct xl_heap_prune_v15 {
+    transaction_id latestRemovedXid;    /**< Latest removed XID. */
+    uint16_t nredirected;               /**< Number of redirected tuples. */
+    uint16_t ndead;                     /**< Number of dead tuples. */
+    /* OFFSET NUMBERS are in the block reference 0 */
+};
+
+/**
+ * @struct xl_heap_prune_v14
+ * @brief Represents a prune operation in the heap (version 14).
+ *
+ * Contains transaction ID for the latest removed tuple, number of redirected and dead tuples.
+ */
+struct xl_heap_prune_v14 {
+    transaction_id latestRemovedXid;    /**< Latest removed XID. */
+    uint16_t nredirected;               /**< Number of redirected tuples. */
+    uint16_t ndead;                     /**< Number of dead tuples. */
+    /* OFFSET NUMBERS are in the block reference 0 */
+};
+
+/**
+ * @struct xl_heap_clean_v13
+ * @brief Represents a cleaning operation in the heap (version 13).
+ *
+ * Similar to prune but named differently.
+ * Contains transaction ID for the latest removed tuple, number of redirected and dead tuples.
+ */
+struct xl_heap_clean_v13 {
+    transaction_id latestRemovedXid;    /**< Latest removed XID. */
+    uint16_t nredirected;               /**< Number of redirected tuples. */
+    uint16_t ndead;                     /**< Number of dead tuples. */
+    /* OFFSET NUMBERS are in the block reference 0 */
+};
+
+/**
+ * @struct xl_heap_prune
+ * @brief Wrapper structure to handle different versions of prune operations in the heap.
+ *
+ * Contains a union for version-specific data and function pointers for parsing and formatting records.
+ */
+struct xl_heap_prune {
+    void (*parse)(struct xl_heap_prune* wrapper, const void* rec);    /**< Function pointer to parse the record */
+    char* (*format)(struct xl_heap_prune* wrapper, char* buf);        /**< Function pointer to format the record */
+    union
+    {
+        struct xl_heap_prune_v17 v17;                                 /**< Prune operation for version 17 */
+        struct xl_heap_prune_v16 v16;                                 /**< Prune operation for version 16 */
+        struct xl_heap_prune_v15 v15;                                 /**< Prune operation for version 15 */
+        struct xl_heap_prune_v14 v14;                                 /**< Prune operation for version 14 */
+        struct xl_heap_clean_v13 v13;                                 /**< Prune operation for version 13 (named clean) */
+    } data;                                                           /**< Version-specific prune data */
+};
+
+/**
+ * @struct xl_heap_vacuum
+ * @brief Represents a vacuum operation in the heap.
+ *
+ * Contains the number of unused items.
+ */
+struct xl_heap_vacuum {
+    uint16_t nunused;    /**< Number of unused items. */
+};
+
+/**
+ * @struct xl_heap_visible
+ * @brief Represents the setting of a visibility map bit in the heap.
+ *
+ * Contains the cutoff transaction ID and associated flags.
+ */
+struct xl_heap_visible {
+    transaction_id cutoff_xid;    /**< Cutoff transaction ID. */
+    uint8_t flags;                /**< Flags associated with the visibility operation. */
+};
+
+/**
+ * @struct xl_heap_freeze_page_v15
+ * @brief Represents a heap freeze operation for version 15.
+ *
+ * This structure is used in WAL records to describe freezing of tuples in heap pages for version 15.
+ */
+struct xl_heap_freeze_page_v15 {
+    transaction_id cutoff_xid;  /**< Transaction ID cutoff for freezing tuples. */
+    uint16_t ntuples;           /**< Number of tuples to freeze. */
+};
+
+/**
+ * @struct xl_heap_freeze_page_v16
+ * @brief Represents a heap freeze operation for version 16.
+ *
+ * This structure is used in WAL records to describe freezing of tuples in heap pages for version 16.
+ */
+struct xl_heap_freeze_page_v16 {
+    transaction_id snapshot_conflict_horizon;  /**< Transaction ID snapshot conflict horizon. */
+    uint16_t nplans;                           /**< Number of freeze plans. */
+    bool is_catalog_rel;                       /**< Indicates if the relation is a catalog relation. */
+};
+
+/**
+ * @struct xl_heap_freeze_page
+ * @brief Wrapper structure to handle different versions of heap freeze operation.
+ *
+ * This structure allows for handling different versions of heap freeze operations using a union.
+ */
+struct xl_heap_freeze_page {
+    void (*parse)(struct xl_heap_freeze_page* wrapper, const void* rec); /**< Parse function pointer.    */
+    char* (*format)(struct xl_heap_freeze_page* wrapper, char* buf);     /**< Format function pointer.  */
+    union {
+        struct xl_heap_freeze_page_v15 v15;                              /**< Version 15 heap freeze structure. */
+        struct xl_heap_freeze_page_v16 v16;                              /**< Version 16 heap freeze structure. */
+    } data;                                                              /**< Version-specific data.    */
+};
+
+
+/**
+ * @struct xl_heap_new_cid
+ * @brief Represents a new command ID operation in the heap.
+ *
+ * Contains the top-level transaction ID, command IDs, and the target relfilenode and ctid.
+ */
+struct xl_heap_new_cid {
+    transaction_id             top_xid;     /**< Top-level transaction ID. */
+    command_id                 cmin;        /**< Minimum command ID. */
+    command_id                 cmax;        /**< Maximum command ID. */
+    command_id                 combocid;    /**< Combined command ID (for debugging).*/
+    struct rel_file_node       target_node; /**< Target relfilenode. */
+    struct item_pointer_data   target_tid;  /**< Target ctid. */
+};
+
+/**
+ * @struct xl_heap_multi_insert
+ * @brief Represents a multi-insert operation in the heap.
+ *
+ * Contains flags, number of tuples, and an array of offsets for the tuples.
+ */
+struct xl_heap_multi_insert {
+    uint8_t flags;                                   /**< Flags associated with the multi-insert operation. */
+    uint16_t ntuples;                                /**< Number of tuples to insert. */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];    /**< Array of tuple offsets. */
+};
+
+/**
+ * @struct xl_heap_lock_updated
+ * @brief Represents a lock operation on an updated version of a row in the heap.
+ *
+ * Contains the transaction ID, offset number, infomask bits, and associated flags.
+ */
+struct xl_heap_lock_updated {
+    transaction_id xmax;           /**< Transaction ID of the locking operation. */
+    offset_number offnum;          /**< Offset of the locked tuple on page.      */
+    uint8_t infobits_set;          /**< Infomask bits to set.                    */
+    uint8_t flags;                 /**< Flags associated with the lock operation. */
+};
+
+/**
+ * @struct xlhp_freeze_plan
+ * @brief Represents a freeze plan for heap tuples.
+ *
+ * Contains transaction ID, infomask, and associated flags for the freeze operation.
+ */
+struct xlhp_freeze_plan {
+    transaction_id xmax;         /**< Transaction ID for freezing. */
+    uint16_t t_infomask2;        /**< Second infomask value. */
+    uint16_t t_infomask;         /**< First infomask value. */
+    uint8_t frzflags;            /**< Flags for freeze operation. */
+    uint16_t ntuples;            /**< Number of tuples affected. */
+};
+
+/**
+ * @struct xlhp_freeze_plans
+ * @brief Represents a collection of freeze plans for heap tuples.
+ *
+ * Contains the number of freeze plans and an array of freeze plans.
+ */
+struct xlhp_freeze_plans {
+    uint16_t nplans;                                        /**< Number of freeze plans. */
+    struct xlhp_freeze_plan plans[FLEXIBLE_ARRAY_MEMBER];   /**< Array of freeze plans. */
+};
+
+/**
+ * @struct xlhp_prune_items
+ * @brief Represents a collection of prune items for heap tuples.
+ *
+ * Contains the number of prune items and an array of offsets for the items.
+ */
+struct xlhp_prune_items {
+    uint16_t ntargets;                           /**< Number of prune items. */
+    offset_number data[FLEXIBLE_ARRAY_MEMBER];   /**< Array of prune item offsets. */
+};
+
+/**
+ * @struct xl_heap_cleanup_info
+ * @brief Represents cleanup information for the heap.
+ *
+ * Contains the latest removed transaction ID.
+ */
+struct xl_heap_cleanup_info {
+    struct rel_file_node node;        /**< RelFileNode of the relation */
+    transaction_id latestRemovedXid;  /**< Latest removed transaction ID */
+};
+
+// Function declarations
+/**
+ * @brief Creates a new xl_heap_prune structure.
+ *
+ * @return A pointer to the newly created xl_heap_prune structure.
+ */
+struct xl_heap_prune* create_xl_heap_prune(void);
+
+/**
+ * @brief Parses a version 17 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void xl_heap_prune_parse_v17(struct xl_heap_prune* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 16 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void xl_heap_prune_parse_v16(struct xl_heap_prune* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 15 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void xl_heap_prune_parse_v15(struct xl_heap_prune* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 14 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void xl_heap_prune_parse_v14(struct xl_heap_prune* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 13 clean record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void xl_heap_prune_parse_v13(struct xl_heap_prune* wrapper, const void* rec);
+
+/**
+ * @brief Formats a version 17 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* xl_heap_prune_format_v17(struct xl_heap_prune* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 16 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* xl_heap_prune_format_v16(struct xl_heap_prune* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 15 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* xl_heap_prune_format_v15(struct xl_heap_prune* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 14 prune record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* xl_heap_prune_format_v14(struct xl_heap_prune* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 13 clean record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char* xl_heap_prune_format_v13(struct xl_heap_prune* wrapper, char* buf);
+
+/**
+ * @brief Describes a heap operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the heap operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char* pgmoneta_wal_heap_desc(char* buf, struct decoded_xlog_record* record);
+
+/**
+ * @brief Describes a heap2 operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the heap2 operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char* pgmoneta_wal_heap2_desc(char* buf, struct decoded_xlog_record* record);
+
+/**
+ * @brief Deserializes prune and freeze operations for the heap.
+ *
+ * @param cursor The cursor position within the XLOG record.
+ * @param flags Flags indicating the presence of certain operations.
+ * @param nplans Pointer to store the number of freeze plans.
+ * @param plans Pointer to store the freeze plans array.
+ * @param frz_offsets Pointer to store the freeze offsets array.
+ * @param nredirected Pointer to store the number of redirected items.
+ * @param redirected Pointer to store the redirected items array.
+ * @param ndead Pointer to store the number of dead items.
+ * @param nowdead Pointer to store the dead items array.
+ * @param nunused Pointer to store the number of unused items.
+ * @param nowunused Pointer to store the unused items array.
+ */
+void heap_xlog_deserialize_prune_and_freeze(char* cursor, uint8_t flags,
+                                            int* nplans, struct xlhp_freeze_plan** plans,
+                                            offset_number** frz_offsets,
+                                            int* nredirected, offset_number** redirected,
+                                            int* ndead, offset_number** nowdead,
+                                            int* nunused, offset_number** nowunused);
+
+/**
+ * Creates a new xl_heap_freeze_page structure.
+ *
+ * @return A pointer to the newly created xl_heap_freeze_page structure.
+ */
+struct xl_heap_freeze_page* pgmoneta_wal_create_xl_heap_freeze_page(void);
+
+/**
+ * Parses a version 15 xl_heap_freeze_page structure.
+ *
+ * @param wrapper The wrapper structure containing the union of different versions.
+ * @param rec The raw data to parse.
+ */
+void pgmoneta_wal_parse_xl_heap_freeze_page_v15(struct xl_heap_freeze_page* wrapper, const void* rec);
+
+/**
+ * Parses a version 16 xl_heap_freeze_page structure.
+ *
+ * @param wrapper The wrapper structure containing the union of different versions.
+ * @param rec The raw data to parse.
+ */
+void pgmoneta_wal_parse_xl_heap_freeze_page_v16(struct xl_heap_freeze_page* wrapper, const void* rec);
+
+/**
+ * Formats a version 15 xl_heap_freeze_page structure.
+ *
+ * @param wrapper The wrapper structure containing the union of different versions.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char* pgmoneta_wal_format_xl_heap_freeze_page_v15(struct xl_heap_freeze_page* wrapper, char* buf);
+
+/**
+ * Formats a version 16 xl_heap_freeze_page structure.
+ *
+ * @param wrapper The wrapper structure containing the union of different versions.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char* pgmoneta_wal_format_xl_heap_freeze_page_v16(struct xl_heap_freeze_page* wrapper, char* buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_HEAP_H

--- a/src/include/wal/walfile/rm_logicalmsg.h
+++ b/src/include/wal/walfile/rm_logicalmsg.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_LOGICALMSG_H
+#define PGMONETA_RM_LOGICALMSG_H
+
+#include <wal/walfile/wal_reader.h>
+
+#define XLOG_LOGICAL_MESSAGE  0x00
+
+/**
+ * @struct xl_logical_message
+ * @brief Represents a logical message in WAL.
+ *
+ * This structure holds the information of a logical message
+ * that is stored in the WAL, including the database OID,
+ * whether the message is transactional, and the message content.
+ */
+struct xl_logical_message
+{
+   oid db_id;                /**< OID of the database the message was emitted from. */
+   bool transactional;      /**< Indicates if the message is transactional. */
+   size_t prefix_size;      /**< Length of the message prefix. */
+   size_t message_size;     /**< Size of the message content. */
+   char message[FLEXIBLE_ARRAY_MEMBER];  /**< The message payload, including the null-terminated prefix. */
+};
+
+/**
+ * Describes a logical message from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the logical message.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_logicalmsg_desc(char* buf, struct decoded_xlog_record* record);
+
+#endif // PGMONETA_RM_LOGICALMSG_H

--- a/src/include/wal/walfile/rm_mxact.h
+++ b/src/include/wal/walfile/rm_mxact.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_MXACT_H
+#define PGMONETA_RM_MXACT_H
+
+#include <wal/walfile/wal_reader.h>
+
+#define XLOG_MULTIXACT_ZERO_OFF_PAGE  0x00
+#define XLOG_MULTIXACT_ZERO_MEM_PAGE  0x10
+#define XLOG_MULTIXACT_CREATE_ID      0x20
+#define XLOG_MULTIXACT_TRUNCATE_ID    0x30
+
+/**
+ * @enum MULTI_XACT_STATUS
+ * @brief Enumeration of possible multixact lock modes.
+ *
+ * These modes represent the lock statuses that can be assigned to a tuple
+ * within a multixact transaction.
+ */
+enum MULTI_XACT_STATUS
+{
+    MULTI_XACT_STATUS_FOR_KEY_SHARE    = 0x00,  /**< FOR KEY SHARE lock mode. */
+    MULTI_XACT_STATUS_FOR_SHARE        = 0x01,  /**< FOR SHARE lock mode. */
+    MULTI_XACT_STATUS_FOR_NO_KEY_UPDATE = 0x02, /**< FOR NO KEY UPDATE lock mode. */
+    MULTI_XACT_STATUS_FOR_UPDATE       = 0x03,  /**< FOR UPDATE lock mode. */
+    MULTI_XACT_STATUS_NO_KEY_UPDATE    = 0x04,  /**< Update that doesn't touch "key" columns. */
+    MULTI_XACT_STATUS_UPDATE           = 0x05   /**< Other updates and delete operations. */
+};
+
+/**
+ * @struct multi_xact_member
+ * @brief Represents a member of a multixact.
+ *
+ * This structure holds a transaction ID and the corresponding lock status.
+ */
+struct multi_xact_member
+{
+    transaction_id xid;                /**< Transaction ID of the member. */
+    enum MULTI_XACT_STATUS status;     /**< Lock status of the member. */
+};
+
+/**
+ * @struct xl_multixact_create
+ * @brief Represents the creation of a multixact in XLOG.
+ *
+ * This structure holds the information necessary to create a new multixact,
+ * including the multixact ID, starting offset, and member XIDs.
+ */
+struct xl_multixact_create
+{
+    multi_xact_id mid;                                        /**< New MultiXact's ID. */
+    multi_xact_offset moff;                                   /**< Starting offset in the members file. */
+    int32_t nmembers;                                         /**< Number of member XIDs. */
+    struct multi_xact_member members[FLEXIBLE_ARRAY_MEMBER];  /**< Array of multixact members. */
+};
+
+/**
+ * @struct xl_multixact_truncate
+ * @brief Represents a multixact truncation in XLOG.
+ *
+ * This structure holds the information required to truncate multixacts,
+ * including the oldest database OID and the range of offsets and members to be truncated.
+ */
+struct xl_multixact_truncate
+{
+    oid oldest_multi_db;                       /**< OID of the oldest database with active multixacts. */
+    multi_xact_id start_trunc_off;             /**< Starting offset for truncation (for completeness). */
+    multi_xact_id end_trunc_off;               /**< Ending offset for truncation. */
+    multi_xact_offset start_trunc_memb;        /**< Starting member offset for truncation. */
+    multi_xact_offset end_trunc_memb;          /**< Ending member offset for truncation. */
+};
+
+/**
+ * Describes a multixact operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the multixact operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_multixact_desc(char* buf, struct decoded_xlog_record* record);
+
+#endif // PGMONETA_RM_MXACT_H

--- a/src/include/wal/walfile/rm_relmap.h
+++ b/src/include/wal/walfile/rm_relmap.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_RELMAP_H
+#define PGMONETA_RM_RELMAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+#define XLOG_RELMAP_UPDATE    0x00 /**< XLOG opcode for relation map update. */
+
+/**
+ * @struct xl_relmap_update
+ * @brief Represents a relation map update operation in XLOG.
+ *
+ * Contains the database ID, tablespace ID, size of the relation map data,
+ * and the relation map data itself.
+ */
+struct xl_relmap_update
+{
+    oid db_id;                         /**< Database ID, or 0 for shared map. */
+    oid ts_id;                         /**< Database's tablespace ID, or pg_global. */
+    int32_t nbytes;                    /**< Size of the relation map data. */
+    char data[FLEXIBLE_ARRAY_MEMBER];  /**< Relation map data. */
+};
+
+/**
+ * Describes a relation map update operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the relation map update operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_relmap_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_RELMAP_H

--- a/src/include/wal/walfile/rm_replorigin.h
+++ b/src/include/wal/walfile/rm_replorigin.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_REPLORIGIN_H
+#define PGMONETA_RM_REPLORIGIN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+#define INVALID_REP_ORIGIN_ID 0            /**< Invalid replication origin ID. */
+#define XLOG_REPLORIGIN_SET   0x00         /**< XLOG opcode for setting a replication origin. */
+#define XLOG_REPLORIGIN_DROP  0x10         /**< XLOG opcode for dropping a replication origin. */
+
+/**
+ * @struct xl_replorigin_set
+ * @brief Represents a replication origin set operation in XLOG.
+ *
+ * Contains the remote LSN, replication origin ID, and a flag indicating
+ * whether the operation should be forced.
+ */
+struct xl_replorigin_set {
+    xlog_rec_ptr remote_lsn;  /**< Remote LSN associated with the replication origin. */
+    rep_origin_id node_id;    /**< Replication origin ID. */
+    bool force;               /**< Indicates if the operation should be forced. */
+};
+
+/**
+ * @struct xl_replorigin_drop
+ * @brief Represents a replication origin drop operation in XLOG.
+ *
+ * Contains the replication origin ID of the node being dropped.
+ */
+struct xl_replorigin_drop {
+    rep_origin_id node_id;  /**< Replication origin ID of the node being dropped. */
+};
+
+/**
+ * Describes a replication origin operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the replication origin operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_replorigin_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_REPLORIGIN_H

--- a/src/include/wal/walfile/rm_seq.h
+++ b/src/include/wal/walfile/rm_seq.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_SEQ_H
+#define PGMONETA_RM_SEQ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+#define XLOG_SEQ_LOG  0x00 /**< XLOG opcode for sequence log operation. */
+
+/**
+ * @struct xl_seq_rec
+ * @brief Represents a sequence record in XLOG.
+ *
+ * Contains the relation file node for the sequence.
+ * The sequence tuple data follows this structure.
+ */
+struct xl_seq_rec
+{
+   struct rel_file_node node;  /**< Relation file node for the sequence. */
+   /* SEQUENCE TUPLE DATA FOLLOWS AT THE END */
+};
+
+/**
+ * Describes a sequence operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the sequence operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_seq_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_SEQ_H

--- a/src/include/wal/walfile/rm_spgist.h
+++ b/src/include/wal/walfile/rm_spgist.h
@@ -1,0 +1,256 @@
+#ifndef PGMONETA_RM_SPGIST_H
+#define PGMONETA_RM_SPGIST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Include pgmoneta-related headers */
+#include <wal/walfile/rm.h>
+#include <wal/walfile/wal_reader.h>
+
+/* Define macros */
+#define XLOG_SPGIST_ADD_LEAF         0x10 /**< XLOG opcode for adding a leaf node in SPGiST. */
+#define XLOG_SPGIST_MOVE_LEAFS       0x20 /**< XLOG opcode for moving leaf nodes in SPGiST. */
+#define XLOG_SPGIST_ADD_NODE         0x30 /**< XLOG opcode for adding a node in SPGiST. */
+#define XLOG_SPGIST_SPLIT_TUPLE      0x40 /**< XLOG opcode for splitting a tuple in SPGiST. */
+#define XLOG_SPGIST_PICKSPLIT        0x50 /**< XLOG opcode for picking and splitting tuples in SPGiST. */
+#define XLOG_SPGIST_VACUUM_LEAF      0x60 /**< XLOG opcode for vacuuming leaf nodes in SPGiST. */
+#define XLOG_SPGIST_VACUUM_ROOT      0x70 /**< XLOG opcode for vacuuming root nodes in SPGiST. */
+#define XLOG_SPGIST_VACUUM_REDIRECT  0x80 /**< XLOG opcode for vacuuming redirect pointers in SPGiST. */
+
+
+/**
+ * @struct spg_xlog_state
+ * @brief Represents the state needed by some SPGiST redo functions.
+ *
+ * Contains the transaction ID and a flag indicating if the operation is during index build.
+ */
+struct spg_xlog_state
+{
+    transaction_id my_xid;  /**< Transaction ID of the current operation. */
+    bool is_build;          /**< Indicates if the operation is during index build. */
+};
+
+/**
+ * @struct spg_xlog_add_leaf
+ * @brief Represents an operation to add a leaf node in SPGiST.
+ *
+ * Contains information about the destination page, parent page, and
+ * the offsets for the leaf tuple and head tuple in the chain.
+ */
+struct spg_xlog_add_leaf
+{
+    bool new_page;                   /**< Indicates if the destination page is new. */
+    bool stores_nulls;               /**< Indicates if the page is in the nulls tree. */
+    offset_number offnum_leaf;       /**< Offset where the leaf tuple is placed. */
+    offset_number offnum_head_leaf;  /**< Offset of the head tuple in the chain, if any. */
+    offset_number offnum_parent;     /**< Offset where the parent downlink is, if any. */
+    uint16_t node_i;                 /**< Index of the node in the parent. */
+    /* New leaf tuple follows (unaligned!). */
+};
+
+/**
+ * @struct spg_xlog_move_leafs
+ * @brief Represents an operation to move leaf nodes in SPGiST.
+ *
+ * Contains information about the source and destination pages, parent page,
+ * and the state of the source page.
+ */
+struct spg_xlog_move_leafs
+{
+    uint16_t n_moves;                              /**< Number of tuples moved from the source page. */
+    bool new_page;                                 /**< Indicates if the destination page is new. */
+    bool replace_dead;                             /**< Indicates if a dead source tuple is being replaced. */
+    bool stores_nulls;                             /**< Indicates if the pages are in the nulls tree. */
+    offset_number offnum_parent;                   /**< Offset where the parent downlink is. */
+    uint16_t node_i;                               /**< Index of the node in the parent. */
+    struct spg_xlog_state state_src;               /**< State of the source page. */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];  /**< Array of tuple offsets. */
+};
+
+/**
+ * @struct spg_xlog_add_node
+ * @brief Represents an operation to add a node in SPGiST.
+ *
+ * Contains information about the original page, new page, and parent page.
+ */
+struct spg_xlog_add_node
+{
+    offset_number offnum;              /**< Offset of the original inner tuple on the original page. */
+    offset_number offnum_new;          /**< Offset of the new tuple on the new page. */
+    bool new_page;                     /**< Indicates if the new page is initialized. */
+    int8_t parent_blk;                 /**< Indicates which page the parent downlink is on. */
+    offset_number offnum_parent;       /**< Offset within the parent page. */
+    uint16_t node_i;                   /**< Index of the node in the parent. */
+    struct spg_xlog_state state_src;   /**< State of the source page. */
+    /* Updated inner tuple follows (unaligned!). */
+};
+
+/**
+ * @struct spg_xlog_split_tuple
+ * @brief Represents an operation to split a tuple in SPGiST.
+ *
+ * Contains information about the prefix and postfix tuples and the pages they are stored on.
+ */
+struct spg_xlog_split_tuple
+{
+    offset_number offnum_prefix;   /**< Offset where the prefix tuple goes. */
+    offset_number offnum_postfix;  /**< Offset where the postfix tuple goes. */
+    bool new_page;                 /**< Indicates if the page is initialized. */
+    bool postfix_blk_same;         /**< Indicates if the postfix tuple is on the same page as the prefix. */
+    /* New prefix and postfix inner tuples follow (unaligned!). */
+};
+
+/**
+ * @struct spg_xlog_pick_split
+ * @brief Represents an operation to pick and split tuples in SPGiST.
+ *
+ * Contains information about the source, destination, inner, and parent pages.
+ */
+struct spg_xlog_pick_split
+{
+    bool is_root_split;                            /**< Indicates if this is a root split. */
+    uint16_t n_delete;                             /**< Number of tuples to delete from the source. */
+    uint16_t n_insert;                             /**< Number of tuples to insert on the source and/or destination. */
+    bool init_src;                                 /**< Indicates if the source page is re-initialized. */
+    bool init_dest;                                /**< Indicates if the destination page is re-initialized. */
+    offset_number offnum_inner;                    /**< Offset where the new inner tuple goes. */
+    bool init_inner;                               /**< Indicates if the inner page is re-initialized. */
+    bool stores_nulls;                             /**< Indicates if the pages are in the nulls tree. */
+    bool inner_is_parent;                          /**< Indicates if the inner page is the parent page. */
+    offset_number offnum_parent;                   /**< Offset within the parent page. */
+    uint16_t node_i;                               /**< Index of the node in the parent. */
+    struct spg_xlog_state state_src;               /**< State of the source page. */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];  /**< Array of tuple offsets. */
+};
+
+/**
+ * @struct spg_xlog_vacuum_leaf
+ * @brief Represents an operation to vacuum leaf nodes in SPGiST.
+ *
+ * Contains information about the tuples to be marked as DEAD, placeholders, moved, or re-chained.
+ */
+struct spg_xlog_vacuum_leaf
+{
+    uint16_t n_dead;                               /**< Number of tuples to be marked as DEAD. */
+    uint16_t n_placeholder;                        /**< Number of tuples to be marked as PLACEHOLDER. */
+    uint16_t n_move;                               /**< Number of tuples to be moved. */
+    uint16_t n_chain;                              /**< Number of tuples to be re-chained. */
+    struct spg_xlog_state state_src;               /**< State of the source page. */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];  /**< Array of tuple offsets. */
+};
+
+/**
+ * @struct spg_xlog_vacuum_root
+ * @brief Represents an operation to vacuum a root page when it is also a leaf in SPGiST.
+ *
+ * Contains information about the tuples to be deleted.
+ */
+struct spg_xlog_vacuum_root {
+    uint16_t n_delete;                             /**< Number of tuples to be deleted. */
+    struct spg_xlog_state state_src;               /**< State of the source page. */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];  /**< Array of tuple offsets. */
+};
+
+/**
+ * @struct spg_xlog_vacuum_redirect_v15
+ * @brief Represents the SP-GiST vacuum redirect operation in version 15.
+ *
+ * This structure is used in XLOG records for vacuuming redirects in a
+ * space-partitioned GiST (SP-GiST) index in version 15.
+ */
+struct spg_xlog_vacuum_redirect_v15 {
+    uint16_t nToPlaceholder;                       /**< Number of redirects to make placeholders. */
+    offset_number firstPlaceholder;                /**< First placeholder tuple to remove. */
+    transaction_id newestRedirectXid;              /**< Newest XID of removed redirects. */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];  /**< Offsets of redirect tuples to make placeholders. */
+};
+
+/**
+ * @struct spg_xlog_vacuum_redirect_v16
+ * @brief Represents the SP-GiST vacuum redirect operation in version 16.
+ *
+ * This structure is used in XLOG records for vacuuming redirects in a
+ * space-partitioned GiST (SP-GiST) index in version 16.
+ */
+struct spg_xlog_vacuum_redirect_v16 {
+    uint16_t n_to_placeholder;                     /**< Number of redirects to make placeholders. */
+    offset_number first_placeholder;               /**< First placeholder tuple to remove. */
+    transaction_id snapshot_conflict_horizon;      /**< Newest XID of removed redirects. */
+    bool is_catalog_rel;                           /**< Handle recovery conflict during logical decoding on standby. */
+    offset_number offsets[FLEXIBLE_ARRAY_MEMBER];  /**< Offsets of redirect tuples to make placeholders. */
+};
+
+/**
+ * @struct spg_xlog_vacuum_redirect
+ * @brief Wrapper structure for handling different versions of SP-GiST vacuum redirect.
+ *
+ * This structure wraps version-specific structures for easier handling of different
+ * SP-GiST vacuum redirect versions.
+ */
+struct spg_xlog_vacuum_redirect {
+    void (*parse)(struct spg_xlog_vacuum_redirect* wrapper, const void* rec); /**< Function pointer to parse the record. */
+    char* (*format)(struct spg_xlog_vacuum_redirect* wrapper, char* buf);     /**< Function pointer to format the record. */
+
+    union {
+        struct spg_xlog_vacuum_redirect_v15 v15;                              /**< Version 15 of the structure. */
+        struct spg_xlog_vacuum_redirect_v16 v16;                              /**< Version 16 of the structure. */
+    } data;                                                                   /**< Version-specific data. */
+};
+
+/* Functions */
+
+/**
+ * Describes an SPGiST operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the SPGiST operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_spg_desc(char* buf, struct decoded_xlog_record* record);
+
+/**
+ * Parse SP-GiST vacuum redirect XLOG record for version 15.
+ *
+ * @param wrapper The wrapper structure to populate.
+ * @param rec The raw XLOG record to parse.
+ */
+void
+pgmoneta_wal_parse_spg_xlog_vacuum_redirect_v15(struct spg_xlog_vacuum_redirect* wrapper, const void* rec);
+
+/**
+ * Parse SP-GiST vacuum redirect XLOG record for version 16.
+ *
+ * @param wrapper The wrapper structure to populate.
+ * @param rec The raw XLOG record to parse.
+ */
+void
+pgmoneta_wal_parse_spg_xlog_vacuum_redirect_v16(struct spg_xlog_vacuum_redirect* wrapper, const void* rec);
+
+/**
+ * Format the SP-GiST vacuum redirect XLOG record for version 15.
+ *
+ * @param wrapper The wrapper structure to format.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char*
+pgmoneta_wal_format_spg_xlog_vacuum_redirect_v15(struct spg_xlog_vacuum_redirect* wrapper, char* buf);
+
+/**
+ * Format the SP-GiST vacuum redirect XLOG record for version 16.
+ *
+ * @param wrapper The wrapper structure to format.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char*
+pgmoneta_wal_format_spg_xlog_vacuum_redirect_v16(struct spg_xlog_vacuum_redirect* wrapper, char* buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_SPGIST_H

--- a/src/include/wal/walfile/rm_standby.h
+++ b/src/include/wal/walfile/rm_standby.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_STANDBY_H
+#define PGMONETA_RM_STANDBY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/sinval.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <stdbool.h>
+
+#define XLOG_STANDBY_LOCK           0x00 /**< XLOG opcode for standby lock. */
+#define XLOG_RUNNING_XACTS          0x10 /**< XLOG opcode for running transactions. */
+#define XLOG_INVALIDATIONS          0x20 /**< XLOG opcode for invalidations. */
+
+/**
+ * @struct xl_standby_lock
+ * @brief Represents a standby lock record in XLOG.
+ *
+ * Contains the transaction ID of the holder of an AccessExclusiveLock,
+ * as well as the database and table OIDs.
+ */
+struct xl_standby_lock
+{
+    transaction_id xid;   /**< Transaction ID of the holder of AccessExclusiveLock. */
+    oid db_oid;           /**< Database OID containing the table. */
+    oid rel_oid;          /**< OID of the locked table. */
+};
+
+/**
+ * @struct xl_standby_locks
+ * @brief Represents multiple standby lock records in XLOG.
+ *
+ * Contains an array of standby lock records.
+ */
+struct xl_standby_locks {
+    int nlocks;                                           /**< Number of entries in the locks array. */
+    struct xl_standby_lock locks[FLEXIBLE_ARRAY_MEMBER];  /**< Array of standby lock records. */
+};
+
+/**
+ * @struct xl_running_xacts
+ * @brief Represents running transactions data in XLOG.
+ *
+ * Contains information about currently running transactions,
+ * including the next transaction ID, the oldest running transaction ID,
+ * and the latest completed transaction ID.
+ */
+struct xl_running_xacts {
+    int xcnt;                                    /**< Number of transaction IDs in xids[]. */
+    int subxcnt;                                 /**< Number of subtransaction IDs in xids[]. */
+    bool subxid_overflow;                        /**< Indicates if snapshot overflowed and subxids are missing. */
+    transaction_id next_xid;                     /**< Next transaction ID from TransamVariables->next_xid. */
+    transaction_id oldest_running_xid;           /**< Oldest running transaction ID (not oldestXmin). */
+    transaction_id latest_completed_xid;         /**< Latest completed transaction ID to set xmax. */
+    transaction_id xids[FLEXIBLE_ARRAY_MEMBER];  /**< Array of transaction IDs. */
+};
+
+/**
+ * @struct xl_invalidations
+ * @brief Represents invalidation messages in XLOG.
+ *
+ * Contains information about invalidation messages,
+ * including the database and tablespace IDs, and whether
+ * to invalidate relcache init files.
+ */
+struct xl_invalidations {
+    oid dbId;                                                       /**< Database ID. */
+    oid tsId;                                                       /**< Tablespace ID. */
+    bool relcacheInitFileInval;                                     /**< Indicates if relcache init files should be invalidated. */
+    int nmsgs;                                                      /**< Number of shared invalidation messages. */
+    union shared_invalidation_message msgs[FLEXIBLE_ARRAY_MEMBER];  /**< Array of invalidation messages. */
+};
+
+/**
+ * Describes a standby operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the standby operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_standby_desc(char* buf, struct decoded_xlog_record* record);
+
+/**
+ * Describes invalidation messages from a standby operation.
+ *
+ * @param buf The buffer to store the description.
+ * @param nmsgs The number of invalidation messages.
+ * @param msgs The array of invalidation messages.
+ * @param dbId The database ID.
+ * @param tsId The tablespace ID.
+ * @param rel_cache_init_file_inval Indicates if relcache init files should be invalidated.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_standby_desc_invalidations(char* buf, int nmsgs, union shared_invalidation_message* msgs, oid dbId, oid tsId,
+                                        bool rel_cache_init_file_inval);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_STANDBY_H

--- a/src/include/wal/walfile/rm_storage.h
+++ b/src/include/wal/walfile/rm_storage.h
@@ -1,0 +1,52 @@
+#ifndef PGMONETA_RM_STORAGE_H
+#define PGMONETA_RM_STORAGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+#define XLOG_SMGR_CREATE   0x10   /**< XLOG opcode for creating a storage manager file. */
+#define XLOG_SMGR_TRUNCATE 0x20   /**< XLOG opcode for truncating a storage manager file. */
+
+/**
+ * @struct xl_smgr_create
+ * @brief Represents a storage manager create operation in XLOG.
+ *
+ * Contains the relation file node and fork number for the created storage manager file.
+ */
+struct xl_smgr_create
+{
+    struct rel_file_node rnode;  /**< Relation file node information. */
+    enum fork_number forkNum;    /**< Fork number for the created file. */
+};
+
+/**
+ * @struct xl_smgr_truncate
+ * @brief Represents a storage manager truncate operation in XLOG.
+ *
+ * Contains the block number, relation file node, and flags indicating which components are truncated.
+ */
+struct xl_smgr_truncate
+{
+    block_number blkno;          /**< Block number from where the truncation starts. */
+    struct rel_file_node rnode;  /**< Relation file node information. */
+    int flags;                   /**< Flags indicating which components are truncated. */
+};
+
+/**
+ * @brief Describes a storage manager operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the storage manager operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_storage_desc(char* buf, struct decoded_xlog_record* record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RM_STORAGE_H

--- a/src/include/wal/walfile/rm_tablespace.h
+++ b/src/include/wal/walfile/rm_tablespace.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_TABLESPACE_H
+#define PGMONETA_RM_TABLESPACE_H
+
+#include <wal/walfile/wal_reader.h>
+
+/* XLOG stuff */
+#define XLOG_TBLSPC_CREATE    0x00       /**< XLOG opcode for creating a tablespace. */
+#define XLOG_TBLSPC_DROP      0x10       /**< XLOG opcode for dropping a tablespace. */
+
+/**
+ * @struct xl_tblspc_create_rec
+ * @brief Represents a tablespace creation record in XLOG.
+ *
+ * Contains the tablespace ID and the path to the tablespace.
+ */
+struct xl_tblspc_create_rec {
+    oid ts_id;                            /**< ID of the tablespace. */
+    char ts_path[FLEXIBLE_ARRAY_MEMBER];  /**< Null-terminated string containing the path to the tablespace. */
+};
+
+/**
+ * @struct xl_tblspc_drop_rec
+ * @brief Represents a tablespace drop record in XLOG.
+ *
+ * Contains the ID of the tablespace being dropped.
+ */
+struct xl_tblspc_drop_rec {
+    oid ts_id;                            /**< ID of the tablespace being dropped. */
+};
+
+/**
+ * Describes a tablespace operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the tablespace operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_tablespace_desc(char* buf, struct decoded_xlog_record* record);
+
+#endif /* PGMONETA_RM_TABLESPACE_H */
+

--- a/src/include/wal/walfile/rm_xact.h
+++ b/src/include/wal/walfile/rm_xact.h
@@ -1,0 +1,630 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_XACT_H
+#define PGMONETA_RM_XACT_H
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_xlog.h>
+#include <wal/walfile/sinval.h>
+#include <wal/walfile/wal_reader.h>
+
+#define GIDSIZE                                     200  /**< Maximum size of Global Transaction ID (including '\0'). */
+#define XLOG_XACT_OPMASK                            0x70 /**< Mask for filtering opcodes out of xl_info. */
+#define XLOG_XACT_HAS_INFO                          0x80 /**< Indicates if this record has a 'xinfo' field. */
+#define XLOG_XACT_COMMIT                            0x00
+#define XLOG_XACT_PREPARE                           0x10
+#define XLOG_XACT_ABORT                             0x20
+#define XLOG_XACT_COMMIT_PREPARED                   0x30
+#define XLOG_XACT_ABORT_PREPARED                    0x40
+#define XLOG_XACT_ASSIGNMENT                        0x50
+#define XLOG_XACT_INVALIDATIONS                     0x60
+
+#define XACT_XINFO_HAS_DBINFO                       (1U << 0)
+#define XACT_XINFO_HAS_SUBXACTS                     (1U << 1)
+#define XACT_XINFO_HAS_RELFILENODES                 (1U << 2)
+#define XACT_XINFO_HAS_INVALS                       (1U << 3)
+#define XACT_XINFO_HAS_TWOPHASE                     (1U << 4)
+#define XACT_XINFO_HAS_ORIGIN                       (1U << 5)
+#define XACT_XINFO_HAS_AE_LOCKS                     (1U << 6)
+#define XACT_XINFO_HAS_GID                          (1U << 7)
+#define XACT_XINFO_HAS_DROPPED_STATS                (1U << 8)
+
+#define XACT_COMPLETION_APPLY_FEEDBACK_FLAG         (1U << 29)
+#define XACT_COMPLETION_UPDATE_RELCACHE_FILE_FLAG   (1U << 30)
+#define XACT_COMPLETION_FORCE_SYNC_COMMIT_FLAG      (1U << 31)
+
+#define XACT_COMPLETION_APPLY_FEEDBACK(xinfo) \
+        ((xinfo & XACT_COMPLETION_APPLY_FEEDBACK_FLAG) != 0)
+#define XACT_COMPLETION_RELCACHE_INIT_FILE_INVAL(xinfo) \
+        ((xinfo & XACT_COMPLETION_UPDATE_RELCACHE_FILE_FLAG) != 0)
+#define XACT_COMPLETION_FORCE_SYNC_COMMIT(xinfo) \
+        ((xinfo & XACT_COMPLETION_FORCE_SYNC_COMMIT_FLAG) != 0)
+
+
+#define MIN_SIZE_OF_XACT_STATS_ITEMS    offsetof(struct xl_xact_stats_items, items)
+#define MIN_SIZE_OF_XACT_SUBXACTS       offsetof(struct xl_xact_subxacts, subxacts)
+#define MIN_SIZE_OF_XACT_RELFILENODES   offsetof(struct xl_xact_relfilenodes, xnodes)
+#define MIN_SIZE_OF_XACT_INVALS         offsetof(struct xl_xact_invals, msgs)
+#define MIN_SIZE_OF_XACT_COMMIT         (offsetof(struct xl_xact_commit, xact_time) + sizeof(timestamp_tz))
+#define MIN_SIZE_OF_XACT_ABORT          sizeof(struct xl_xact_abort)
+
+/**
+ * @struct xl_xact_stats_item
+ * @brief Represents a transaction statistic item.
+ *
+ * This structure holds information about a particular object within a transaction.
+ * Each object is represented by a kind, a database OID, and the object's OID.
+ *
+ * Fields:
+ * - kind: An integer that represents the type of transaction statistic being recorded.
+ *         This could refer to various types of transaction events, such as an insert, delete, or update.
+ * - dboid: The OID (Object Identifier) of the database in which the transaction is taking place.
+ *          The OID is a unique identifier used internally by the database to distinguish between different objects.
+ * - objoid: The OID of the specific object (table, index, etc.) that the transaction statistic pertains to.
+ *           This represents the target object of the operation within the transaction.
+ */
+struct xl_xact_stats_item
+{
+    int kind;         /**< Type of transaction statistic */
+    oid dboid;        /**< Database OID */
+    oid objoid;       /**< Object OID */
+};
+
+/**
+ * @struct xl_xact_stats_items
+ * @brief Represents a collection of transaction statistic items.
+ *
+ * This structure aggregates multiple transaction statistic items, which provide information
+ * about various objects affected by a transaction. It contains a count of the items and an
+ * array of individual transaction statistic items.
+ *
+ * Fields:
+ * - nitems: The number of transaction statistic items included in this structure.
+ * - items: A flexible array of `xl_xact_stats_item` structures, where each item represents
+ *          a particular object affected by the transaction. The flexible array member allows
+ *          for variable-length arrays of transaction statistic items.
+ */
+struct xl_xact_stats_items
+{
+    int nitems;                                              /**< Number of transaction statistic items */
+    struct xl_xact_stats_item items[FLEXIBLE_ARRAY_MEMBER];  /**< Array of transaction statistic items */
+};
+
+/**
+ * @struct xl_xact_assignment
+ * @brief Represents the assignment of a transaction ID in XLOG.
+ *
+ * Contains the top-level transaction ID and any associated subtransaction IDs.
+ */
+struct xl_xact_assignment
+{
+    transaction_id xtop;                        /**< Assigned XID's top-level XID. */
+    int nsubxacts;                              /**< Number of subtransaction XIDs. */
+    transaction_id xsub[FLEXIBLE_ARRAY_MEMBER]; /**< Array of assigned subxids. */
+};
+
+/**
+ * @struct xl_xact_xinfo
+ * @brief Represents extended transaction information in commit/abort records.
+ *
+ * Holds additional flags that indicate the presence of various pieces of
+ * information within a commit or abort record.
+ */
+struct xl_xact_xinfo
+{
+    uint32_t xinfo;  /**< Flags indicating additional information in the record. */
+};
+
+/**
+ * @struct xl_xact_dbinfo
+ * @brief Represents database information in a commit/abort record.
+ *
+ * Contains the database ID and tablespace ID associated with the transaction.
+ */
+struct xl_xact_dbinfo
+{
+    oid db_id;    /**< Database ID. */
+    oid ts_id;    /**< Tablespace ID. */
+};
+
+/**
+ * @struct xl_xact_subxacts
+ * @brief Represents subtransactions in a commit/abort record.
+ *
+ * Contains an array of subtransaction IDs.
+ */
+struct xl_xact_subxacts
+{
+    int nsubxacts;                                  /**< Number of subtransaction XIDs. */
+    transaction_id subxacts[FLEXIBLE_ARRAY_MEMBER]; /**< Array of subtransaction IDs. */
+};
+
+/**
+ * @struct xl_xact_relfilenodes
+ * @brief Represents relfilenodes in a commit/abort record.
+ *
+ * Contains an array of relfilenodes for the transaction.
+ */
+struct xl_xact_relfilenodes
+{
+    int nrels;                                          /**< Number of relations. */
+    struct rel_file_node xnodes[FLEXIBLE_ARRAY_MEMBER]; /**< Array of relation file nodes. */
+};
+
+/**
+ * @struct xl_xact_invals
+ * @brief Represents invalidation messages in a commit/abort record.
+ *
+ * Contains an array of shared invalidation messages.
+ */
+struct xl_xact_invals
+{
+    int nmsgs;                                                     /**< Number of shared invalidation messages. */
+    union shared_invalidation_message msgs[FLEXIBLE_ARRAY_MEMBER]; /**< Array of invalidation messages. */
+};
+
+/**
+ * @struct xl_xact_twophase
+ * @brief Represents two-phase commit information in a commit/abort record.
+ *
+ * Contains the transaction ID for a two-phase commit.
+ */
+struct xl_xact_twophase
+{
+    transaction_id xid;  /**< Transaction ID for the two-phase commit. */
+};
+
+/**
+ * @struct xl_xact_origin
+ * @brief Represents the origin of a transaction in a commit/abort record.
+ *
+ * Contains the LSN and timestamp of the transaction at the origin node.
+ */
+struct xl_xact_origin
+{
+    xlog_rec_ptr origin_lsn;         /**< LSN of this record at the origin node. */
+    timestamp_tz origin_timestamp;   /**< Timestamp of the transaction at the origin node. */
+};
+
+/**
+ * @struct xl_xact_commit
+ * @brief Represents a commit record in XLOG.
+ *
+ * Contains the timestamp of the commit and may include additional
+ * information depending on the flags in `xinfo`.
+ */
+struct xl_xact_commit
+{
+    timestamp_tz xact_time;  /**< Time of commit. */
+
+    /* Additional structures follow based on flags in `xinfo`:
+     * - xl_xact_xinfo
+     * - xl_xact_dbinfo
+     * - xl_xact_subxacts
+     * - xl_xact_relfilenodes
+     * - xl_xact_invals
+     * - xl_xact_twophase
+     * - twophase_gid
+     * - xl_xact_origin
+     */
+};
+
+/**
+ * @struct xl_xact_abort
+ * @brief Represents an abort record in XLOG.
+ *
+ * Contains the timestamp of the abort and may include additional
+ * information depending on the flags in `xinfo`.
+ */
+struct xl_xact_abort
+{
+    timestamp_tz xact_time;  /**< Time of abort. */
+
+    /* Additional structures follow based on flags in `xinfo`:
+     * - xl_xact_xinfo
+     * - xl_xact_dbinfo
+     * - xl_xact_subxacts
+     * - xl_xact_relfilenodes
+     * - xl_xact_twophase
+     * - twophase_gid
+     * - xl_xact_origin
+     */
+};
+
+/**
+ * @struct xl_xact_prepare_v14
+ * @brief Represents the prepared transaction record (version 14).
+ *
+ * This data record is used for the XLOG_XACT_PREPARE operation in version 14.
+ */
+struct xl_xact_prepare_v14 {
+    uint32_t magic;                   /**< Format identifier. */
+    uint32_t total_len;               /**< Actual file length. */
+    transaction_id xid;               /**< Original transaction XID. */
+    oid database;                     /**< OID of the database it was in. */
+    timestamp_tz prepared_at;         /**< Time of preparation. */
+    oid owner;                        /**< User running the transaction. */
+    int32_t nsubxacts;                /**< Number of following subxact XIDs. */
+    int32_t ncommitrels;              /**< Number of delete-on-commit rels. */
+    int32_t nabortrels;               /**< Number of delete-on-abort rels. */
+    int32_t ninvalmsgs;               /**< Number of cache invalidation messages. */
+    bool initfileinval;               /**< Does relcache init file need invalidation? */
+    uint16_t gidlen;                  /**< Length of the GID - GID follows the header. */
+    xlog_rec_ptr origin_lsn;          /**< LSN of this record at origin node. */
+    timestamp_tz origin_timestamp;    /**< Time of prepare at origin node. */
+};
+
+
+/**
+ * @struct xl_xact_prepare_v15
+ * @brief Represents the prepared transaction record (version 15).
+ *
+ * This data record is used for the XLOG_XACT_PREPARE operation in version 15.
+ */
+struct xl_xact_prepare_v15 {
+    uint32_t magic;                    /**< Format identifier. */
+    uint32_t total_len;                /**< Actual file length. */
+    transaction_id xid;                /**< Original transaction XID. */
+    oid database;                      /**< OID of the database it was in. */
+    timestamp_tz prepared_at;          /**< Time of preparation. */
+    oid owner;                         /**< User running the transaction. */
+    int32_t nsubxacts;                 /**< Number of following subxact XIDs. */
+    int32_t ncommitrels;               /**< Number of delete-on-commit rels. */
+    int32_t nabortrels;                /**< Number of delete-on-abort rels. */
+    int32_t ncommitstats;              /**< Number of stats to drop on commit. */
+    int32_t nabortstats;               /**< Number of stats to drop on abort. */
+    int32_t ninvalmsgs;                /**< Number of cache invalidation messages. */
+    bool initfileinval;                /**< Does relcache init file need invalidation? */
+    uint16_t gidlen;                   /**< Length of the GID - GID follows the header. */
+    xlog_rec_ptr origin_lsn;           /**< LSN of this record at origin node. */
+    timestamp_tz origin_timestamp;     /**< Time of prepare at origin node. */
+};
+
+
+/**
+ * @struct xl_xact_prepare
+ * @brief A wrapper for versioned structures of the prepared transaction record.
+ *
+ * This is used to handle multiple versions of the xl_xact_prepare structure.
+ */
+struct xl_xact_prepare {
+    void (*parse)(struct xl_xact_prepare* wrapper, const void* rec);        /**< Parsing function. */
+    char* (*format)(struct xl_xact_prepare* wrapper, char* rec, char* buf); /**< Formatting function. */
+    union {
+        struct xl_xact_prepare_v14 v14;                                     /**< Version 14 structure. */
+        struct xl_xact_prepare_v15 v15;                                     /**< Version 15 structure. */
+    } data;                                                                 /**< Union holding different structure versions. */
+};
+
+/**
+ * @struct xl_xact_parsed_commit_v14
+ * @brief Represents a parsed commit record from version 14.
+ *
+ * This structure holds details of a parsed commit operation in the transaction log.
+ */
+struct xl_xact_parsed_commit_v14 {
+    timestamp_tz xact_time;                  /**< Transaction commit timestamp. */
+    uint32_t xinfo;                          /**< Additional commit info flags. */
+
+    oid db_id;                               /**< Database ID for the transaction. */
+    oid ts_id;                               /**< Tablespace ID for the transaction. */
+
+    int nsubxacts;                           /**< Number of subtransactions. */
+    transaction_id* subxacts;                /**< Array of subtransaction IDs. */
+
+    int nrels;                               /**< Number of relations involved. */
+    struct rel_file_node* xnodes;            /**< Array of relation file nodes. */
+
+    int nmsgs;                               /**< Number of invalidation messages. */
+    union shared_invalidation_message* msgs; /**< Array of invalidation messages. */
+
+    transaction_id twophase_xid;             /**< 2PC transaction ID. */
+    char twophase_gid[GIDSIZE];              /**< Global ID for 2PC. */
+    int nabortrels;                          /**< Number of relations aborted in 2PC. */
+    struct rel_file_node* abortnodes;        /**< Array of aborted relation file nodes. */
+
+    xlog_rec_ptr origin_lsn;                 /**< Log sequence number of the origin. */
+    timestamp_tz origin_timestamp;           /**< Timestamp of the origin. */
+};
+
+
+typedef struct xl_xact_parsed_commit_v14 xl_xact_parsed_prepare_v14;
+
+/**
+ * @struct xl_xact_parsed_commit_v15
+ * @brief Represents a parsed commit record from version 15.
+ *
+ * This structure holds details of a parsed commit operation in the transaction log.
+ */
+struct xl_xact_parsed_commit_v15 {
+    timestamp_tz xact_time;                   /**< Transaction commit timestamp. */
+    uint32_t xinfo;                           /**< Additional commit info flags. */
+    oid db_id;                                /**< Database ID for the transaction. */
+    oid ts_id;                                /**< Tablespace ID for the transaction. */
+    int nsubxacts;                            /**< Number of subtransactions. */
+    transaction_id* subxacts;                 /**< Array of subtransaction IDs. */
+    int nrels;                                /**< Number of relations involved. */
+    struct rel_file_node* xnodes;             /**< Array of relation file nodes. */
+    int nstats;                               /**< Number of statistical records. */
+    struct xl_xact_stats_item* stats;         /**< Array of statistical records. */
+    int nmsgs;                                /**< Number of invalidation messages. */
+    union shared_invalidation_message* msgs;  /**< Array of invalidation messages. */
+    transaction_id twophase_xid;              /**< 2PC transaction ID. */
+    char twophase_gid[GIDSIZE];               /**< Global ID for 2PC. */
+    int nabortrels;                           /**< Number of relations aborted in 2PC. */
+    struct rel_file_node* abortnodes;         /**< Array of aborted relation file nodes. */
+    int nabortstats;                          /**< Number of aborted statistical records in 2PC. */
+    struct xl_xact_stats_item* abortstats;    /**< Array of aborted statistical records in 2PC. */
+    xlog_rec_ptr origin_lsn;                  /**< Log sequence number of the origin. */
+    timestamp_tz origin_timestamp;            /**< Timestamp of the origin. */
+};
+
+
+typedef struct xl_xact_parsed_commit_v15 xl_xact_parsed_prepare_v15;
+
+/**
+ * @struct xl_xact_parsed_commit
+ * @brief Wrapper structure for different versions of parsed commit records.
+ *
+ * This structure encapsulates version 14 and version 15 commit records.
+ */
+struct xl_xact_parsed_commit {
+    void (*parse)(struct xl_xact_parsed_commit* wrapper, const void* rec);          /**< Parsing function pointer. */
+    char* (*format)(struct xl_xact_parsed_commit* wrapper, char* rec, char* buf);   /**< Formatting function pointer. */
+    union {
+        struct xl_xact_parsed_commit_v14 v14;                                       /**< Parsed commit record for version 14. */
+        struct xl_xact_parsed_commit_v15 v15;                                       /**< Parsed commit record for version 15. */
+    } data;                                                                         /**< Union of parsed commit records. */
+};
+
+/**
+ * @struct xl_xact_parsed_abort_v14
+ * @brief Represents a parsed abort transaction in PostgreSQL (v14).
+ *
+ * This structure is used to store parsed transaction abort data for version 14.
+ */
+struct xl_xact_parsed_abort_v14 {
+    timestamp_tz xact_time;            /**< Transaction commit timestamp. */
+    uint32_t xinfo;                    /**< Additional info flags. */
+    oid dbId;                          /**< Database OID. */
+    oid tsId;                          /**< Tablespace OID. */
+    int nsubxacts;                     /**< Number of subtransactions. */
+    transaction_id* subxacts;          /**< Array of subtransaction IDs. */
+    int nrels;                         /**< Number of relations involved. */
+    struct rel_file_node* xnodes;      /**< Array of relation file nodes. */
+    transaction_id twophase_xid;       /**< Two-phase transaction ID. */
+    char twophase_gid[GIDSIZE];        /**< Two-phase transaction GID. */
+    xlog_rec_ptr origin_lsn;           /**< Replication origin LSN. */
+    timestamp_tz origin_timestamp;     /**< Replication origin timestamp. */
+};
+
+
+/**
+ * @struct xl_xact_parsed_abort_v15
+ * @brief Represents a parsed abort transaction in PostgreSQL (v15).
+ *
+ * This structure is used to store parsed transaction abort data for version 15.
+ */
+struct xl_xact_parsed_abort_v15 {
+    timestamp_tz xact_time;            /**< Transaction commit timestamp. */
+    uint32_t xinfo;                    /**< Additional info flags. */
+    oid db_id;                         /**< Database OID. */
+    oid ts_id;                         /**< Tablespace OID. */
+    int nsubxacts;                     /**< Number of subtransactions. */
+    transaction_id* subxacts;          /**< Array of subtransaction IDs. */
+    int nrels;                         /**< Number of relations involved. */
+    struct rel_file_node* xnodes;      /**< Array of relation file nodes. */
+    int nstats;                        /**< Number of statistical changes. */
+    struct xl_xact_stats_item* stats;  /**< Array of statistical changes. */
+    transaction_id twophase_xid;       /**< Two-phase transaction ID. */
+    char twophase_gid[GIDSIZE];        /**< Two-phase transaction GID. */
+    xlog_rec_ptr origin_lsn;           /**< Replication origin LSN. */
+    timestamp_tz origin_timestamp;     /**< Replication origin timestamp. */
+};
+
+
+/**
+ * @struct xl_xact_parsed_abort
+ * @brief Wrapper for handling different versions of parsed abort transactions.
+ *
+ * This structure provides a union for handling different versions of
+ * the parsed abort transaction data (v14 and v15).
+ */
+struct xl_xact_parsed_abort {
+    void (*parse)(struct xl_xact_parsed_abort* wrapper, const void* rec);        /**< Parse function pointer. */
+    char* (*format)(struct xl_xact_parsed_abort* wrapper, char* rec, char* buf); /**< Format function pointer. */
+    union {
+        struct xl_xact_parsed_abort_v14 v14;                                     /**< Parsed abort transaction data for version 14. */
+        struct xl_xact_parsed_abort_v15 v15;                                     /**< Parsed abort transaction data for version 15. */
+    } data;                                                                      /**< Union of parsed abort transaction data. */
+};
+
+
+/**
+ * Describes a transaction operation from a decoded XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record containing the transaction operation.
+ * @return A pointer to the buffer containing the description.
+ */
+char*
+pgmoneta_wal_xact_desc(char* buf, struct decoded_xlog_record* record);
+
+/**
+ * Parses a version 14 xl_xact_prepare record.
+ *
+ * @param wrapper The xl_xact_prepare wrapper.
+ * @param rec The record data to parse.
+ */
+void
+pgmoneta_wal_parse_xl_xact_prepare_v14(struct xl_xact_prepare* wrapper, const void* rec);
+
+/**
+ * Parses a version 15 xl_xact_prepare record.
+ *
+ * @param wrapper The xl_xact_prepare wrapper.
+ * @param rec The record data to parse.
+ */
+void
+pgmoneta_wal_parse_xl_xact_prepare_v15(struct xl_xact_prepare* wrapper, const void* rec);
+
+/**
+ * Formats a version 14 xl_xact_prepare record into a buffer.
+ *
+ * @param wrapper The xl_xact_prepare wrapper.
+ * @param buf The buffer to store the formatted result.
+ * @return The formatted buffer.
+ */
+char*
+pgmoneta_wal_format_xl_xact_prepare_v14(struct xl_xact_prepare* wrapper, char* rec, char* buf);
+
+/**
+ * Formats a version 15 xl_xact_prepare record into a buffer.
+ *
+ * @param wrapper The xl_xact_prepare wrapper.
+ * @param buf The buffer to store the formatted result.
+ * @return The formatted buffer.
+ */
+char*
+pgmoneta_wal_format_xl_xact_prepare_v15(struct xl_xact_prepare* wrapper, char* rec, char* buf);
+
+/**
+ * Initializes a parsed commit wrapper structure based on the server version.
+ *
+ * @return A pointer to the initialized xl_xact_parsed_commit structure.
+ */
+struct xl_xact_parsed_commit*
+pgmoneta_wal_create_xact_parsed_commit(void);
+
+/**
+ * Parses a commit record for version 14.
+ *
+ * @param wrapper The commit wrapper structure to populate.
+ * @param rec The raw commit record to parse.
+ */
+void
+pgmoneta_wal_parse_xact_commit_v14(struct xl_xact_parsed_commit* wrapper, const void* rec);
+
+/**
+ * Parses a commit record for version 15.
+ *
+ * @param wrapper The commit wrapper structure to populate.
+ * @param rec The raw commit record to parse.
+ */
+void
+pgmoneta_wal_parse_xact_commit_v15(struct xl_xact_parsed_commit* wrapper, const void* rec);
+
+/**
+ * Formats a commit record for version 14 into a human-readable string.
+ *
+ * @param wrapper The commit wrapper structure to format.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char*
+pgmoneta_wal_format_xact_commit_v14(struct xl_xact_parsed_commit* wrapper, char* rec, char* buf);
+
+/**
+ * Formats a commit record for version 15 into a human-readable string.
+ *
+ * @param wrapper The commit wrapper structure to format.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the buffer containing the formatted string.
+ */
+char*
+pgmoneta_wal_format_xact_commit_v15(struct xl_xact_parsed_commit* wrapper, char* rec, char* buf);
+
+/**
+ * Create a new xl_xact_parsed_abort structure.
+ *
+ * This function allocates and initializes a new xl_xact_parsed_abort structure,
+ * which is used to store parsed information about a transaction abort record
+ * in the Write-Ahead Logging (WAL).
+ *
+ * @return Pointer to the newly created xl_xact_parsed_abort structure.
+ */
+struct xl_xact_parsed_abort*
+pgmoneta_wal_create_xl_xact_parsed_abort(void);
+
+/**
+ * Parse a transaction abort record (v14).
+ *
+ * This function parses the transaction abort record for version 14 of the
+ * WAL and stores the parsed information in the provided xl_xact_parsed_abort
+ * structure.
+ *
+ * @param wrapper Pointer to the xl_xact_parsed_abort structure where the parsed data will be stored.
+ * @param rec Pointer to the raw WAL record to be parsed.
+ */
+void
+pgmoneta_wal_parse_xl_xact_parsed_abort_v14(struct xl_xact_parsed_abort* wrapper, const void* rec);
+
+/**
+ * Parse a transaction abort record (v15).
+ *
+ * This function parses the transaction abort record for version 15 of the
+ * WAL and stores the parsed information in the provided xl_xact_parsed_abort
+ * structure.
+ *
+ * @param wrapper Pointer to the xl_xact_parsed_abort structure where the parsed data will be stored.
+ * @param rec Pointer to the raw WAL record to be parsed.
+ */
+void
+pgmoneta_wal_parse_xl_xact_parsed_abort_v15(struct xl_xact_parsed_abort* wrapper, const void* rec);
+
+/**
+ * Format a transaction abort record (v14) as a string.
+ *
+ * This function formats the parsed transaction abort record for version 14
+ * of the WAL into a human-readable string and stores it in the provided buffer.
+ *
+ * @param wrapper Pointer to the xl_xact_parsed_abort structure containing the parsed data.
+ * @param rec Pointer to the raw WAL record.
+ * @param buf Buffer where the formatted string will be stored.
+ * @return Pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_xl_xact_parsed_abort_v14(struct xl_xact_parsed_abort* wrapper, char* rec, char* buf);
+
+/**
+ * Format a transaction abort record (v15) as a string.
+ *
+ * This function formats the parsed transaction abort record for version 15
+ * of the WAL into a human-readable string and stores it in the provided buffer.
+ *
+ * @param wrapper Pointer to the xl_xact_parsed_abort structure containing the parsed data.
+ * @param rec Pointer to the raw WAL record.
+ * @param buf Buffer where the formatted string will be stored.
+ * @return Pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_xl_xact_parsed_abort_v15(struct xl_xact_parsed_abort* wrapper, char* rec, char* buf);
+
+
+#endif // PGMONETA_RM_XACT_H

--- a/src/include/wal/walfile/rm_xlog.h
+++ b/src/include/wal/walfile/rm_xlog.h
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RM_XLOG_H
+#define PGMONETA_RM_XLOG_H
+
+#include <wal/walfile/wal_reader.h>
+
+#define MAXFNAMELEN                  64
+#define MAXDATELEN                   128
+#define UNIX_EPOCH_JDATE             2440588    /**< == date2j(1970, 1, 1) */
+#define POSTGRES_EPOCH_JDATE         2451545    /**< == date2j(2000, 1, 1) */
+#define SECS_PER_DAY                 86400
+
+#define INTpgmoneta_wal_64CONST(x)   (x ## L)
+#define USECS_PER_SEC                INTpgmoneta_wal_64CONST(1000000)
+
+/**
+ * @struct xl_parameter_change
+ * @brief Structure representing a change in parameters important for Hot Standby.
+ *
+ * Fields:
+ * - max_connections: Maximum number of connections.
+ * - max_worker_processes: Maximum number of worker processes.
+ * - max_wal_senders: Maximum number of WAL senders.
+ * - max_prepared_xacts: Maximum number of prepared transactions.
+ * - max_locks_per_xact: Maximum number of locks per transaction.
+ * - wal_level: WAL level.
+ * - wal_log_hints: WAL log hints.
+ * - track_commit_timestamp: Track commit timestamp.
+ */
+struct xl_parameter_change
+{
+    int max_connections;             /**< Maximum number of connections */
+    int max_worker_processes;        /**< Maximum number of worker processes */
+    int max_wal_senders;             /**< Maximum number of WAL senders */
+    int max_prepared_xacts;          /**< Maximum number of prepared transactions */
+    int max_locks_per_xact;          /**< Maximum number of locks per transaction */
+    int wal_level;                   /**< WAL level */
+    bool wal_log_hints;              /**< WAL log hints */
+    bool track_commit_timestamp;     /**< Track commit timestamp */
+};
+
+/**
+ * @struct xl_restore_point
+ * @brief Structure representing a restore point log.
+ *
+ * Fields:
+ * - rp_time: Restore point timestamp.
+ * - rp_name: Restore point name.
+ */
+struct xl_restore_point
+{
+    timestamp_tz rp_time;               /**< Restore point timestamp */
+    char rp_name[MAXFNAMELEN];          /**< Restore point name */
+};
+
+/**
+ * @struct xl_overwrite_contrecord
+ * @brief Structure representing an overwrite of a prior contrecord.
+ *
+ * Fields:
+ * - overwritten_lsn: Overwritten Log Sequence Number (LSN).
+ * - overwrite_time: Time of overwrite.
+ */
+struct xl_overwrite_contrecord
+{
+    xlog_rec_ptr overwritten_lsn;       /**< Overwritten Log Sequence Number (LSN) */
+    timestamp_tz overwrite_time;        /**< Time of overwrite */
+};
+
+/**
+ * @struct xl_end_of_recovery_v17
+ * @brief Structure representing the end of recovery log for version 17.
+ *
+ * Fields:
+ * - end_time: End time of recovery.
+ * - ThisTimeLineID: The new timeline ID.
+ * - PrevTimeLineID: The previous timeline ID.
+ * - wal_level: The WAL level.
+ */
+struct xl_end_of_recovery_v17
+{
+    timestamp_tz end_time;               /**< End time of recovery */
+    timeline_id this_timeline_id;        /**< New timeline ID */
+    timeline_id prev_timeline_id;        /**< Previous timeline ID */
+    int wal_level;                       /**< WAL level */
+};
+
+/**
+ * @struct xl_end_of_recovery_v16
+ * @brief Structure representing the end of recovery log for version 16.
+ *
+ * Fields:
+ * - end_time: End time of recovery.
+ * - ThisTimeLineID: The new timeline ID.
+ * - PrevTimeLineID: The previous timeline ID.
+ */
+struct xl_end_of_recovery_v16
+{
+    timestamp_tz end_time;               /**< End time of recovery */
+    timeline_id this_timeline_id;        /**< New timeline ID */
+    timeline_id prev_timeline_id;        /**< Previous timeline ID */
+};
+
+/**
+ * @struct xl_end_of_recovery
+ * @brief Wrapper structure to handle different versions of end of recovery logs.
+ *
+ * Fields:
+ * - data: A union containing version-specific recovery log data.
+ * - parse: Function pointer to parse the record.
+ * - format: Function pointer to format the record.
+ */
+struct xl_end_of_recovery
+{
+    void (*parse)(struct xl_end_of_recovery* wrapper, const void* rec);    /**< Function pointer to parse the record */
+    char* (*format)(struct xl_end_of_recovery* wrapper, char* buf);        /**< Function pointer to format the record */
+    union {
+        struct xl_end_of_recovery_v17 v17;                                 /**< End of recovery data for version 17 */
+        struct xl_end_of_recovery_v16 v16;                                 /**< End of recovery data for version 16 */
+    } data;                                                                /**< Version-specific recovery log data */
+};
+
+/**
+ * @struct config_enum_entry
+ * @brief Structure representing an enumeration entry in the configuration.
+ *
+ * Fields:
+ * - name: Name of the configuration entry.
+ * - val: Value of the configuration entry.
+ * - hidden: Indicates if the entry is hidden.
+ */
+struct config_enum_entry {
+    const char* name;      /**< Name of the configuration entry */
+    int val;               /**< Value of the configuration entry */
+    bool hidden;           /**< Indicates if the entry is hidden */
+};
+
+/**
+ * @brief Creates a new xl_end_of_recovery structure.
+ *
+ * @return A pointer to the newly created xl_end_of_recovery structure.
+ */
+struct xl_end_of_recovery*
+create_xl_end_of_recovery(void);
+
+/**
+ * @brief Parses a version 17 end of recovery record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+xl_end_of_recovery_parse_v17(struct xl_end_of_recovery* wrapper, const void* rec);
+
+/**
+ * @brief Parses a version 16 end of recovery record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+xl_end_of_recovery_parse_v16(struct xl_end_of_recovery* wrapper, const void* rec);
+
+/**
+ * @brief Formats a version 17 end of recovery record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+xl_end_of_recovery_format_v17(struct xl_end_of_recovery* wrapper, char* buf);
+
+/**
+ * @brief Formats a version 16 end of recovery record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+xl_end_of_recovery_format_v16(struct xl_end_of_recovery* wrapper, char* buf);
+
+/**
+ * @brief Convert a timestamp to a string.
+ *
+ * @param dt The timestamp to convert.
+ * @return const char* The string representation of the timestamp.
+ */
+const char*
+pgmoneta_wal_timestamptz_to_str(timestamp_tz dt);
+
+/**
+ * @brief Describe an XLOG record.
+ *
+ * @param buf The buffer to store the description.
+ * @param record The decoded XLOG record.
+ * @return char* The buffer containing the description of the XLOG record.
+ */
+char*
+pgmoneta_wal_xlog_desc(char* buf, struct decoded_xlog_record* record);
+
+#endif /* PGMONETA_RM_XLOG_H */

--- a/src/include/wal/walfile/rmgr.h
+++ b/src/include/wal/walfile/rmgr.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_RMGR_H
+#define PGMONETA_RMGR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <wal/walfile/rm_xlog.h>
+#include <wal/walfile/rm_xact.h>
+#include <wal/walfile/rm_storage.h>
+#include <wal/walfile/rm_clog.h>
+#include <wal/walfile/rm_database.h>
+#include <wal/walfile/rm_tablespace.h>
+#include <wal/walfile/rm_mxact.h>
+#include <wal/walfile/rm_relmap.h>
+#include <wal/walfile/rm_standby.h>
+#include <wal/walfile/rm_heap.h>
+#include <wal/walfile/rm_btree.h>
+#include <wal/walfile/rm_hash.h>
+#include <wal/walfile/rm_gin.h>
+#include <wal/walfile/rm_gist.h>
+#include <wal/walfile/rm_seq.h>
+#include <wal/walfile/rm_spgist.h>
+#include <wal/walfile/rm_brin.h>
+#include <wal/walfile/rm_generic.h>
+#include <wal/walfile/rm_commit_ts.h>
+#include <wal/walfile/rm_replorigin.h>
+#include <wal/walfile/rm_logicalmsg.h>
+
+#define PG_RMGR(symname, name, desc) {name, desc},
+#define RM_MAX_ID           UINT8_MAX
+
+/**
+ * @struct rmgr_data
+ * @brief Represents a Resource Manager (RMGR) data structure.
+ *
+ * Fields:
+ * - name: The name of the resource manager.
+ * - rm_desc: A function pointer to the description function for the resource manager.
+ */
+struct rmgr_data
+{
+   char* name;                                    /**< The name of the resource manager */
+   char* (*rm_desc)(char* buf, struct decoded_xlog_record* record);  /**< Function pointer to the RMGR description function */
+};
+
+/**
+ * Table of resource managers. Each entry corresponds to a specific RMGR identified by an ID.
+ */
+struct rmgr_data RmgrTable[RM_MAX_ID + 1] = {
+   PG_RMGR(RM_XLOG_ID, "XLOG", pgmoneta_wal_xlog_desc)
+   PG_RMGR(RM_XACT_ID, "Transaction", pgmoneta_wal_xact_desc)
+   PG_RMGR(RM_SMGR_ID, "Storage", pgmoneta_wal_storage_desc)
+   PG_RMGR(RM_CLOG_ID, "CLOG", pgmoneta_wal_clog_desc)
+   PG_RMGR(RM_DBASE_ID, "Database", pgmoneta_wal_database_desc)
+   PG_RMGR(RM_TBLSPC_ID, "Tablespace", pgmoneta_wal_tablespace_desc)
+   PG_RMGR(RM_MULTIXACT_ID, "MultiXact", pgmoneta_wal_multixact_desc)
+   PG_RMGR(RM_RELMAP_ID, "RelMap", pgmoneta_wal_relmap_desc)
+   PG_RMGR(RM_STANDBY_ID, "Standby", pgmoneta_wal_standby_desc)
+   PG_RMGR(RM_HEAP2_ID, "Heap2", pgmoneta_wal_heap2_desc)
+   PG_RMGR(RM_HEAP_ID, "Heap", pgmoneta_wal_heap_desc)
+   PG_RMGR(RM_BTREE_ID, "Btree", pgmoneta_wal_btree_desc)
+   PG_RMGR(RM_HASH_ID, "Hash", pgmoneta_wal_hash_desc)
+   PG_RMGR(RM_GIN_ID, "Gin", pgmoneta_wal_gin_desc)
+   PG_RMGR(RM_GIST_ID, "Gist", pgmoneta_wal_gist_desc)
+   PG_RMGR(RM_SEQ_ID, "Sequence", pgmoneta_wal_seq_desc)
+   PG_RMGR(RM_SPGIST_ID, "SPGist", pgmoneta_wal_spg_desc)
+   PG_RMGR(RM_BRIN_ID, "BRIN", pgmoneta_wal_brin_desc)
+   PG_RMGR(RM_COMMIT_TS_ID, "CommitTs", pgmoneta_wal_commit_ts_desc)
+   PG_RMGR(RM_REPLORIGIN_ID, "ReplicationOrigin", pgmoneta_wal_replorigin_desc)
+   PG_RMGR(RM_GENERIC_ID, "Generic", pgmoneta_wal_generic_desc)
+   PG_RMGR(RM_LOGICALMSG_ID, "LogicalMessage", pgmoneta_wal_logicalmsg_desc)
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_RMGR_H

--- a/src/include/wal/walfile/sinval.h
+++ b/src/include/wal/walfile/sinval.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_SINVAL_H
+#define PGMONETA_SINVAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wal/walfile/wal_reader.h>
+
+typedef signed char int8; /**< Signed 8-bit integer. */
+
+#define SHAREDINVALCATALOG_ID   (-1)
+#define SHAREDINVALRELCACHE_ID  (-2)
+#define SHAREDINVALSMGR_ID      (-3)
+#define SHAREDINVALRELMAP_ID    (-4)
+#define SHAREDINVALSNAPSHOT_ID  (-5)
+
+/**
+ * @struct shared_inval_catcache_msg
+ * @brief Message structure for shared invalidation of catalog caches.
+ *
+ * Fields:
+ * - id: Cache ID (must be first).
+ * - db_id: Database ID, or 0 if it's a shared relation.
+ * - hashValue: Hash value of the key for this catalog cache.
+ */
+struct shared_inval_catcache_msg
+{
+    int8 id;                   /**< Cache ID --- must be first */
+    oid db_id;                 /**< Database ID, or 0 if a shared relation */
+    uint32_t hashValue;        /**< Hash value of key for this catcache */
+};
+
+/**
+ * @struct shared_inval_catalog_msg
+ * @brief Message structure for shared invalidation of catalogs.
+ *
+ * Fields:
+ * - id: Type field (must be first).
+ * - db_id: Database ID, or 0 if it's a shared catalog.
+ * - cat_id: ID of the catalog whose contents are invalid.
+ */
+struct shared_inval_catalog_msg
+{
+    int8 id;                   /**< Type field --- must be first */
+    oid db_id;                 /**< Database ID, or 0 if a shared catalog */
+    oid cat_id;                /**< ID of catalog whose contents are invalid */
+};
+
+/**
+ * @struct shared_inval_relcache_msg
+ * @brief Message structure for shared invalidation of relation caches.
+ *
+ * Fields:
+ * - id: Type field (must be first).
+ * - db_id: Database ID, or 0 if it's a shared relation.
+ * - rel_id: Relation ID, or 0 if the whole relcache is invalid.
+ */
+struct shared_inval_relcache_msg
+{
+    int8 id;                   /**< Type field --- must be first */
+    oid db_id;                 /**< Database ID, or 0 if a shared relation */
+    oid rel_id;                /**< Relation ID, or 0 if whole relcache */
+};
+
+/**
+ * @struct shared_inval_smgr_msg
+ * @brief Message structure for shared invalidation of storage manager data.
+ *
+ * Fields:
+ * - id: Type field (must be first).
+ * - backend_hi: High bits of backend process number, if it's a temporary relation.
+ * - backend_lo: Low bits of backend process number, if it's a temporary relation.
+ * - rlocator: Rel file locator structure containing spcOid, dbOid, and relNumber.
+ */
+struct shared_inval_smgr_msg
+{
+    int8 id;                           /**< Type field --- must be first */
+    int8 backend_hi;                   /**< High bits of backend procno, if temprel */
+    uint16_t backend_lo;               /**< Low bits of backend procno, if temprel */
+    struct rel_file_locator rlocator;  /**< spcOid, dbOid, relNumber */
+};
+
+/**
+ * @struct shared_inval_relmap_msg
+ * @brief Message structure for shared invalidation of relation mapping.
+ *
+ * Fields:
+ * - id: Type field (must be first).
+ * - db_id: Database ID, or 0 for shared catalogs.
+ */
+struct shared_inval_relmap_msg
+{
+    int8 id;                   /**< Type field --- must be first */
+    oid db_id;                 /**< Database ID, or 0 for shared catalogs */
+};
+
+/**
+ * @struct shared_inval_snapshot_msg
+ * @brief Message structure for shared invalidation of snapshots.
+ *
+ * Fields:
+ * - id: Type field (must be first).
+ * - db_id: Database ID, or 0 if it's a shared relation.
+ * - rel_id: Relation ID.
+ */
+struct shared_inval_snapshot_msg
+{
+    int8 id;                   /**< Type field --- must be first */
+    oid db_id;                 /**< Database ID, or 0 if a shared relation */
+    oid rel_id;                /**< Relation ID */
+};
+
+/**
+ * @union shared_invalidation_message
+ * @brief Union of all shared invalidation message types.
+ *
+ * Fields:
+ * - id: Type field (must be first).
+ * - cc: Catalog cache invalidation message.
+ * - cat: Catalog invalidation message.
+ * - rc: Relation cache invalidation message.
+ * - sm: Storage manager invalidation message.
+ * - rm: Relation mapping invalidation message.
+ * - sn: Snapshot invalidation message.
+ */
+union shared_invalidation_message {
+    int8 id;                             /**< Type field --- must be first */
+    struct shared_inval_catcache_msg cc; /**< Catalog cache invalidation message */
+    struct shared_inval_catalog_msg cat; /**< Catalog invalidation message */
+    struct shared_inval_relcache_msg rc; /**< Relation cache invalidation message */
+    struct shared_inval_smgr_msg sm;     /**< Storage manager invalidation message */
+    struct shared_inval_relmap_msg rm;   /**< Relation mapping invalidation message */
+    struct shared_inval_snapshot_msg sn; /**< Snapshot invalidation message */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_SINVAL_H

--- a/src/include/wal/walfile/transaction.h
+++ b/src/include/wal/walfile/transaction.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PGMONETA_TRANSACTION_H
+#define PGMONETA_TRANSACTION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+// Typedefs
+typedef uint32_t transaction_id;
+typedef transaction_id multi_xact_id;
+typedef uint32_t multi_xact_offset;
+
+// #define variables
+#define INVALID_TRANSACTION_ID              ((transaction_id) 0)
+
+// #define macros
+#define EPOCH_FROM_FULL_TRANSACTION_ID(x)   ((uint32_t) ((x).value >> 32))
+#define XID_FROM_FULL_TRANSACTION_ID(x)     ((uint32_t) (x).value)
+#define TRANSACTION_ID_IS_VALID(xid)        ((xid) != INVALID_TRANSACTION_ID)
+
+// Structs
+/**
+ * @struct full_transaction_id
+ * @brief Represents a full transaction identifier.
+ *
+ * Fields:
+ * - value: The full 64-bit transaction ID value.
+ */
+struct full_transaction_id {
+    uint64_t value;  /**< The full 64-bit transaction ID value */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_TRANSACTION_H

--- a/src/include/wal/walfile/wal_reader.h
+++ b/src/include/wal/walfile/wal_reader.h
@@ -1,0 +1,440 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PGMONETA_WAL_READER_H
+#define PGMONETA_WAL_READER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* pgmoneta-related includes */
+#include <pgmoneta.h>
+#include <wal/walfile/transaction.h>
+
+/* System includes */
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Typedefs */
+typedef uint32_t timeline_id;
+typedef uint64_t xlog_rec_ptr;
+typedef uint32_t pg_crc32c;
+typedef uint8_t rmgr_id;
+typedef uint64_t xlog_seg_no;
+typedef uint16_t rep_origin_id;
+typedef int64_t timestamp_tz;
+
+typedef int buffer;
+typedef uint32_t block_number;
+typedef unsigned int oid;
+typedef oid rel_file_number;
+
+/* #define variables */
+#define MAXIMUM_ALIGNOF            8  // TODO: double check this value
+#define ALIGNOF_SHORT              2  // TODO: double check this value
+#define InvalidXLogRecPtr          0
+#define InvalidBuffer              0
+#define XLOG_PAGE_MAGIC            0xD10D  // WAL version indicator
+#define InvalidOid                 ((oid) 0)
+#define FLEXIBLE_ARRAY_MEMBER      /* empty */
+#define INVALID_REP_ORIGIN_ID      0
+#define XLR_MAX_BLOCK_ID           32
+#define XLR_BLOCK_ID_DATA_SHORT    255
+#define XLR_BLOCK_ID_DATA_LONG     254
+#define XLR_BLOCK_ID_ORIGIN        253
+#define XLR_BLOCK_ID_TOPLEVEL_XID  252
+#define BKPBLOCK_FORK_MASK         0x0F
+#define BKPBLOCK_FLAG_MASK         0xF0
+#define BKPBLOCK_HAS_IMAGE         0x10    /* Block data is an XLogRecordBlockImage */
+#define BKPBLOCK_HAS_DATA          0x20
+#define BKPBLOCK_WILL_INIT         0x40    /* Redo will re-init the page */
+#define BKPBLOCK_SAME_REL          0x80    /* rel_file_locator omitted, same as previous */
+#define BKPIMAGE_HAS_HOLE          0x01    /* Page image has a "hole" */
+#define BKPIMAGE_IS_COMPRESSED     0x02    /* Page image is compressed */
+#define BKPIMAGE_APPLY             0x04    /* Page image should be restored during replay */
+#define BKPIMAGE_COMPRESS_PGLZ     0x04
+#define BKPIMAGE_COMPRESS_LZ4      0x08
+#define BKPIMAGE_COMPRESS_ZSTD     0x10
+
+#define SIZE_OF_XLOG_LONG_PHD      MAXALIGN(sizeof(struct xlog_long_page_header_data))
+#define SIZE_OF_XLOG_SHORT_PHD     MAXALIGN(sizeof(struct xlog_page_header_data))
+#define SIZE_OF_XLOG_RECORD        (offsetof(struct xlog_record, xl_crc) + sizeof(pg_crc32c))
+
+/* #define macros */
+#define MAXALIGN(x)                (((x) + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1))
+#define TYPEALIGN(ALIGNVAL, LEN)   (((uintptr_t)(LEN) + ((ALIGNVAL) -1)) & ~((uintptr_t)((ALIGNVAL) -1)))
+#define MAXALIGNTYPE(LEN)          TYPEALIGN(MAXIMUM_ALIGNOF, (LEN))
+#define SHORTALIGN(LEN)            TYPEALIGN(ALIGNOF_SHORT, (LEN))
+
+#define XLogRecHasBlockRef(record, block_id) \
+        ((record->max_block_id >= (block_id)) && \
+         (record->blocks[block_id].in_use))
+
+#define XLogRecHasBlockImage(record, block_id) \
+        (record->blocks[block_id].has_image)
+
+#define XLogRecHasBlockData(record, block_id) \
+        (record->blocks[block_id].has_data)
+
+#define LSN_FORMAT_ARGS(lsn)    ((uint32_t)((lsn) >> 32)), ((uint32_t)(lsn))
+#define XLOG_REC_GET_DATA(record) ((record)->main_data)
+#define XLOG_REC_GET_INFO(record) ((record)->header.xl_info)
+#define XLOG_REC_GET_BLOCK(record, i) (&record->blocks[(i)])
+#define XLOG_REC_BLOCK_IMAGE_APPLY(record, block_id) (record->blocks[block_id].apply_image)
+#define XLOG_REC_GET_ORIGIN(record) (record->record_origin)
+#define XLOG_REC_GET_DATA_LEN(record) (record->main_data_len)
+
+
+/* Enums */
+
+/**
+ * @enum fork_number
+ * @brief Enumeration of different fork numbers.
+ *
+ * This enum represents various fork types used in PostgreSQL.
+ */
+enum fork_number
+{
+    InvalidForkNumber = -1,    /**< Invalid fork number. */
+    MAIN_FORKNUM = 0,          /**< Main fork. */
+    FSM_FORKNUM,               /**< Free space map fork. */
+    VISIBILITYMAP_FORKNUM,     /**< Visibility map fork. */
+    INIT_FORKNUM,              /**< Initialization fork. */
+
+    /*
+     * NOTE: if you add a new fork, change MAX_FORKNUM and possibly
+     * FORKNAMECHARS below, and update the forkNames array in
+     * src/common/relpath.c
+     */
+};
+
+/**
+ * @enum wal_level
+ * @brief Enumeration of WAL levels.
+ *
+ * Represents the various levels of WAL (Write-Ahead Logging).
+ */
+enum wal_level
+{
+    WAL_LEVEL_MINIMAL = 0,    /**< Minimal WAL logging. */
+    WAL_LEVEL_REPLICA,        /**< WAL logging for replication. */
+    WAL_LEVEL_LOGICAL         /**< Logical WAL logging. */
+};
+
+/* Structs */
+
+/**
+ * @struct xlog_page_header_data
+ * @brief Represents the header of an XLOG page.
+ *
+ * Contains metadata for an XLOG page including magic value,
+ * timeline ID, and page address.
+ *
+ * Fields:
+ * - xlp_magic: Magic value for correctness checks.
+ * - xlp_info: Flag bits for the page.
+ * - xlp_tli: Timeline ID of the first record on the page.
+ * - xlp_pageaddr: XLOG address of this page.
+ * - xlp_rem_len: Remaining length of data for the record.
+ */
+struct xlog_page_header_data {
+    uint16_t xlp_magic;         /**< Magic value for correctness checks. */
+    uint16_t xlp_info;          /**< Flag bits for the page. */
+    timeline_id xlp_tli;        /**< Timeline ID of the first record on the page. */
+    xlog_rec_ptr xlp_pageaddr;  /**< XLOG address of this page. */
+    uint32_t xlp_rem_len;       /**< Remaining length of data for the record. */
+};
+
+/**
+ * @struct xlog_long_page_header_data
+ * @brief Extended XLOG page header.
+ *
+ * Extends `xlog_page_header_data` with additional fields such as
+ * system identifier, segment size, and block size.
+ *
+ * Fields:
+ * - std: Standard header fields.
+ * - xlp_sysid: System identifier from pg_control.
+ * - xlp_seg_size: Segment size for cross-checking.
+ * - xlp_xlog_blcksz: XLOG block size for cross-checking.
+ */
+struct xlog_long_page_header_data {
+    struct xlog_page_header_data std;    /**< Standard header fields. */
+    uint64_t xlp_sysid;                  /**< System identifier from pg_control. */
+    uint32_t xlp_seg_size;               /**< Segment size for cross-checking. */
+    uint32_t xlp_xlog_blcksz;            /**< XLOG block size for cross-checking. */
+};
+
+/**
+ * @struct xlog_record
+ * @brief Represents an XLOG record.
+ *
+ * Contains metadata for an XLOG record, including transaction ID,
+ * previous record pointer, and CRC.
+ *
+ * Fields:
+ * - xl_tot_len: Total length of the entire record.
+ * - xl_xid: Transaction ID associated with the record.
+ * - xl_prev: Pointer to the previous record in the log.
+ * - xl_info: Flag bits for the record.
+ * - xl_rmid: Resource manager ID for this record.
+ * - xl_crc: CRC for this record.
+ */
+struct xlog_record {
+    uint32_t xl_tot_len;        /**< Total length of the entire record. */
+    transaction_id xl_xid;      /**< Transaction ID associated with the record. */
+    xlog_rec_ptr xl_prev;       /**< Pointer to the previous record in the log. */
+    uint8_t xl_info;            /**< Flag bits for the record. */
+    rmgr_id xl_rmid;            /**< Resource manager ID for this record. */
+    pg_crc32c xl_crc;           /**< CRC for this record. */
+};
+
+/**
+ * @struct rel_file_locator
+ * @brief Identifies a relation file.
+ *
+ * Used to locate a relation file by tablespace, database, and relation ID.
+ *
+ * Fields:
+ * - spcOid: Tablespace OID.
+ * - dbOid: Database OID.
+ * - relNumber: Relation file number.
+ */
+struct rel_file_locator {
+    oid spcOid;                  /**< Tablespace OID. */
+    oid dbOid;                   /**< Database OID. */
+    rel_file_number relNumber;   /**< Relation file number. */
+};
+
+/**
+ * @struct decoded_bkp_block
+ * @brief Represents a decoded backup block.
+ *
+ * Contains information about a block reference, including whether
+ * it is in use, has an image, and related data.
+ *
+ * Fields:
+ * - in_use: Indicates if this block reference is in use.
+ * - rlocator: Locator for the referenced block.
+ * - forknum: Fork number of the block.
+ * - blkno: Block number.
+ * - prefetch_buffer: Prefetching workspace.
+ * - flags: Copy of the fork_flags field from the block header.
+ * - has_image: Indicates if the block has an image.
+ * - apply_image: Indicates if the image should be applied.
+ * - bkp_image: Backup image of the block.
+ * - hole_offset: Offset of the hole in the image.
+ * - hole_length: Length of the hole in the image.
+ * - bimg_len: Length of the backup image.
+ * - bimg_info: Additional information about the backup image.
+ * - has_data: Indicates if the block has associated data.
+ * - data: Data associated with the block.
+ * - data_len: Length of the data.
+ * - data_bufsz: Buffer size for the data.
+ */
+struct decoded_bkp_block {
+    bool in_use;                        /**< Indicates if this block reference is in use. */
+    struct rel_file_locator rlocator;   /**< Locator for the referenced block. */
+    enum fork_number forknum;           /**< Fork number of the block. */
+    block_number blkno;                 /**< Block number. */
+    buffer prefetch_buffer;             /**< Prefetching workspace. */
+    uint8_t flags;                      /**< Copy of the fork_flags field from the block header. */
+    bool has_image;                     /**< Indicates if the block has an image. */
+    bool apply_image;                   /**< Indicates if the image should be applied. */
+    char* bkp_image;                    /**< Backup image of the block. */
+    uint16_t hole_offset;               /**< Offset of the hole in the image. */
+    uint16_t hole_length;               /**< Length of the hole in the image. */
+    uint16_t bimg_len;                  /**< Length of the backup image. */
+    uint8_t bimg_info;                  /**< Additional information about the backup image. */
+    bool has_data;                      /**< Indicates if the block has associated data. */
+    char* data;                         /**< Data associated with the block. */
+    uint16_t data_len;                  /**< Length of the data. */
+    uint16_t data_bufsz;                /**< Buffer size for the data. */
+};
+
+/**
+ * @struct decoded_xlog_record
+ * @brief Represents a decoded XLOG record.
+ *
+ * Contains the decoded contents of an XLOG record, including
+ * block references, main data, and transaction information.
+ *
+ * Fields:
+ * - size: Total size of the decoded record.
+ * - oversized: Indicates if the record is outside the regular decode buffer.
+ * - next: Link to the next decoded record in the queue.
+ * - lsn: Location of the record.
+ * - next_lsn: Location of the next record.
+ * - header: Header of the record.
+ * - record_origin: Origin ID of the record.
+ * - toplevel_xid: Top-level transaction ID.
+ * - main_data: Main data portion of the record.
+ * - main_data_len: Length of the main data portion.
+ * - max_block_id: Highest block ID in use (-1 if none).
+ * - blocks: Array of decoded backup blocks.
+ */
+struct decoded_xlog_record {
+    size_t size;                          /**< Total size of the decoded record. */
+    bool oversized;                       /**< Indicates if the record is outside the regular decode buffer. */
+    struct decoded_xlog_record* next;     /**< Link to the next decoded record in the queue. */
+    xlog_rec_ptr lsn;                     /**< Location of the record. */
+    xlog_rec_ptr next_lsn;                /**< Location of the next record. */
+    struct xlog_record header;            /**< Header of the record. */
+    rep_origin_id record_origin;          /**< Origin ID of the record. */
+    transaction_id toplevel_xid;          /**< Top-level transaction ID. */
+    char* main_data;                      /**< Main data portion of the record. */
+    uint32_t main_data_len;               /**< Length of the main data portion. */
+    int max_block_id;                     /**< Highest block ID in use (-1 if none). */
+    struct decoded_bkp_block blocks[XLR_MAX_BLOCK_ID + 1];   /**< Array of decoded backup blocks. */
+};
+
+/**
+ * @struct rel_file_node
+ * @brief Identifies a relation file node.
+ *
+ * Used to locate a relation file by tablespace, database, and relation ID.
+ *
+ * Fields:
+ * - spcNode: Tablespace OID.
+ * - dbNode: Database OID.
+ * - relNode: Relation OID.
+ */
+struct rel_file_node {
+    oid spcNode;     /**< Tablespace OID. */
+    oid dbNode;      /**< Database OID. */
+    oid relNode;     /**< Relation OID. */
+};
+
+/* External variables */
+extern struct server* server_config;
+
+/* Function definitions */
+
+/**
+ * Parses a WAL file and populates server information.
+ *
+ * @param path The file path of the WAL file.
+ * @param server_info The server structure to be populated with parsed data.
+ */
+void
+pgmoneta_wal_parse_wal_file(char* path, struct server* server_info);
+
+/**
+ * Decodes an XLOG record from a buffer.
+ *
+ * @param buffer The buffer containing the XLOG record data.
+ * @param decoded The structure to hold the decoded XLOG record.
+ * @param record The original XLOG record structure.
+ * @param block_size The block size used for decoding.
+ * @param server_info The server structure for context.
+ * @return true if the decoding was successful, false otherwise.
+ */
+bool
+pgmoneta_wal_decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlog_record* record, uint32_t block_size, struct server* server_info);
+
+/**
+ * Retrieves the length of the XLOG record.
+ *
+ * @param record The decoded XLOG record.
+ * @param rec_len Pointer to hold the record length.
+ * @param fpi_len Pointer to hold the full-page image length.
+ */
+void
+pgmoneta_wal_get_record_length(struct decoded_xlog_record* record, uint32_t* rec_len, uint32_t* fpi_len);
+
+/**
+ * Displays the decoded XLOG record.
+ *
+ * @param record The decoded XLOG record to display.
+ * @param count The count of records to display.
+ * @param server_info The server structure for context.
+ */
+void
+pgmoneta_wal_display_decoded_record(struct decoded_xlog_record* record, int count, struct server* server_info);
+
+/**
+ * Retrieves block reference information from the decoded XLOG record.
+ *
+ * @param buf The buffer to store the block reference information.
+ * @param record The decoded XLOG record.
+ * @param pretty Format output in a more readable way if true.
+ * @param detailed_format Use a detailed format if true.
+ * @param fpi_len Pointer to store the full-page image length.
+ * @param server_info The server structure for context.
+ * @return The buffer containing the block reference information.
+ */
+char*
+pgmoneta_wal_get_record_block_ref_info(char* buf, struct decoded_xlog_record* record, bool pretty, bool detailed_format, uint32_t* fpi_len, struct server* server_info);
+
+/**
+ * Retrieves block data from the decoded XLOG record.
+ *
+ * @param record The decoded XLOG record.
+ * @param block_id The block ID to retrieve data from.
+ * @param len Pointer to store the length of the retrieved data.
+ * @return The block data.
+ */
+char*
+pgmoneta_wal_get_record_block_data(struct decoded_xlog_record* record, uint8_t block_id, size_t* len);
+
+/**
+ * Retrieves the block tag extended information from the decoded XLOG record.
+ *
+ * @param pRecord The decoded XLOG record.
+ * @param id The block ID to retrieve the tag for.
+ * @param pLocator The relation file locator structure to be filled.
+ * @param pNumber The fork number structure to be filled.
+ * @param pInt The block number structure to be filled.
+ * @param pVoid The buffer structure to be filled.
+ * @return true if the retrieval was successful, false otherwise.
+ */
+bool
+pgmoneta_wal_get_record_block_tag_extended(struct decoded_xlog_record* pRecord, int id, struct rel_file_locator* pLocator, enum fork_number* pNumber,
+                                           block_number* pInt, buffer* pVoid);
+
+/**
+ * Checks if the backup image is compressed.
+ *
+ * @param server_info The server structure for context.
+ * @param bimg_info The backup image information to check.
+ * @return true if the image is compressed, false otherwise.
+ */
+bool
+pgmoneta_wal_is_bkp_image_compressed(struct server* server_info, uint8_t bimg_info);
+
+char*
+pgmoneta_wal_array_desc(char* buf, void* array, size_t elem_size, int count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PGMONETA_WAL_READER_H

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -3947,6 +3947,31 @@ pgmoneta_token_bucket_once(struct token_bucket* tb, unsigned long tokens)
    return 1;
 }
 
+char*
+pgmoneta_format_and_append(char* buf, const char* format, ...)
+{
+   va_list args;
+   va_start(args, format);
+
+   // Determine the required buffer size
+   int size_needed = vsnprintf(NULL, 0, format, args) + 1;
+   va_end(args);
+
+   // Allocate buffer to hold the formatted string
+   char* formatted_str = malloc(size_needed);
+
+   va_start(args, format);
+   vsnprintf(formatted_str, size_needed, format, args);
+   va_end(args);
+
+   buf = pgmoneta_append(buf, formatted_str);
+
+   free(formatted_str);
+
+   return buf;
+
+}
+
 int
 pgmoneta_atoi(const char* input)
 {

--- a/src/libpgmoneta/wal/relpath.c
+++ b/src/libpgmoneta/wal/relpath.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * get_relation_path - construct path to a relation's file
+ *
+ * Result is a palloc'd string.
+ *
+ * Note: ideally, backendId would be declared as type backend_id, but relpath.h
+ * would have to include a backend-only header to do that; doesn't seem worth
+ * the trouble considering backend_id is just int anyway.
+ */
+
+#include <wal/walfile/relpath.h>
+
+#include <assert.h>
+#include <utils.h>
+
+char*
+pgmoneta_wal_get_relation_path(oid dbNode, oid spcNode, oid relNode,
+                               int backendId, enum fork_number forkNumber)
+{
+   const char*const forkNames[] = {
+      "main",                       /* MAIN_FORKNUM */
+      "fsm",                        /* FSM_FORKNUM */
+      "vm",                      /* VISIBILITYMAP_FORKNUM */
+      "init"                        /* INIT_FORKNUM */
+   };
+   char* path;
+   path = NULL;
+
+   if (spcNode == GLOBALTABLESPACE_OID)
+   {
+      /* Shared system relations live in {datadir}/global */
+      assert(dbNode == 0);
+      assert(backendId == INVALID_BACKEND_ID);
+      if (forkNumber != MAIN_FORKNUM)
+      {
+         path = pgmoneta_format_and_append(path, "global/%u_%s",
+                                           relNode, forkNames[forkNumber]);
+      }
+      else
+      {
+         path = pgmoneta_format_and_append(path, "global/%u", relNode);
+      }
+   }
+   else if (spcNode == DEFAULTTABLESPACE_OID)
+   {
+      /* The default tablespace is {datadir}/base */
+      if (backendId == INVALID_BACKEND_ID)
+      {
+         if (forkNumber != MAIN_FORKNUM)
+         {
+            path = pgmoneta_format_and_append(path, "base/%u/%u_%s",
+                                              dbNode, relNode,
+                                              forkNames[forkNumber]);
+         }
+         else
+         {
+            path = pgmoneta_format_and_append(path, "base/%u/%u",
+                                              dbNode, relNode);
+         }
+      }
+      else
+      {
+         if (forkNumber != MAIN_FORKNUM)
+         {
+            path = pgmoneta_format_and_append(path, "base/%u/t%d_%u_%s",
+                                              dbNode, backendId, relNode,
+                                              forkNames[forkNumber]);
+         }
+         else
+         {
+            path = pgmoneta_format_and_append(path, "base/%u/t%d_%u",
+                                              dbNode, backendId, relNode);
+         }
+      }
+   }
+   else
+   {
+      char* version_directory = pgmoneta_wal_get_tablespace_version_directory();
+      /* All other tablespaces are accessed via symlinks */
+      if (backendId == INVALID_BACKEND_ID)
+      {
+
+         if (forkNumber != MAIN_FORKNUM)
+         {
+            path = pgmoneta_format_and_append(path, "pg_tblspc/%u/%s/%u/%u_%s",
+                                              spcNode, version_directory,
+                                              dbNode, relNode,
+                                              forkNames[forkNumber]);
+         }
+         else
+         {
+            path = pgmoneta_format_and_append(path, "pg_tblspc/%u/%s/%u/%u",
+                                              spcNode, version_directory,
+                                              dbNode, relNode);
+         }
+      }
+      else
+      {
+         if (forkNumber != MAIN_FORKNUM)
+         {
+            path = pgmoneta_format_and_append(path, "pg_tblspc/%u/%s/%u/t%d_%u_%s",
+                                              spcNode, version_directory,
+                                              dbNode, backendId, relNode,
+                                              forkNames[forkNumber]);
+         }
+         else
+         {
+            path = pgmoneta_format_and_append(path, "pg_tblspc/%u/%s/%u/t%d_%u",
+                                              spcNode, version_directory,
+                                              dbNode, backendId, relNode);
+         }
+      }
+      free(version_directory);
+   }
+   return path;
+}
+
+char*
+pgmoneta_wal_get_tablespace_version_directory(void)
+{
+   char* result = (char*)malloc(50);
+   result = pgmoneta_format_and_append(result, "PG_%d_%s", server_config->version, pgmoneta_wal_get_catalog_version_number());
+   return result;
+}
+char*
+pgmoneta_wal_get_catalog_version_number(void)
+{
+   switch (server_config->version)
+   {
+      case 13: return "202004022";
+      case 14: return "202104081";
+      case 15: return "202204062";
+      case 16: return "202303311";
+      case 17: return "202407111";
+      default: return "Key not found";    // Return a default message for invalid keys
+   }
+}

--- a/src/libpgmoneta/wal/rm_brin.c
+++ b/src/libpgmoneta/wal/rm_brin.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm_brin.h>
+
+#include <utils.h>
+
+char*
+pgmoneta_wal_brin_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   info &= XLOG_BRIN_OPMASK;
+   if (info == XLOG_BRIN_CREATE_INDEX)
+   {
+      struct xl_brin_createidx* xlrec = (struct xl_brin_createidx*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "v%d pagesPerRange %u",
+                                       xlrec->version, xlrec->pagesPerRange);
+   }
+   else if (info == XLOG_BRIN_INSERT)
+   {
+      struct xl_brin_insert* xlrec = (struct xl_brin_insert*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "heapBlk %u pagesPerRange %u offnum %u",
+                                       xlrec->heapBlk,
+                                       xlrec->pagesPerRange,
+                                       xlrec->offnum);
+   }
+   else if (info == XLOG_BRIN_UPDATE)
+   {
+      struct xl_brin_update* xlrec = (struct xl_brin_update*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "heapBlk %u pagesPerRange %u old offnum %u, new offnum %u",
+                                       xlrec->insert.heapBlk,
+                                       xlrec->insert.pagesPerRange,
+                                       xlrec->oldOffnum,
+                                       xlrec->insert.offnum);
+   }
+   else if (info == XLOG_BRIN_SAMEPAGE_UPDATE)
+   {
+      struct xl_brin_samepage_update* xlrec = (struct xl_brin_samepage_update*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "offnum %u", xlrec->offnum);
+   }
+   else if (info == XLOG_BRIN_REVMAP_EXTEND)
+   {
+      struct xl_brin_revmap_extend* xlrec = (struct xl_brin_revmap_extend*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "targetBlk %u", xlrec->targetBlk);
+   }
+   else if (info == XLOG_BRIN_DESUMMARIZE)
+   {
+      struct xl_brin_desummarize* xlrec = (struct xl_brin_desummarize*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "pagesPerRange %u, heapBlk %u, page offset %u",
+                                       xlrec->pagesPerRange, xlrec->heapBlk, xlrec->regOffset);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_btree.c
+++ b/src/libpgmoneta/wal/rm_btree.c
@@ -1,0 +1,530 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm_btree.h>
+#include <wal/walfile/wal_reader.h>
+#include <utils.h>
+
+#include <assert.h>
+#include <stdbool.h>
+
+struct xl_btree_reuse_page*
+pgmoneta_wal_create_xl_btree_reuse_page(void)
+{
+   struct xl_btree_reuse_page* wrapper = malloc(sizeof(struct xl_btree_reuse_page));
+
+   if (server_config->version >= 16)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_reuse_page_v16;
+      wrapper->format = pgmoneta_wal_format_xl_btree_reuse_page_v16;
+   }
+   else if (server_config->version >= 14)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_reuse_page_v15;
+      wrapper->format = pgmoneta_wal_format_xl_btree_reuse_page_v15;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_reuse_page_v13;
+      wrapper->format = pgmoneta_wal_format_xl_btree_reuse_page_v13;
+   }
+
+   return wrapper;
+}
+
+void
+pgmoneta_wal_parse_xl_btree_reuse_page_v13(struct xl_btree_reuse_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v13, rec, sizeof(struct xl_btree_reuse_page_v15));
+}
+
+void
+pgmoneta_wal_parse_xl_btree_reuse_page_v15(struct xl_btree_reuse_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_btree_reuse_page_v15));
+}
+
+void
+pgmoneta_wal_parse_xl_btree_reuse_page_v16(struct xl_btree_reuse_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct xl_btree_reuse_page_v16));
+}
+
+char*
+pgmoneta_wal_format_xl_btree_reuse_page_v13(struct xl_btree_reuse_page* wrapper, char* buf)
+{
+   struct xl_btree_reuse_page_v13* xlrec = &wrapper->data.v13;
+   buf = pgmoneta_format_and_append(buf, "rel %u/%u/%u; latestRemovedXid %u",
+                                    xlrec->node.spcNode, xlrec->node.dbNode,
+                                    xlrec->node.relNode, xlrec->latest_removed_xid);
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_xl_btree_reuse_page_v15(struct xl_btree_reuse_page* wrapper, char* buf)
+{
+   struct xl_btree_reuse_page_v15* xlrec = &wrapper->data.v15;
+   buf = pgmoneta_format_and_append(buf, "rel %u/%u/%u; latestRemovedXid %u:%u",
+                                    xlrec->node.spcNode, xlrec->node.dbNode,
+                                    xlrec->node.relNode,
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(xlrec->latest_removed_full_xid),
+                                    XID_FROM_FULL_TRANSACTION_ID(xlrec->latest_removed_full_xid));
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_xl_btree_reuse_page_v16(struct xl_btree_reuse_page* wrapper, char* buf)
+{
+   struct xl_btree_reuse_page_v16* xlrec = &wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "rel %u/%u/%u; snapshot_conflict_horizon_id %u:%u",
+                                    xlrec->locator.spcOid, xlrec->locator.dbOid,
+                                    xlrec->locator.relNumber,
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(xlrec->snapshot_conflict_horizon_id),
+                                    XID_FROM_FULL_TRANSACTION_ID(xlrec->snapshot_conflict_horizon_id));
+   return buf;
+}
+
+struct xl_btree_delete*
+pgmoneta_wal_create_xl_btree_delete(void)
+{
+   struct xl_btree_delete* wrapper = malloc(sizeof(struct xl_btree_delete));
+
+   if (server_config->version >= 16)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_delete_v16;
+      wrapper->format = pgmoneta_wal_format_xl_btree_delete_v16;
+   }
+   else if (server_config->version >= 14)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_delete_v15;
+      wrapper->format = pgmoneta_wal_format_xl_btree_delete_v15;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_delete_v13;
+      wrapper->format = pgmoneta_wal_format_xl_btree_delete_v13;
+   }
+
+   return wrapper;
+}
+
+void
+pgmoneta_wal_parse_xl_btree_delete_v13(struct xl_btree_delete* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v13, rec, sizeof(struct xl_btree_delete_v13));
+}
+
+void
+pgmoneta_wal_parse_xl_btree_delete_v15(struct xl_btree_delete* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_btree_delete_v15));
+}
+
+void
+pgmoneta_wal_parse_xl_btree_delete_v16(struct xl_btree_delete* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct xl_btree_delete_v16));
+}
+
+char*
+pgmoneta_wal_format_xl_btree_delete_v13(struct xl_btree_delete* wrapper, char* buf)
+{
+   struct xl_btree_delete_v13* xlrec = &wrapper->data.v13;
+   buf = pgmoneta_format_and_append(buf, "latestRemovedXid %u; ndeleted %u",
+                                    xlrec->latest_removed_xid, xlrec->ndeleted);
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_xl_btree_delete_v15(struct xl_btree_delete* wrapper, char* buf)
+{
+   struct xl_btree_delete_v15* xlrec = &wrapper->data.v15;
+   buf = pgmoneta_format_and_append(buf, "latestRemovedXid %u; ndeleted %u; nupdated %u",
+                                    xlrec->latestRemovedXid, xlrec->ndeleted, xlrec->nupdated);
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_xl_btree_delete_v16(struct xl_btree_delete* wrapper, char* buf)
+{
+   struct xl_btree_delete_v16* xlrec = &wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "snapshot_conflict_horizon_id %u; ndeleted %u; nupdated %u",
+                                    xlrec->snapshot_conflict_horizon,
+                                    xlrec->ndeleted, xlrec->nupdated);
+   return buf;
+}
+
+struct xl_btree_metadata*
+pgmoneta_wal_create_xl_btree_metadata(void)
+{
+   struct xl_btree_metadata* wrapper = malloc(sizeof(struct xl_btree_metadata));
+
+   if (server_config->version >= 14)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_metadata_v14;
+      wrapper->format = pgmoneta_wal_format_xl_btree_metadata_v14;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_metadata_v13;
+      wrapper->format = pgmoneta_wal_format_xl_btree_metadata_v13;
+   }
+
+   return wrapper;
+}
+
+void
+pgmoneta_wal_parse_xl_btree_metadata_v13(struct xl_btree_metadata* wrapper, const char* rec)
+{
+   memcpy(&wrapper->data.v13, rec, sizeof(struct xl_btree_metadata_v13));
+}
+
+void
+pgmoneta_wal_parse_xl_btree_metadata_v14(struct xl_btree_metadata* wrapper, const char* rec)
+{
+   memcpy(&wrapper->data.v14, rec, sizeof(struct xl_btree_metadata_v14));
+}
+
+char*
+pgmoneta_wal_format_xl_btree_metadata_v13(struct xl_btree_metadata* wrapper, char* buf)
+{
+   struct xl_btree_metadata_v13* xlrec = &wrapper->data.v13;
+   buf = pgmoneta_format_and_append(buf, "oldest_btpo_xact %u; last_cleanup_num_heap_tuples: %f",
+                                    xlrec->oldest_btpo_xact,
+                                    xlrec->last_cleanup_num_heap_tuples);
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_xl_btree_metadata_v14(struct xl_btree_metadata* wrapper, char* buf)
+{
+   struct xl_btree_metadata_v14* xlrec = &wrapper->data.v14;
+   buf = pgmoneta_format_and_append(buf, "last_cleanup_num_delpages: %u",
+                                    xlrec->last_cleanup_num_delpages);
+   return buf;
+}
+
+struct xl_btree_unlink_page*
+pgmoneta_wal_create_xl_btree_unlink_page(void)
+{
+   struct xl_btree_unlink_page* wrapper = malloc(sizeof(struct xl_btree_unlink_page));
+
+   if (server_config->version >= 14)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_unlink_page_v14;
+      wrapper->format = pgmoneta_wal_format_xl_btree_unlink_page_v14;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_btree_unlink_page_v13;
+      wrapper->format = pgmoneta_wal_format_xl_btree_unlink_page_v13;
+   }
+
+   return wrapper;
+}
+
+/**
+ * Parses a version 13 xl_btree_unlink_page record.
+ *
+ * @param wrapper The wrapper struct.
+ * @param rec The record to parse.
+ */
+void
+pgmoneta_wal_parse_xl_btree_unlink_page_v13(struct xl_btree_unlink_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v13, rec, sizeof(struct xl_btree_unlink_page_v13));
+}
+
+/**
+ * Parses a version 14 xl_btree_unlink_page record.
+ *
+ * @param wrapper The wrapper struct.
+ * @param rec The record to parse.
+ */
+void
+pgmoneta_wal_parse_xl_btree_unlink_page_v14(struct xl_btree_unlink_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v14, rec, sizeof(struct xl_btree_unlink_page_v14));
+}
+
+/**
+ * Formats a version 13 xl_btree_unlink_page record into a string.
+ *
+ * @param wrapper The wrapper struct.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_xl_btree_unlink_page_v13(struct xl_btree_unlink_page* wrapper, char* buf)
+{
+   struct xl_btree_unlink_page_v13* xlrec = &wrapper->data.v13;
+   buf = pgmoneta_format_and_append(buf, "left %u; right %u; btpo_xact %u; ",
+                                    xlrec->leftsib, xlrec->rightsib,
+                                    xlrec->btpo_xact);
+   buf = pgmoneta_format_and_append(buf, "leafleft %u; leafright %u; topparent %u",
+                                    xlrec->leafleftsib, xlrec->leafrightsib,
+                                    xlrec->topparent);
+   return buf;
+}
+
+/**
+ * Formats a version 14 xl_btree_unlink_page record into a string.
+ *
+ * @param wrapper The wrapper struct.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+pgmoneta_wal_format_xl_btree_unlink_page_v14(struct xl_btree_unlink_page* wrapper, char* buf)
+{
+   struct xl_btree_unlink_page_v14* xlrec = &wrapper->data.v14;
+   buf = pgmoneta_format_and_append(buf, "left %u; right %u; level %u; safexid %u:%u; ",
+                                    xlrec->leftsib, xlrec->rightsib, xlrec->level,
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(xlrec->safexid),
+                                    XID_FROM_FULL_TRANSACTION_ID(xlrec->safexid));
+   buf = pgmoneta_format_and_append(buf, "leafleft %u; leafright %u; leaftopparent %u",
+                                    xlrec->leafleftsib, xlrec->leafrightsib,
+                                    xlrec->leaftopparent);
+   return buf;
+}
+
+static char*
+pgmoneta_wal_delvacuum_desc(char* buf, char* block_data, uint16_t ndeleted, uint16_t nupdated)
+{
+   offset_number* deletedoffsets;
+   offset_number* updatedoffsets;
+   struct xl_btree_update* updates;
+
+   /* Output deleted page offset number array */
+   buf = pgmoneta_format_and_append(buf, ", deleted:");
+   deletedoffsets = (offset_number*) block_data;
+   buf = pgmoneta_wal_array_desc(buf, deletedoffsets, sizeof(offset_number), ndeleted);
+
+   /*
+    * Output updates as an array of "update objects", where each element
+    * contains a page offset number from updated array.  (This is not the
+    * most literal representation of the underlying physical data structure
+    * that we could use.  Readability seems more important here.)
+    */
+   buf = pgmoneta_format_and_append(buf, ", updated: [");
+   updatedoffsets = (offset_number*) (block_data + ndeleted *
+                                      sizeof(offset_number));
+   updates = (struct xl_btree_update*) ((char*) updatedoffsets +
+                                        nupdated *
+                                        sizeof(offset_number));
+   for (int i = 0; i < nupdated; i++)
+   {
+      offset_number off = updatedoffsets[i];
+
+      assert(OFFSET_NUMBER_IS_VALID(off));
+      assert(updates->ndeletedtids > 0);
+
+      /*
+       * "ptid" is the symbol name used when building each xl_btree_update's
+       * array of offsets into a posting list tuple's item_pointer_data array.
+       * xl_btree_update describes a subset of the existing TIDs to delete.
+       */
+      buf = pgmoneta_format_and_append(buf, "{ off: %u, nptids: %u, ptids: [",
+                                       off, updates->ndeletedtids);
+      for (int p = 0; p < updates->ndeletedtids; p++)
+      {
+         uint16_t* ptid;
+
+         ptid = (uint16_t*) ((char*) updates + SIZE_OF_BTREE_UPDATE) + p;
+         buf = pgmoneta_format_and_append(buf, "%u", *ptid);
+
+         if (p < updates->ndeletedtids - 1)
+         {
+            buf = pgmoneta_format_and_append(buf, ", ");
+         }
+      }
+      buf = pgmoneta_format_and_append(buf, "] }");
+      if (i < nupdated - 1)
+      {
+         buf = pgmoneta_format_and_append(buf, ", ");
+      }
+
+      updates = (struct xl_btree_update*)
+                ((char*) updates + SIZE_OF_BTREE_UPDATE +
+                 updates->ndeletedtids * sizeof(uint16_t));
+   }
+   buf = pgmoneta_format_and_append(buf, "]");
+
+   return buf;
+}
+
+char*
+pgmoneta_wal_btree_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = record->main_data;
+   uint8_t info = record->header.xl_info & ~XLR_INFO_MASK;
+
+   switch (info)
+   {
+      case XLOG_BTREE_INSERT_LEAF:
+      case XLOG_BTREE_INSERT_UPPER:
+      case XLOG_BTREE_INSERT_META:
+      case XLOG_BTREE_INSERT_POST: {
+         struct xl_btree_insert* xlrec = (struct xl_btree_insert*) rec;
+         buf = pgmoneta_format_and_append(buf, " off: %u", xlrec->offnum);
+         break;
+      }
+      case XLOG_BTREE_SPLIT_L:
+      case XLOG_BTREE_SPLIT_R: {
+         struct xl_btree_split* xlrec = (struct xl_btree_split*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "level: %u, firstrightoff: %d, newitemoff: %d, postingoff: %d",
+                                          xlrec->level, xlrec->firstrightoff,
+                                          xlrec->newitemoff, xlrec->postingoff);
+         break;
+      }
+      case XLOG_BTREE_DEDUP: {
+         struct xl_btree_dedup* xlrec = (struct xl_btree_dedup*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "nintervals: %u", xlrec->nintervals);
+         break;
+      }
+      case XLOG_BTREE_VACUUM: {
+         struct xl_btree_vacuum* xlrec = (struct xl_btree_vacuum*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "ndeleted: %u, nupdated: %u",
+                                          xlrec->ndeleted, xlrec->nupdated);
+
+         if (XLogRecHasBlockData(record, 0))
+         {
+            buf = pgmoneta_wal_delvacuum_desc(buf, pgmoneta_wal_get_record_block_data(record, 0, NULL),
+                                              xlrec->ndeleted, xlrec->nupdated);
+         }
+         break;
+      }
+      case XLOG_BTREE_DELETE: {
+         struct xl_btree_delete* xlrec = pgmoneta_wal_create_xl_btree_delete();
+         xlrec->parse(xlrec, rec);
+         buf = xlrec->format(xlrec, buf);
+         free(xlrec);
+         break;
+      }
+      case XLOG_BTREE_MARK_PAGE_HALFDEAD: {
+         struct xl_btree_mark_page_halfdead* xlrec = (struct xl_btree_mark_page_halfdead*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "topparent: %u, leaf: %u, left: %u, right: %u",
+                                          xlrec->topparent, xlrec->leafblk, xlrec->leftblk, xlrec->rightblk);
+         break;
+      }
+      case XLOG_BTREE_UNLINK_PAGE_META:
+      case XLOG_BTREE_UNLINK_PAGE: {
+         struct xl_btree_unlink_page* xlrec = pgmoneta_wal_create_xl_btree_unlink_page();
+         xlrec->parse(xlrec, rec);
+         buf = xlrec->format(xlrec, buf);
+         free(xlrec);
+
+         break;
+      }
+      case XLOG_BTREE_NEWROOT: {
+         struct xl_btree_newroot* xlrec = (struct xl_btree_newroot*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "level: %u", xlrec->level);
+         break;
+      }
+      case XLOG_BTREE_REUSE_PAGE: {
+         struct xl_btree_reuse_page* xlrec = pgmoneta_wal_create_xl_btree_reuse_page();
+         xlrec->parse(xlrec, rec);
+         buf = xlrec->format(xlrec, buf);
+         free(xlrec);
+         break;
+      }
+      case XLOG_BTREE_META_CLEANUP: {
+         struct xl_btree_metadata* xlrec = pgmoneta_wal_create_xl_btree_metadata();
+
+         xlrec->parse(xlrec, pgmoneta_wal_get_record_block_data(record, 0, NULL));
+         buf = xlrec->format(xlrec, buf);
+         free(xlrec);
+         break;
+      }
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_btree_identify (uint8_t info)
+{
+   {
+      char* id = NULL;
+
+      switch (info & ~XLR_INFO_MASK)
+      {
+         case XLOG_BTREE_INSERT_LEAF:
+            id = "INSERT_LEAF";
+            break;
+         case XLOG_BTREE_INSERT_UPPER:
+            id = "INSERT_UPPER";
+            break;
+         case XLOG_BTREE_INSERT_META:
+            id = "INSERT_META";
+            break;
+         case XLOG_BTREE_SPLIT_L:
+            id = "SPLIT_L";
+            break;
+         case XLOG_BTREE_SPLIT_R:
+            id = "SPLIT_R";
+            break;
+         case XLOG_BTREE_INSERT_POST:
+            id = "INSERT_POST";
+            break;
+         case XLOG_BTREE_DEDUP:
+            id = "DEDUP";
+            break;
+         case XLOG_BTREE_VACUUM:
+            id = "VACUUM";
+            break;
+         case XLOG_BTREE_DELETE:
+            id = "DELETE";
+            break;
+         case XLOG_BTREE_MARK_PAGE_HALFDEAD:
+            id = "MARK_PAGE_HALFDEAD";
+            break;
+         case XLOG_BTREE_UNLINK_PAGE:
+            id = "UNLINK_PAGE";
+            break;
+         case XLOG_BTREE_UNLINK_PAGE_META:
+            id = "UNLINK_PAGE_META";
+            break;
+         case XLOG_BTREE_NEWROOT:
+            id = "NEWROOT";
+            break;
+         case XLOG_BTREE_REUSE_PAGE:
+            id = "REUSE_PAGE";
+            break;
+         case XLOG_BTREE_META_CLEANUP:
+            id = "META_CLEANUP";
+            break;
+      }
+
+      return id;
+   }
+}

--- a/src/libpgmoneta/wal/rm_clog.c
+++ b/src/libpgmoneta/wal/rm_clog.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_clog.h>
+#include <utils.h>
+
+#include <string.h>
+
+struct xl_clog_truncate*
+create_xl_clog_truncate(void)
+{
+   struct xl_clog_truncate* wrapper = malloc(sizeof(struct xl_clog_truncate));
+
+   if (server_config->version >= 17)
+   {
+      wrapper->parse = xl_clog_truncate_parse_v17;
+      wrapper->format = xl_clog_truncate_format_v17;
+   }
+   else
+   {
+      wrapper->parse = xl_clog_truncate_parse_v16;
+      wrapper->format = xl_clog_truncate_format_v16;
+   }
+   return wrapper;
+}
+void
+xl_clog_truncate_parse_v16(struct xl_clog_truncate* wrapper, char* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct xl_clog_truncate_16));
+}
+
+void
+xl_clog_truncate_parse_v17(struct xl_clog_truncate* wrapper, char* rec)
+{
+   memcpy(&wrapper->data.v17, rec, sizeof(struct xl_clog_truncate_17));
+}
+
+char*
+xl_clog_truncate_format_v16(struct xl_clog_truncate* wrapper, char* buf)
+{
+   return pgmoneta_format_and_append(buf, "page %ld; oldestXact %u",
+                                     wrapper->data.v16.pageno,
+                                     wrapper->data.v16.oldestXact);
+}
+
+char*
+xl_clog_truncate_format_v17(struct xl_clog_truncate* wrapper, char* buf)
+{
+   return pgmoneta_format_and_append(buf, "page %d; oldestXact %u",
+                                     wrapper->data.v17.pageno,
+                                     wrapper->data.v17.oldestXact);
+}
+
+char*
+pgmoneta_wal_clog_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == CLOG_ZEROPAGE)
+   {
+      int64_t pageno;
+
+      memcpy(&pageno, rec, server_config->version >= 17 ? sizeof(int): sizeof(int64_t));
+      buf = pgmoneta_format_and_append(buf, "page %d", pageno);
+   }
+   else if (info == CLOG_TRUNCATE)
+   {
+      struct xl_clog_truncate* xlrec = create_xl_clog_truncate();
+      xlrec->parse(xlrec, rec);
+      buf = xlrec->format(xlrec, buf);
+      free(xlrec);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_commit_ts.c
+++ b/src/libpgmoneta/wal/rm_commit_ts.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm_commit_ts.h>
+#include <utils.h>
+
+struct xl_commit_ts_truncate*
+create_xl_commit_ts_truncate()
+{
+   struct xl_commit_ts_truncate* wrapper = malloc(sizeof(struct xl_commit_ts_truncate));
+   if (server_config->version >= 17)
+   {
+      wrapper->parse = xl_commit_ts_truncate_parse_v17;
+      wrapper->format = xl_commit_ts_truncate_format_v17;
+   }
+   else
+   {
+      wrapper->parse = xl_commit_ts_truncate_parse_v16;
+      wrapper->format = xl_commit_ts_truncate_format_v16;
+   }
+   return wrapper;
+}
+
+void
+xl_commit_ts_truncate_parse_v16(struct xl_commit_ts_truncate* wrapper, char* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct xl_commit_ts_truncate_16));
+}
+
+void
+xl_commit_ts_truncate_parse_v17(struct xl_commit_ts_truncate* wrapper, char* rec)
+{
+   memcpy(&wrapper->data.v17, rec, sizeof(struct xl_commit_ts_truncate_17));
+}
+
+char*
+xl_commit_ts_truncate_format_v16(struct xl_commit_ts_truncate* wrapper, char* buf)
+{
+   return pgmoneta_format_and_append(buf, "pageno %d, oldest_xid %u",
+                                     wrapper->data.v16.pageno, wrapper->data.v16.oldestXid);
+}
+
+char*
+xl_commit_ts_truncate_format_v17(struct xl_commit_ts_truncate* wrapper, char* buf)
+{
+   return pgmoneta_format_and_append(buf, "pageno %d, oldest_xid %u",
+                                     wrapper->data.v17.pageno, wrapper->data.v17.oldestXid);
+}
+
+char*
+pgmoneta_wal_commit_ts_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == COMMIT_TS_ZEROPAGE)
+   {
+      int64_t pageno;
+
+      memcpy(&pageno, rec, server_config->version >= 17 ? sizeof(int) : sizeof(int64_t));
+      buf = pgmoneta_format_and_append(buf, "%d", pageno);
+   }
+   else if (info == COMMIT_TS_TRUNCATE)
+   {
+      struct xl_commit_ts_truncate* trunc = create_xl_commit_ts_truncate();
+      buf = trunc->format(trunc, buf);
+      free(trunc);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_database.c
+++ b/src/libpgmoneta/wal/rm_database.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm_database.h>
+#include <wal/walfile/rm.h>
+#include <utils.h>
+
+char*
+pgmoneta_wal_database_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == XLOG_DBASE_CREATE)
+   {
+      struct xl_dbase_create_rec* xlrec = (struct xl_dbase_create_rec*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "copy dir %u/%u to %u/%u",
+                                       xlrec->src_tablespace_id, xlrec->src_db_id,
+                                       xlrec->tablespace_id, xlrec->db_id);
+   }
+   else if (info == XLOG_DBASE_DROP)
+   {
+      struct xl_dbase_drop_rec* xlrec = (struct xl_dbase_drop_rec*) rec;
+      int i;
+
+      buf = pgmoneta_format_and_append(buf, "dir");
+      for (i = 0; i < xlrec->ntablespaces; i++)
+      {
+         buf = pgmoneta_format_and_append(buf, " %u/%u",
+                                          xlrec->tablespace_ids[i], xlrec->db_id);
+      }
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_generic.c
+++ b/src/libpgmoneta/wal/rm_generic.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_generic.h>
+#include <utils.h>
+
+#include <string.h>
+
+char*
+pgmoneta_wal_generic_desc(char* buf, struct decoded_xlog_record* record)
+{
+   pointer ptr = XLOG_REC_GET_DATA(record),
+           end = ptr + XLOG_REC_GET_DATA_LEN(record);
+
+   while (ptr < end)
+   {
+      offset_number offset,
+                    length;
+
+      memcpy(&offset, ptr, sizeof(offset));
+      ptr += sizeof(offset);
+      memcpy(&length, ptr, sizeof(length));
+      ptr += sizeof(length);
+      ptr += length;
+
+      if (ptr < end)
+      {
+         buf = pgmoneta_format_and_append(buf, "offset %u, length %u; ", offset, length);
+      }
+      else
+      {
+         buf = pgmoneta_format_and_append(buf, "offset %u, length %u", offset, length);
+      }
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_gin.c
+++ b/src/libpgmoneta/wal/rm_gin.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_gin.h>
+#include <utils.h>
+#include <wal/walfile/wal_reader.h>
+
+static char*
+desc_recompress_leaf(char* buf, struct gin_xlog_recompress_data_leaf* insertData)
+{
+   int i;
+   char* walbuf = ((char*) insertData) + sizeof(struct gin_xlog_recompress_data_leaf);
+
+   buf = pgmoneta_format_and_append(buf, " %d segments:", (int) insertData->nactions);
+
+   for (i = 0; i < insertData->nactions; i++)
+   {
+      uint8_t a_segno = *((uint8_t*) (walbuf++));
+      uint8_t a_action = *((uint8_t*) (walbuf++));
+      uint16_t nitems = 0;
+      int newsegsize = 0;
+
+      if (a_action == GIN_SEGMENT_INSERT ||
+          a_action == GIN_SEGMENT_REPLACE)
+      {
+         newsegsize = SIZE_OF_GIN_POSTING_LIST((struct gin_posting_list*) walbuf);
+         walbuf += SHORTALIGN(newsegsize);
+      }
+
+      if (a_action == GIN_SEGMENT_ADDITEMS)
+      {
+         memcpy(&nitems, walbuf, sizeof(uint16_t));
+         walbuf += sizeof(uint16_t);
+         walbuf += nitems * sizeof(struct item_pointer_data);
+      }
+
+      switch (a_action)
+      {
+         case GIN_SEGMENT_ADDITEMS:
+            buf = pgmoneta_format_and_append(buf, " %d (add %d items)", a_segno, nitems);
+            break;
+         case GIN_SEGMENT_DELETE:
+            buf = pgmoneta_format_and_append(buf, " %d (delete)", a_segno);
+            break;
+         case GIN_SEGMENT_INSERT:
+            buf = pgmoneta_format_and_append(buf, " %d (insert)", a_segno);
+            break;
+         case GIN_SEGMENT_REPLACE:
+            buf = pgmoneta_format_and_append(buf, " %d (replace)", a_segno);
+            break;
+         default:
+            buf = pgmoneta_format_and_append(buf, " %d unknown action %d ???", a_segno, a_action);
+            /* cannot decode unrecognized actions further */
+            break;
+      }
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_gin_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = record->main_data;
+   uint8_t info = record->header.xl_info & ~XLR_INFO_MASK;
+
+   switch (info)
+   {
+      case XLOG_GIN_CREATE_PTREE:
+         /* no further information */
+         break;
+      case XLOG_GIN_INSERT: {
+         struct gin_xlog_insert* xlrec = (struct gin_xlog_insert*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "isdata: %c isleaf: %c",
+                                          (xlrec->flags & GIN_INSERT_ISDATA) ? 'T' : 'F',
+                                          (xlrec->flags & GIN_INSERT_ISLEAF) ? 'T' : 'F');
+         if (!(xlrec->flags & GIN_INSERT_ISLEAF))
+         {
+            char* payload = rec + sizeof(struct gin_xlog_insert);
+            block_number leftChildBlkno;
+            block_number rightChildBlkno;
+
+            leftChildBlkno = BLOCK_ID_GET_BLOCK_NUMBER((block_id) payload);
+            payload += sizeof(struct block_id_data);
+            rightChildBlkno = BLOCK_ID_GET_BLOCK_NUMBER((block_id) payload);
+            payload += sizeof(block_number);
+            buf = pgmoneta_format_and_append(buf, " children: %u/%u",
+                                             leftChildBlkno, rightChildBlkno);
+         }
+         if (XLogRecHasBlockImage(record, 0))
+         {
+            if (XLOG_REC_BLOCK_IMAGE_APPLY(record, 0))
+            {
+               buf = pgmoneta_format_and_append(buf, " (full page image)");
+            }
+            else
+            {
+               buf = pgmoneta_format_and_append(buf, " (full page image, for WAL verification)");
+            }
+         }
+         else
+         {
+            char* payload = pgmoneta_wal_get_record_block_data(record, 0, NULL);
+
+            if (!(xlrec->flags & GIN_INSERT_ISDATA))
+            {
+               buf = pgmoneta_format_and_append(buf, " isdelete: %c",
+                                                (((struct gin_xlog_insert_entry*) payload)->isDelete) ? 'T' : 'F');
+            }
+            else if (xlrec->flags & GIN_INSERT_ISLEAF)
+            {
+               buf = desc_recompress_leaf(buf, (struct gin_xlog_recompress_data_leaf*) payload);
+            }
+            else
+            {
+               struct gin_xlog_insert_data_internal* insertData =
+                  (struct gin_xlog_insert_data_internal*) payload;
+
+               buf = pgmoneta_format_and_append(buf, " pitem: %u-%u/%u",
+                                                POSTING_ITEM_GET_BLOCK_NUMBER(&insertData->newitem),
+                                                ITEM_POINTER_GET_BLOCK_NUMBER(&insertData->newitem.key),
+                                                ITEM_POINTER_GET_OFFSET_NUMBER(&insertData->newitem.key));
+            }
+         }
+      }
+      break;
+      case XLOG_GIN_SPLIT: {
+         struct gin_xlog_split* xlrec = (struct gin_xlog_split*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "isrootsplit: %c",
+                                          (((struct gin_xlog_split*) rec)->flags & GIN_SPLIT_ROOT) ? 'T' : 'F');
+         buf = pgmoneta_format_and_append(buf, " isdata: %c isleaf: %c",
+                                          (xlrec->flags & GIN_INSERT_ISDATA) ? 'T' : 'F',
+                                          (xlrec->flags & GIN_INSERT_ISLEAF) ? 'T' : 'F');
+      }
+      break;
+      case XLOG_GIN_VACUUM_PAGE:
+         /* no further information */
+         break;
+      case XLOG_GIN_VACUUM_DATA_LEAF_PAGE: {
+         if (XLogRecHasBlockImage(record, 0))
+         {
+            if (XLOG_REC_BLOCK_IMAGE_APPLY(record, 0))
+            {
+               buf = pgmoneta_format_and_append(buf, " (full page image)");
+            }
+            else
+            {
+               buf = pgmoneta_format_and_append(buf, " (full page image, for WAL verification)");
+            }
+         }
+         else
+         {
+            struct gin_xlog_vacuum_data_leaf_page* xlrec =
+               (struct gin_xlog_vacuum_data_leaf_page*) pgmoneta_wal_get_record_block_data(record, 0, NULL);
+
+            buf = desc_recompress_leaf(buf, &xlrec->data);
+         }
+      }
+      break;
+      case XLOG_GIN_DELETE_PAGE:
+         /* no further information */
+         break;
+      case XLOG_GIN_UPDATE_META_PAGE:
+         /* no further information */
+         break;
+      case XLOG_GIN_INSERT_LISTPAGE:
+         /* no further information */
+         break;
+      case XLOG_GIN_DELETE_LISTPAGE:
+         buf = pgmoneta_format_and_append(buf, "ndeleted: %d",
+                                          ((struct gin_xlog_delete_list_pages*) rec)->ndeleted);
+         break;
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_gist.c
+++ b/src/libpgmoneta/wal/rm_gist.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_gist.h>
+#include <utils.h>
+
+struct gist_xlog_delete*
+create_gist_xlog_delete(void)
+{
+   struct gist_xlog_delete* wrapper = malloc(sizeof(struct gist_xlog_delete));
+
+   if (server_config->version >= 16)
+   {
+      wrapper->parse = pgmoneta_wal_parse_gist_xlog_delete_v16;
+      wrapper->format = pgmoneta_wal_format_gist_xlog_delete_v16;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_gist_xlog_delete_v15;
+      wrapper->format = pgmoneta_wal_format_gist_xlog_delete_v15;
+   }
+
+   return wrapper;
+}
+
+// Parsing function for version 15
+void
+pgmoneta_wal_parse_gist_xlog_delete_v15(struct gist_xlog_delete* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct gist_xlog_delete_v15));
+}
+
+// Parsing function for version 16
+void
+pgmoneta_wal_parse_gist_xlog_delete_v16(struct gist_xlog_delete* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct gist_xlog_delete_v16));
+}
+
+// Formatting function for version 15
+char*
+pgmoneta_wal_format_gist_xlog_delete_v15(struct gist_xlog_delete* wrapper, char* buf)
+{
+   struct gist_xlog_delete_v15* xlrec = &wrapper->data.v15;
+   buf = pgmoneta_format_and_append(buf, "latestRemovedXid: %u; ntodelete: %u", xlrec->latestRemovedXid, xlrec->ntodelete);
+   return buf;
+}
+
+// Formatting function for version 16
+char*
+pgmoneta_wal_format_gist_xlog_delete_v16(struct gist_xlog_delete* wrapper, char* buf)
+{
+   struct gist_xlog_delete_v16* xlrec = &wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "delete: snapshot_conflict_horizon_id %u, nitems: %u",
+                                    xlrec->snapshotConflictHorizon, xlrec->ntodelete);
+   return buf;
+}
+
+struct gist_xlog_page_reuse*
+create_gist_xlog_page_reuse(void)
+{
+   struct gist_xlog_page_reuse* wrapper = malloc(sizeof(struct gist_xlog_page_reuse));
+
+   if (server_config->version >= 16)
+   {
+      wrapper->parse = pgmoneta_wal_parse_gist_xlog_page_reuse_v16;
+      wrapper->format = pgmoneta_wal_format_gist_xlog_page_reuse_v16;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_gist_xlog_page_reuse_v15;
+      wrapper->format = pgmoneta_wal_format_gist_xlog_page_reuse_v15;
+   }
+
+   return wrapper;
+}
+
+void
+pgmoneta_wal_parse_gist_xlog_page_reuse_v15(struct gist_xlog_page_reuse* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct gist_xlog_page_reuse_v15));
+}
+
+void
+pgmoneta_wal_parse_gist_xlog_page_reuse_v16(struct gist_xlog_page_reuse* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct gist_xlog_page_reuse_v16));
+}
+
+char*
+pgmoneta_wal_format_gist_xlog_page_reuse_v15(struct gist_xlog_page_reuse* wrapper, char* buf)
+{
+   struct gist_xlog_page_reuse_v15* xlrec = &wrapper->data.v15;
+   buf = pgmoneta_format_and_append(buf, "rel %u/%u/%u; blk %u; latestRemovedXid %u:%u",
+                                    xlrec->node.spcNode, xlrec->node.dbNode,
+                                    xlrec->node.relNode, xlrec->block,
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(xlrec->latestRemovedFullXid),
+                                    XID_FROM_FULL_TRANSACTION_ID(xlrec->latestRemovedFullXid));
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_gist_xlog_page_reuse_v16(struct gist_xlog_page_reuse* wrapper, char* buf)
+{
+   struct gist_xlog_page_reuse_v16* xlrec = &wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "rel %u/%u/%u; blk %u; snapshot_conflict_horizon_id %u:%u",
+                                    xlrec->locator.spcOid, xlrec->locator.dbOid,
+                                    xlrec->locator.relNumber, xlrec->block,
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(xlrec->snapshot_conflict_horizon),
+                                    XID_FROM_FULL_TRANSACTION_ID(xlrec->snapshot_conflict_horizon));
+   return buf;
+}
+
+static char*
+out_gistxlogPageUpdate(char* buf, struct gist_xlog_page_update* xlrec)
+{
+   return buf;
+}
+
+static char*
+out_gistxlogPageSplit(char* buf, struct gist_xlog_page_split* xlrec)
+{
+   buf = pgmoneta_format_and_append(buf, "page_split: splits to %d pages",
+                                    xlrec->npage);
+   return buf;
+}
+
+static char*
+out_gistxlogPageDelete(char* buf, struct gist_xlog_page_delete* xlrec)
+{
+   buf = pgmoneta_format_and_append(buf, "deleteXid %u:%u; downlink %u",
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(xlrec->deleteXid),
+                                    XID_FROM_FULL_TRANSACTION_ID(xlrec->deleteXid),
+                                    xlrec->downlinkOffset);
+   return buf;
+}
+
+char*
+pgmoneta_wal_gist_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+   struct gist_xlog_page_reuse* xlrec_reuse;
+   struct gist_xlog_delete* xlrec_delete;
+
+   switch (info)
+   {
+      case XLOG_GIST_PAGE_UPDATE:
+         buf = out_gistxlogPageUpdate(buf, (struct gist_xlog_page_update*) rec);
+         break;
+      case XLOG_GIST_PAGE_REUSE:
+         xlrec_reuse = create_gist_xlog_page_reuse();
+         xlrec_reuse->parse(xlrec_reuse, rec);
+         buf = xlrec_reuse->format(xlrec_reuse, buf);
+         free(xlrec_reuse);
+         break;
+      case XLOG_GIST_DELETE:
+         xlrec_delete = create_gist_xlog_delete();
+         xlrec_delete->parse(xlrec_delete, rec);
+         buf = xlrec_delete->format(xlrec_delete, buf);
+         free(xlrec_delete);
+         break;
+      case XLOG_GIST_PAGE_SPLIT:
+         buf = out_gistxlogPageSplit(buf, (struct gist_xlog_page_split*) rec);
+         break;
+      case XLOG_GIST_PAGE_DELETE:
+         buf = out_gistxlogPageDelete(buf, (struct gist_xlog_page_delete*) rec);
+         break;
+      case XLOG_GIST_ASSIGN_LSN:
+         /* No details to write out */
+         break;
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_hash.c
+++ b/src/libpgmoneta/wal/rm_hash.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_hash.h>
+#include <utils.h>
+
+struct xl_hash_vacuum_one_page*
+pgmoneta_wal_create_xl_hash_vacuum_one_page(void)
+{
+   struct xl_hash_vacuum_one_page* wrapper = malloc(sizeof(struct xl_hash_vacuum_one_page));
+
+   if (server_config->version >= 16)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_hash_vacuum_one_page_v16;
+      wrapper->format = pgmoneta_wal_format_xl_hash_vacuum_one_page_v16;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_hash_vacuum_one_page_v15;
+      wrapper->format = pgmoneta_wal_format_xl_hash_vacuum_one_page_v15;
+   }
+
+   return wrapper;
+}
+
+void
+pgmoneta_wal_parse_xl_hash_vacuum_one_page_v15(struct xl_hash_vacuum_one_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_hash_vacuum_one_page_v15));
+}
+
+void
+pgmoneta_wal_parse_xl_hash_vacuum_one_page_v16(struct xl_hash_vacuum_one_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct xl_hash_vacuum_one_page_v16));
+}
+
+char*
+pgmoneta_wal_format_xl_hash_vacuum_one_page_v15(struct xl_hash_vacuum_one_page* wrapper, char* buf)
+{
+   struct xl_hash_vacuum_one_page_v15* xlrec = &wrapper->data.v15;
+   buf = pgmoneta_format_and_append(buf, "ntuples %d, latestRemovedXid %u",
+                                    xlrec->ntuples,
+                                    xlrec->latestRemovedXid);
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_xl_hash_vacuum_one_page_v16(struct xl_hash_vacuum_one_page* wrapper, char* buf)
+{
+   struct xl_hash_vacuum_one_page_v16* xlrec = &wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "ntuples %d, snapshot_conflict_horizon_id %u",
+                                    xlrec->ntuples,
+                                    xlrec->snaphost_conflict_horizon);
+   return buf;
+}
+
+char*
+pgmoneta_wal_hash_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   switch (info)
+   {
+      case XLOG_HASH_INIT_META_PAGE:
+      {
+         struct xl_hash_init_meta_page* xlrec = (struct xl_hash_init_meta_page*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "num_tuples %g, fillfactor %d",
+                                          xlrec->num_tuples, xlrec->ffactor);
+         break;
+      }
+      case XLOG_HASH_INIT_BITMAP_PAGE:
+      {
+         struct xl_hash_init_bitmap_page* xlrec = (struct xl_hash_init_bitmap_page*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "bmsize %d", xlrec->bmsize);
+         break;
+      }
+      case XLOG_HASH_INSERT:
+      {
+         struct xl_hash_insert* xlrec = (struct xl_hash_insert*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "off %u", xlrec->offnum);
+         break;
+      }
+      case XLOG_HASH_ADD_OVFL_PAGE:
+      {
+         struct xl_hash_add_ovfl_page* xlrec = (struct xl_hash_add_ovfl_page*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "bmsize %d, bmpage_found %c",
+                                          xlrec->bmsize, (xlrec->bmpage_found) ? 'T' : 'F');
+         break;
+      }
+      case XLOG_HASH_SPLIT_ALLOCATE_PAGE:
+      {
+         struct xl_hash_split_allocate_page* xlrec = (struct xl_hash_split_allocate_page*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "new_bucket %u, meta_page_masks_updated %c, issplitpoint_changed %c",
+                                          xlrec->new_bucket,
+                                          (xlrec->flags & XLH_SPLIT_META_UPDATE_MASKS) ? 'T' : 'F',
+                                          (xlrec->flags & XLH_SPLIT_META_UPDATE_SPLITPOINT) ? 'T' : 'F');
+         break;
+      }
+      case XLOG_HASH_SPLIT_COMPLETE:
+      {
+         struct xl_hash_split_complete* xlrec = (struct xl_hash_split_complete*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "old_bucket_flag %u, new_bucket_flag %u",
+                                          xlrec->old_bucket_flag, xlrec->new_bucket_flag);
+         break;
+      }
+      case XLOG_HASH_MOVE_PAGE_CONTENTS:
+      {
+         struct xl_hash_move_page_contents* xlrec = (struct xl_hash_move_page_contents*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "ntups %d, is_primary %c",
+                                          xlrec->ntups,
+                                          xlrec->is_prim_bucket_same_wrt ? 'T' : 'F');
+         break;
+      }
+      case XLOG_HASH_SQUEEZE_PAGE:
+      {
+         struct xl_hash_squeeze_page* xlrec = (struct xl_hash_squeeze_page*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "prevblkno %u, nextblkno %u, ntups %d, is_primary %c",
+                                          xlrec->prevblkno,
+                                          xlrec->nextblkno,
+                                          xlrec->ntups,
+                                          xlrec->is_prim_bucket_same_wrt ? 'T' : 'F');
+         break;
+      }
+      case XLOG_HASH_DELETE:
+      {
+         struct xl_hash_delete* xlrec = (struct xl_hash_delete*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "clear_dead_marking %c, is_primary %c",
+                                          xlrec->clear_dead_marking ? 'T' : 'F',
+                                          xlrec->is_primary_bucket_page ? 'T' : 'F');
+         break;
+      }
+      case XLOG_HASH_UPDATE_META_PAGE:
+      {
+         struct xl_hash_update_meta_page* xlrec = (struct xl_hash_update_meta_page*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "ntuples %g",
+                                          xlrec->ntuples);
+         break;
+      }
+      case XLOG_HASH_VACUUM_ONE_PAGE:
+      {
+         struct xl_hash_vacuum_one_page* xlrec = pgmoneta_wal_create_xl_hash_vacuum_one_page();
+         xlrec->parse(xlrec, rec);
+         buf = xlrec->format(xlrec, buf);
+         free(xlrec);
+         break;
+      }
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_heap.c
+++ b/src/libpgmoneta/wal/rm_heap.c
@@ -1,0 +1,465 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm_heap.h>
+#include <utils.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <assert.h>
+
+struct xl_heap_freeze_page*
+pgmoneta_wal_create_xl_heap_freeze_page(void)
+{
+   struct xl_heap_freeze_page* wrapper = malloc(sizeof(struct xl_heap_freeze_page));
+
+   if (server_config->version >= 16)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_heap_freeze_page_v16;
+      wrapper->format = pgmoneta_wal_format_xl_heap_freeze_page_v16;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_heap_freeze_page_v15;
+      wrapper->format = pgmoneta_wal_format_xl_heap_freeze_page_v15;
+   }
+
+   return wrapper;
+}
+
+/**
+ * Parses a version 15 xl_heap_freeze_page structure.
+ */
+void
+pgmoneta_wal_parse_xl_heap_freeze_page_v15(struct xl_heap_freeze_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_heap_freeze_page_v15));
+}
+
+/**
+ * Parses a version 16 xl_heap_freeze_page structure.
+ */
+void
+pgmoneta_wal_parse_xl_heap_freeze_page_v16(struct xl_heap_freeze_page* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct xl_heap_freeze_page_v16));
+}
+
+/**
+ * Formats a version 15 xl_heap_freeze_page structure.
+ */
+char*
+pgmoneta_wal_format_xl_heap_freeze_page_v15(struct xl_heap_freeze_page* wrapper, char* buf)
+{
+   struct xl_heap_freeze_page_v15* xlrec = &wrapper->data.v15;
+   buf = pgmoneta_format_and_append(buf, "cutoff xid %u ntuples %u",
+                                    xlrec->cutoff_xid, xlrec->ntuples);
+   return buf;
+}
+
+/**
+ * Formats a version 16 xl_heap_freeze_page structure.
+ */
+char*
+pgmoneta_wal_format_xl_heap_freeze_page_v16(struct xl_heap_freeze_page* wrapper, char* buf)
+{
+   struct xl_heap_freeze_page_v16* xlrec = &wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "snapshot_conflict_horizon_id %u nplans %u",
+                                    xlrec->snapshot_conflict_horizon, xlrec->nplans);
+   return buf;
+}
+
+static char*
+out_infobits(char* buf, uint8_t infobits)
+{
+   if (infobits & XLHL_XMAX_IS_MULTI)
+   {
+      buf = pgmoneta_format_and_append(buf, "IS_MULTI ");
+   }
+   if (infobits & XLHL_XMAX_LOCK_ONLY)
+   {
+      buf = pgmoneta_format_and_append(buf, "LOCK_ONLY ");
+   }
+   if (infobits & XLHL_XMAX_EXCL_LOCK)
+   {
+      buf = pgmoneta_format_and_append(buf, "EXCL_LOCK ");
+   }
+   if (infobits & XLHL_XMAX_KEYSHR_LOCK)
+   {
+      buf = pgmoneta_format_and_append(buf, "KEYSHR_LOCK ");
+   }
+   if (infobits & XLHL_KEYS_UPDATED)
+   {
+      buf = pgmoneta_format_and_append(buf, "KEYS_UPDATED ");
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_heap_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = record->main_data;
+   uint8_t info = record->header.xl_info & ~XLR_INFO_MASK;
+
+   info &= XLOG_HEAP_OPMASK;
+   if (info == XLOG_HEAP_INSERT)
+   {
+      struct xl_heap_insert* xlrec = (struct xl_heap_insert*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u flags 0x%02X", xlrec->offnum, xlrec->flags);
+   }
+   else if (info == XLOG_HEAP_DELETE)
+   {
+      struct xl_heap_delete* xlrec = (struct xl_heap_delete*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u flags 0x%02X ",
+                                       xlrec->offnum,
+                                       xlrec->flags);
+      buf = out_infobits(buf, xlrec->infobits_set);
+   }
+   else if (info == XLOG_HEAP_UPDATE)
+   {
+      struct xl_heap_update* xlrec = (struct xl_heap_update*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u xmax %u flags 0x%02X ",
+                                       xlrec->old_offnum,
+                                       xlrec->old_xmax,
+                                       xlrec->flags);
+      buf = out_infobits(buf, xlrec->old_infobits_set);
+      buf = pgmoneta_format_and_append(buf, "; new off %u xmax %u",
+                                       xlrec->new_offnum,
+                                       xlrec->new_xmax);
+   }
+   else if (info == XLOG_HEAP_HOT_UPDATE)
+   {
+      struct xl_heap_update* xlrec = (struct xl_heap_update*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u xmax %u flags 0x%02X ",
+                                       xlrec->old_offnum,
+                                       xlrec->old_xmax,
+                                       xlrec->flags);
+      buf = out_infobits(buf, xlrec->old_infobits_set);
+      buf = pgmoneta_format_and_append(buf, "; new off %u xmax %u",
+                                       xlrec->new_offnum,
+                                       xlrec->new_xmax);
+   }
+   else if (info == XLOG_HEAP_TRUNCATE)
+   {
+      struct xl_heap_truncate* xlrec = (struct xl_heap_truncate*) rec;
+      int i;
+
+      if (xlrec->flags & XLH_TRUNCATE_CASCADE)
+      {
+         buf = pgmoneta_format_and_append(buf, "cascade ");
+      }
+      if (xlrec->flags & XLH_TRUNCATE_RESTART_SEQS)
+      {
+         buf = pgmoneta_format_and_append(buf, "restart_seqs ");
+      }
+      buf = pgmoneta_format_and_append(buf, "nrelids %u relids", xlrec->nrelids);
+      for (i = 0; i < xlrec->nrelids; i++)
+      {
+         buf = pgmoneta_format_and_append(buf, " %u", xlrec->relids[i]);
+      }
+   }
+   else if (info == XLOG_HEAP_CONFIRM)
+   {
+      struct xl_heap_confirm* xlrec = (struct xl_heap_confirm*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u", xlrec->offnum);
+   }
+   else if (info == XLOG_HEAP_LOCK)
+   {
+      struct xl_heap_lock* xlrec = (struct xl_heap_lock*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u: xid %u: flags 0x%02X ",
+                                       xlrec->offnum, xlrec->locking_xid, xlrec->flags);
+      buf = out_infobits(buf, xlrec->infobits_set);
+   }
+   else if (info == XLOG_HEAP_INPLACE)
+   {
+      struct xl_heap_inplace* xlrec = (struct xl_heap_inplace*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u", xlrec->offnum);
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_heap2_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = record->main_data;
+   uint8_t info = record->header.xl_info & ~XLR_INFO_MASK;
+
+   info &= XLOG_HEAP_OPMASK;
+
+   if ((server_config->version >= 17) && (info == XLOG_HEAP2_PRUNE_ON_ACCESS || info == XLOG_HEAP2_PRUNE_VACUUM_SCAN || info == XLOG_HEAP2_PRUNE_VACUUM_CLEANUP)) \
+   {
+      struct xl_heap_prune_v17* xlrec = (struct xl_heap_prune_v17*) rec;
+
+      if (xlrec->flags & XLHP_HAS_CONFLICT_HORIZON)
+      {
+         transaction_id conflict_xid;
+
+         memcpy(&conflict_xid, rec + SizeOfHeapPruneV17, sizeof(transaction_id));
+
+         buf = pgmoneta_format_and_append(buf, "snapshot_conflict_horizon_id: %u", conflict_xid);
+      }
+
+      buf = pgmoneta_format_and_append(buf, ", is_catalog_rel: %c", xlrec->flags & XLHP_IS_CATALOG_REL ? 'T' : 'F');
+
+      if (XLogRecHasBlockData(record, 0))
+      {
+         offset_number* redirected;
+         offset_number* nowdead;
+         offset_number* nowunused;
+         int nredirected;
+         int nunused;
+         int ndead;
+         int nplans;
+         struct xlhp_freeze_plan* plans;
+         offset_number* frz_offsets;
+
+         struct decoded_bkp_block bkpb = record->blocks[0];
+         char* cursor = bkpb.data;
+
+         heap_xlog_deserialize_prune_and_freeze(cursor, xlrec->flags,
+                                                &nplans, &plans, &frz_offsets,
+                                                &nredirected, &redirected,
+                                                &ndead, &nowdead,
+                                                &nunused, &nowunused);
+
+         buf = pgmoneta_format_and_append(buf, ", nplans: %u, nredirected: %u, ndead: %u, nunused: %u",
+                                          nplans, nredirected, ndead, nunused);
+
+         if (nplans > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", plans:");
+            buf = pgmoneta_wal_array_desc(buf, plans, sizeof(struct xlhp_freeze_plan), nplans);
+         }
+
+         if (nredirected > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", redirected:");
+            buf = pgmoneta_wal_array_desc(buf, redirected, sizeof(offset_number) * 2, nredirected);
+         }
+
+         if (ndead > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", dead:");
+            buf = pgmoneta_wal_array_desc(buf, nowdead, sizeof(offset_number), ndead);
+         }
+
+         if (nunused > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", unused:");
+            buf = pgmoneta_wal_array_desc(buf, nowunused, sizeof(offset_number), nunused);
+         }
+      }
+
+   }
+   else if (server_config->version < 17 && info == XLOG_HEAP2_PRUNE)
+   {
+      struct xl_heap_prune_v16* xlrec = (struct xl_heap_prune_v16*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "snapshot_conflict_horizon_id %u nredirected %u ndead %u",
+                                       xlrec->snapshotConflictHorizon,
+                                       xlrec->nredirected,
+                                       xlrec->ndead);
+   }
+   else if (info == XLOG_HEAP2_VACUUM)
+   {
+      struct xl_heap_vacuum* xlrec = (struct xl_heap_vacuum*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "nunused %u", xlrec->nunused);
+   }
+   else if (info == XLOG_HEAP2_FREEZE_PAGE)
+   {
+
+      struct xl_heap_freeze_page* xlrec = pgmoneta_wal_create_xl_heap_freeze_page();
+      xlrec->parse(xlrec, rec);
+      buf = xlrec->format(xlrec, buf);
+      free(xlrec);
+   }
+   else if (info == XLOG_HEAP2_VISIBLE)
+   {
+      struct xl_heap_visible* xlrec = (struct xl_heap_visible*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "cutoff xid %u flags 0x%02X",
+                                       xlrec->cutoff_xid, xlrec->flags);
+   }
+   else if (info == XLOG_HEAP2_MULTI_INSERT)
+   {
+      struct xl_heap_multi_insert* xlrec = (struct xl_heap_multi_insert*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "%d tuples flags 0x%02X", xlrec->ntuples,
+                                       xlrec->flags);
+   }
+   else if (info == XLOG_HEAP2_LOCK_UPDATED)
+   {
+      struct xl_heap_lock_updated* xlrec = (struct xl_heap_lock_updated*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "off %u: xmax %u: flags 0x%02X ",
+                                       xlrec->offnum, xlrec->xmax, xlrec->flags);
+      buf = out_infobits(buf, xlrec->infobits_set);
+   }
+   else if (info == XLOG_HEAP2_NEW_CID)
+   {
+      struct xl_heap_new_cid* xlrec = (struct xl_heap_new_cid*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "rel %u/%u/%u; tid %u/%u",
+                                       xlrec->target_node.spcNode,
+                                       xlrec->target_node.dbNode,
+                                       xlrec->target_node.relNode,
+                                       ITEM_POINTER_GET_BLOCK_NUMBER(&(xlrec->target_tid)),
+                                       ITEM_POINTER_GET_OFFSET_NUMBER(&(xlrec->target_tid)));
+      buf = pgmoneta_format_and_append(buf, "; cmin: %u, cmax: %u, combo: %u",
+                                       xlrec->cmin, xlrec->cmax, xlrec->combocid);
+   }
+   return buf;
+}
+void
+heap_xlog_deserialize_prune_and_freeze(char* cursor, uint8_t flags,
+                                       int* nplans, struct xlhp_freeze_plan** plans,
+                                       offset_number** frz_offsets,
+                                       int* nredirected, offset_number** redirected,
+                                       int* ndead, offset_number** nowdead,
+                                       int* nunused, offset_number** nowunused)
+{
+   if (flags & XLHP_HAS_FREEZE_PLANS)
+   {
+      struct xlhp_freeze_plans* freeze_plans = (struct xlhp_freeze_plans*) cursor;
+
+      *nplans = freeze_plans->nplans;
+      assert(*nplans > 0);
+      *plans = freeze_plans->plans;
+
+      cursor += offsetof(struct xlhp_freeze_plans, plans);
+      cursor += sizeof(struct xlhp_freeze_plan) * *nplans;
+   }
+   else
+   {
+      *nplans = 0;
+      *plans = NULL;
+   }
+
+   if (flags & XLHP_HAS_REDIRECTIONS)
+   {
+      struct xlhp_prune_items* subrecord = (struct xlhp_prune_items*) cursor;
+
+      *nredirected = subrecord->ntargets;
+      assert(*nredirected > 0);
+      *redirected = &subrecord->data[0];
+
+      cursor += offsetof(struct xlhp_prune_items, data);
+      cursor += sizeof(offset_number [2]) * *nredirected;
+   }
+   else
+   {
+      *nredirected = 0;
+      *redirected = NULL;
+   }
+
+   if (flags & XLHP_HAS_DEAD_ITEMS)
+   {
+      struct xlhp_prune_items* subrecord = (struct xlhp_prune_items*) cursor;
+
+      *ndead = subrecord->ntargets;
+      assert(*ndead > 0);
+      *nowdead = subrecord->data;
+
+      cursor += offsetof(struct xlhp_prune_items, data);
+      cursor += sizeof(offset_number) * *ndead;
+   }
+   else
+   {
+      *ndead = 0;
+      *nowdead = NULL;
+   }
+
+   if (flags & XLHP_HAS_NOW_UNUSED_ITEMS)
+   {
+      struct xlhp_prune_items* subrecord = (struct xlhp_prune_items*) cursor;
+
+      *nunused = subrecord->ntargets;
+      assert(*nunused > 0);
+      *nowunused = subrecord->data;
+
+      cursor += offsetof(struct xlhp_prune_items, data);
+      cursor += sizeof(offset_number) * *nunused;
+   }
+   else
+   {
+      *nunused = 0;
+      *nowunused = NULL;
+   }
+
+   *frz_offsets = (offset_number*) cursor;
+}
+
+char*
+offset_elem_desc(char* buf, void* offset, void* data)
+{
+   buf = pgmoneta_format_and_append(buf, "%u", *(offset_number*) offset);
+   return buf;
+}
+
+char*
+plan_elem_desc(char* buf, void* plan, void* data)
+{
+   struct xlhp_freeze_plan* new_plan = (struct xlhp_freeze_plan*) plan;
+   offset_number** offsets = data;
+
+   buf = pgmoneta_format_and_append(buf, "{ xmax: %u, infomask: %u, infomask2: %u, ntuples: %u",
+                                    new_plan->xmax,
+                                    new_plan->t_infomask, new_plan->t_infomask2,
+                                    new_plan->ntuples);
+
+   buf = pgmoneta_format_and_append(buf, ", offsets:");
+   buf = pgmoneta_wal_array_desc(buf, *offsets, sizeof(offset_number), new_plan->ntuples);
+
+   *offsets += new_plan->ntuples;
+
+   buf = pgmoneta_format_and_append(buf, " }");
+   return buf;
+}
+
+char*
+redirect_elem_desc(char* buf, void* offset, void* data)
+{
+   offset_number* new_offset = (offset_number*) offset;
+
+   buf = pgmoneta_format_and_append(buf, "%u->%u", new_offset[0], new_offset[1]);
+   return buf;
+}
+
+char*
+oid_elem_desc(char* buf, void* relid, void* data)
+{
+   buf = pgmoneta_format_and_append(buf, "%u", *(oid*) relid);
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_logicalmsg.c
+++ b/src/libpgmoneta/wal/rm_logicalmsg.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_logicalmsg.h>
+#include <utils.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <assert.h>
+
+char*
+pgmoneta_wal_logicalmsg_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == XLOG_LOGICAL_MESSAGE)
+   {
+      struct xl_logical_message* xlrec = (struct xl_logical_message*) rec;
+      char* prefix = xlrec->message;
+      char* message = xlrec->message + xlrec->prefix_size;
+      char* sep = "";
+
+      assert(prefix[xlrec->prefix_size - 1] == '\0');
+
+      buf = pgmoneta_format_and_append(buf, "%s, prefix \"%s\"; payload (%zu bytes): ",
+                                       xlrec->transactional ? "transactional" : "non-transactional",
+                                       prefix, xlrec->message_size);
+      /* Write message payload as a series of hex bytes */
+      for (int cnt = 0; cnt < xlrec->message_size; cnt++)
+      {
+         buf = pgmoneta_format_and_append(buf, "%s%02X", sep, (unsigned char) message[cnt]);
+         sep = " ";
+      }
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_mxact.c
+++ b/src/libpgmoneta/wal/rm_mxact.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_mxact.h>
+#include <utils.h>
+
+static char*
+out_member(char* buf, struct multi_xact_member* member)
+{
+   buf = pgmoneta_format_and_append(buf, "%u ", member->xid);
+   switch (member->status)
+   {
+      case MULTI_XACT_STATUS_FOR_KEY_SHARE:
+         buf = pgmoneta_format_and_append(buf, "(keysh) ");
+         break;
+      case MULTI_XACT_STATUS_FOR_SHARE:
+         buf = pgmoneta_format_and_append(buf, "(sh) ");
+         break;
+      case MULTI_XACT_STATUS_FOR_NO_KEY_UPDATE:
+         buf = pgmoneta_format_and_append(buf, "(fornokeyupd) ");
+         break;
+      case MULTI_XACT_STATUS_FOR_UPDATE:
+         buf = pgmoneta_format_and_append(buf, "(forupd) ");
+         break;
+      case MULTI_XACT_STATUS_NO_KEY_UPDATE:
+         buf = pgmoneta_format_and_append(buf, "(nokeyupd) ");
+         break;
+      case MULTI_XACT_STATUS_UPDATE:
+         buf = pgmoneta_format_and_append(buf, "(upd) ");
+         break;
+      default:
+         buf = pgmoneta_format_and_append(buf, "(unk) ");
+         break;
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_multixact_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == XLOG_MULTIXACT_ZERO_OFF_PAGE ||
+       info == XLOG_MULTIXACT_ZERO_MEM_PAGE)
+   {
+      int pageno;
+
+      memcpy(&pageno, rec, sizeof(int));
+      buf = pgmoneta_format_and_append(buf, "%d", pageno);
+   }
+   else if (info == XLOG_MULTIXACT_CREATE_ID)
+   {
+      struct xl_multixact_create* xlrec = (struct xl_multixact_create*) rec;
+      int i;
+
+      buf = pgmoneta_format_and_append(buf, "%u offset %u nmembers %d: ", xlrec->mid,
+                                       xlrec->moff, xlrec->nmembers);
+      for (i = 0; i < xlrec->nmembers; i++)
+      {
+         out_member(buf, &xlrec->members[i]);
+      }
+   }
+   else if (info == XLOG_MULTIXACT_TRUNCATE_ID)
+   {
+      struct xl_multixact_truncate* xlrec = (struct xl_multixact_truncate*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "offsets [%u, %u), members [%u, %u)",
+                                       xlrec->start_trunc_off, xlrec->end_trunc_off,
+                                       xlrec->start_trunc_memb, xlrec->end_trunc_memb);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_relmap.c
+++ b/src/libpgmoneta/wal/rm_relmap.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_relmap.h>
+#include <utils.h>
+
+char*
+pgmoneta_wal_relmap_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == XLOG_RELMAP_UPDATE)
+   {
+      struct xl_relmap_update* xlrec = (struct xl_relmap_update*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "database %u tablespace %u size %u",
+                                       xlrec->db_id, xlrec->ts_id, xlrec->nbytes);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_replorigin.c
+++ b/src/libpgmoneta/wal/rm_replorigin.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_replorigin.h>
+#include <utils.h>
+
+char*
+pgmoneta_wal_replorigin_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   switch (info)
+   {
+      case XLOG_REPLORIGIN_SET:
+      {
+         struct xl_replorigin_set* xlrec;
+
+         xlrec = (struct xl_replorigin_set*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "set %u; lsn %X/%X; force: %d",
+                                          xlrec->node_id,
+                                          LSN_FORMAT_ARGS(xlrec->remote_lsn),
+                                          xlrec->force);
+         break;
+      }
+      case XLOG_REPLORIGIN_DROP:
+      {
+         struct xl_replorigin_drop* xlrec;
+
+         xlrec = (struct xl_replorigin_drop*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "drop %u", xlrec->node_id);
+         break;
+      }
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_seq.c
+++ b/src/libpgmoneta/wal/rm_seq.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_seq.h>
+#include <utils.h>
+
+char*
+pgmoneta_wal_seq_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+   struct xl_seq_rec* xlrec = (struct xl_seq_rec*) rec;
+
+   if (info == XLOG_SEQ_LOG)
+   {
+      buf = pgmoneta_format_and_append(buf, "rel %u/%u/%u",
+                                       xlrec->node.spcNode, xlrec->node.dbNode,
+                                       xlrec->node.relNode);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_spgist.c
+++ b/src/libpgmoneta/wal/rm_spgist.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_spgist.h>
+#include <utils.h>
+
+struct spg_xlog_vacuum_redirect*
+create_spg_xlog_vacuum_redirect(void)
+{
+   struct spg_xlog_vacuum_redirect* wrapper = malloc(sizeof(struct spg_xlog_vacuum_redirect));
+
+   if (server_config->version >= 16)
+   {
+      wrapper->parse = pgmoneta_wal_parse_spg_xlog_vacuum_redirect_v16;
+      wrapper->format = pgmoneta_wal_format_spg_xlog_vacuum_redirect_v16;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_spg_xlog_vacuum_redirect_v15;
+      wrapper->format = pgmoneta_wal_format_spg_xlog_vacuum_redirect_v15;
+   }
+
+   return wrapper;
+}
+
+void
+pgmoneta_wal_parse_spg_xlog_vacuum_redirect_v15(struct spg_xlog_vacuum_redirect* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct spg_xlog_vacuum_redirect_v15));
+}
+
+void
+pgmoneta_wal_parse_spg_xlog_vacuum_redirect_v16(struct spg_xlog_vacuum_redirect* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v16, rec, sizeof(struct spg_xlog_vacuum_redirect_v16));
+}
+
+char*
+pgmoneta_wal_format_spg_xlog_vacuum_redirect_v15(struct spg_xlog_vacuum_redirect* wrapper, char* buf)
+{
+   struct spg_xlog_vacuum_redirect_v15* xlrec = &wrapper->data.v15;
+   buf = pgmoneta_format_and_append(buf, "ntoplaceholder: %u, firstplaceholder: %u, newestredirectxid: %u",
+                                    xlrec->nToPlaceholder,
+                                    xlrec->firstPlaceholder,
+                                    xlrec->newestRedirectXid);
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_spg_xlog_vacuum_redirect_v16(struct spg_xlog_vacuum_redirect* wrapper, char* buf)
+{
+   struct spg_xlog_vacuum_redirect_v16* xlrec = &wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "ntoplaceholder: %u, firstplaceholder: %u, snapshot_conflict_horizon_id: %u",
+                                    xlrec->n_to_placeholder,
+                                    xlrec->first_placeholder,
+                                    xlrec->snapshot_conflict_horizon);
+   return buf;
+}
+
+char*
+pgmoneta_wal_spg_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   switch (info)
+   {
+      case XLOG_SPGIST_ADD_LEAF:
+      {
+         struct spg_xlog_add_leaf* xlrec = (struct spg_xlog_add_leaf*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "off: %u, headoff: %u, parentoff: %u, node_i: %u",
+                                          xlrec->offnum_leaf, xlrec->offnum_head_leaf,
+                                          xlrec->offnum_parent, xlrec->node_i);
+         if (xlrec->new_page)
+         {
+            buf = pgmoneta_format_and_append(buf, " (newpage)");
+         }
+         if (xlrec->stores_nulls)
+         {
+            buf = pgmoneta_format_and_append(buf, " (nulls)");
+         }
+      }
+      break;
+      case XLOG_SPGIST_MOVE_LEAFS:
+      {
+         struct spg_xlog_move_leafs* xlrec = (struct spg_xlog_move_leafs*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "nmoves: %u, parentoff: %u, node_i: %u",
+                                          xlrec->n_moves,
+                                          xlrec->offnum_parent, xlrec->node_i);
+         if (xlrec->new_page)
+         {
+            buf = pgmoneta_format_and_append(buf, " (newpage)");
+         }
+         if (xlrec->replace_dead)
+         {
+            buf = pgmoneta_format_and_append(buf, " (replacedead)");
+         }
+         if (xlrec->stores_nulls)
+         {
+            buf = pgmoneta_format_and_append(buf, " (nulls)");
+         }
+      }
+      break;
+      case XLOG_SPGIST_ADD_NODE:
+      {
+         struct spg_xlog_add_node* xlrec = (struct spg_xlog_add_node*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "off: %u, newoff: %u, parent_blk: %d, "
+                                          "parentoff: %u, node_i: %u",
+                                          xlrec->offnum,
+                                          xlrec->offnum_new,
+                                          xlrec->parent_blk,
+                                          xlrec->offnum_parent,
+                                          xlrec->node_i);
+         if (xlrec->new_page)
+         {
+            buf = pgmoneta_format_and_append(buf, " (newpage)");
+         }
+      }
+      break;
+      case XLOG_SPGIST_SPLIT_TUPLE:
+      {
+         struct spg_xlog_split_tuple* xlrec = (struct spg_xlog_split_tuple*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "prefixoff: %u, postfixoff: %u",
+                                          xlrec->offnum_prefix,
+                                          xlrec->offnum_postfix);
+         if (xlrec->new_page)
+         {
+            buf = pgmoneta_format_and_append(buf, " (newpage)");
+         }
+         if (xlrec->postfix_blk_same)
+         {
+            buf = pgmoneta_format_and_append(buf, " (same)");
+         }
+      }
+      break;
+      case XLOG_SPGIST_PICKSPLIT:
+      {
+         struct spg_xlog_pick_split* xlrec = (struct spg_xlog_pick_split*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "ndelete: %u, ninsert: %u, inneroff: %u, "
+                                          "parentoff: %u, node_i: %u",
+                                          xlrec->n_delete, xlrec->n_insert,
+                                          xlrec->offnum_inner,
+                                          xlrec->offnum_parent, xlrec->node_i);
+         if (xlrec->inner_is_parent)
+         {
+            buf = pgmoneta_format_and_append(buf, " (inner_is_parent)");
+         }
+         if (xlrec->stores_nulls)
+         {
+            buf = pgmoneta_format_and_append(buf, " (nulls)");
+         }
+         if (xlrec->is_root_split)
+         {
+            buf = pgmoneta_format_and_append(buf, " (is_root_split)");
+         }
+      }
+      break;
+      case XLOG_SPGIST_VACUUM_LEAF:
+      {
+         struct spg_xlog_vacuum_leaf* xlrec = (struct spg_xlog_vacuum_leaf*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "ndead: %u, nplaceholder: %u, nmove: %u, nchain: %u",
+                                          xlrec->n_dead, xlrec->n_placeholder,
+                                          xlrec->n_move, xlrec->n_chain);
+      }
+      break;
+      case XLOG_SPGIST_VACUUM_ROOT:
+      {
+         struct spg_xlog_vacuum_root* xlrec = (struct spg_xlog_vacuum_root*) rec;
+
+         buf = pgmoneta_format_and_append(buf, "ndelete: %u",
+                                          xlrec->n_delete);
+      }
+      break;
+      case XLOG_SPGIST_VACUUM_REDIRECT:
+      {
+         struct spg_xlog_vacuum_redirect* xlrec = create_spg_xlog_vacuum_redirect();
+         xlrec->parse(xlrec, rec);
+         buf = xlrec->format(xlrec, buf);
+         free(xlrec);
+      }
+      break;
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_standby.c
+++ b/src/libpgmoneta/wal/rm_standby.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm_standby.h>
+#include <utils.h>
+
+static char*
+standby_desc_running_xacts(char* buf, struct xl_running_xacts* xlrec)
+{
+   int i;
+
+   buf = pgmoneta_format_and_append(buf, "next_xid %u latest_completed_xid %u oldest_running_xid %u",
+                                    xlrec->next_xid,
+                                    xlrec->latest_completed_xid,
+                                    xlrec->oldest_running_xid);
+   if (xlrec->xcnt > 0)
+   {
+      buf = pgmoneta_format_and_append(buf, "; %d xacts:", xlrec->xcnt);
+      for (i = 0; i < xlrec->xcnt; i++)
+      {
+         buf = pgmoneta_format_and_append(buf, " %u", xlrec->xids[i]);
+      }
+   }
+
+   if (xlrec->subxid_overflow)
+   {
+      buf = pgmoneta_format_and_append(buf, "; subxid overflowed");
+   }
+
+   if (xlrec->subxcnt > 0)
+   {
+      buf = pgmoneta_format_and_append(buf, "; %d subxacts:", xlrec->subxcnt);
+      for (i = 0; i < xlrec->subxcnt; i++)
+      {
+         buf = pgmoneta_format_and_append(buf, " %u", xlrec->xids[xlrec->xcnt + i]);
+      }
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_standby_desc_invalidations(char* buf, int nmsgs, union shared_invalidation_message* msgs, oid dbId, oid tsId, bool rel_cache_init_file_inval
+                                        )
+{
+   int i;
+
+   /* Do nothing if there are no invalidation messages */
+   if (nmsgs <= 0)
+   {
+      return buf;
+   }
+
+   if (rel_cache_init_file_inval)
+   {
+      buf = pgmoneta_format_and_append(buf, "; relcache init file inval db_id %u ts_id %u", dbId, tsId);
+   }
+
+   buf = pgmoneta_format_and_append(buf, "; inval msgs:");
+   for (i = 0; i < nmsgs; i++)
+   {
+
+      union shared_invalidation_message* msg = &msgs[i];
+
+      if (msg->id >= 0)
+      {
+         buf = pgmoneta_format_and_append(buf, " catcache %d", msg->id);
+      }
+      else if (msg->id == SHAREDINVALCATALOG_ID)
+      {
+         pgmoneta_format_and_append(buf, " catalog %u", msg->cat.cat_id);
+      }
+      else if (msg->id == SHAREDINVALRELCACHE_ID)
+      {
+         buf = pgmoneta_format_and_append(buf, " relcache %u", msg->rc.rel_id);
+      }
+      /* not expected, but print something anyway */
+      else if (msg->id == SHAREDINVALSMGR_ID)
+      {
+         buf = pgmoneta_format_and_append(buf, " smgr");
+      }
+      /* not expected, but print something anyway */
+      else if (msg->id == SHAREDINVALRELMAP_ID)
+      {
+         buf = pgmoneta_format_and_append(buf, " relmap db %u", msg->rm.db_id);
+      }
+      else if (msg->id == SHAREDINVALSNAPSHOT_ID)
+      {
+         buf = pgmoneta_format_and_append(buf, " snapshot %u", msg->sn.rel_id);
+      }
+      else
+      {
+         buf = pgmoneta_format_and_append(buf, " unrecognized id %d", msg->id);
+      }
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_standby_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = record->main_data;
+   uint8_t info = record->header.xl_info & ~XLR_INFO_MASK;
+
+   if (info == XLOG_STANDBY_LOCK)
+   {
+      struct xl_standby_locks* xlrec = (struct xl_standby_locks*) rec;
+      int i;
+
+      for (i = 0; i < xlrec->nlocks; i++)
+      {
+         buf = pgmoneta_format_and_append(buf, "xid %u db %u rel %u ",
+                                          xlrec->locks[i].xid, xlrec->locks[i].db_oid,
+                                          xlrec->locks[i].rel_oid);
+      }
+   }
+   else if (info == XLOG_RUNNING_XACTS)
+   {
+      struct xl_running_xacts* xlrec = (struct xl_running_xacts*) rec;
+
+      buf = standby_desc_running_xacts(buf, xlrec);
+   }
+   else if (info == XLOG_INVALIDATIONS)
+   {
+      struct xl_invalidations* xlrec = (struct xl_invalidations*) rec;
+      buf = pgmoneta_wal_standby_desc_invalidations(buf, xlrec->nmsgs, xlrec->msgs,
+                                                    xlrec->dbId, xlrec->tsId,
+                                                    xlrec->relcacheInitFileInval);
+
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_storage.c
+++ b/src/libpgmoneta/wal/rm_storage.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/relpath.h>
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_storage.h>
+#include <utils.h>
+
+char*
+pgmoneta_wal_storage_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == XLOG_SMGR_CREATE)
+   {
+      struct xl_smgr_create* xlrec = (struct xl_smgr_create*) rec;
+      char* path = RELPATHPERM(xlrec->rnode, xlrec->forkNum);
+
+      buf = pgmoneta_format_and_append(buf, path);
+      free(path);
+   }
+   else if (info == XLOG_SMGR_TRUNCATE)
+   {
+      struct xl_smgr_truncate* xlrec = (struct xl_smgr_truncate*) rec;
+      char* path = RELPATHPERM(xlrec->rnode, MAIN_FORKNUM);
+
+      buf = pgmoneta_format_and_append(buf, "%s to %u blocks flags %d", path,
+                                       xlrec->blkno, xlrec->flags);
+      free(path);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_tablespace.c
+++ b/src/libpgmoneta/wal/rm_tablespace.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_tablespace.h>
+#include <utils.h>
+
+char*
+pgmoneta_wal_tablespace_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & ~XLR_INFO_MASK;
+
+   if (info == XLOG_TBLSPC_CREATE)
+   {
+      struct xl_tblspc_create_rec* xlrec = (struct xl_tblspc_create_rec*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "%u \"%s\"", xlrec->ts_id, xlrec->ts_path);
+   }
+   else if (info == XLOG_TBLSPC_DROP)
+   {
+      struct xl_tblspc_drop_rec* xlrec = (struct xl_tblspc_drop_rec*) rec;
+
+      buf = pgmoneta_format_and_append(buf, "%u", xlrec->ts_id);
+   }
+   return buf;
+}

--- a/src/libpgmoneta/wal/rm_xact.c
+++ b/src/libpgmoneta/wal/rm_xact.c
@@ -1,0 +1,940 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <wal/walfile/relpath.h>
+#include <wal/walfile/rm_standby.h>
+#include <wal/walfile/rm_xact.h>
+#include <utils.h>
+
+#include <string.h>
+
+typedef struct xl_xact_xinfo xl_xact_xinfo;
+
+static char*xact_desc_relations(char* buf, char* label, int nrels, struct rel_file_node* xnodes);
+
+static char*xact_desc_commit_v14(char* buf, uint8_t info, struct xl_xact_commit* xlrec, rep_origin_id origin_id);
+static char*xact_desc_abort_v14(char* buf, uint8_t info, struct xl_xact_abort* xlrec);
+static char*xact_desc_prepare_v14(char* buf, uint8_t info, struct xl_xact_prepare_v14* xlrec);
+
+static char*xact_desc_commit_v15(char* buf, uint8_t info, struct xl_xact_commit* xlrec, rep_origin_id origin_id);
+static char*xact_desc_abort_v15(char* buf, uint8_t info, struct xl_xact_abort* xlrec);
+static char*xact_desc_prepare_v15(char* buf, uint8_t info, struct xl_xact_prepare_v15* xlrec);
+
+static char*xact_desc_assignment(char* buf, struct xl_xact_assignment* xlrec);
+static char*xact_desc_subxacts(char* buf, int nsubxacts, transaction_id* subxacts);
+
+void parse_abort_record_v14(uint8_t info, struct xl_xact_abort* xlrec, struct xl_xact_parsed_abort_v14* parsed);
+void parse_abort_record_v15(uint8_t info, struct xl_xact_abort* xlrec, struct xl_xact_parsed_abort_v15* parsed);
+
+void parse_prepare_record_v14(uint8_t info, struct xl_xact_prepare_v14* xlrec, xl_xact_parsed_prepare_v14* parsed);
+void parse_prepare_record_v15(uint8_t info, struct xl_xact_prepare_v15* xlrec, xl_xact_parsed_prepare_v15* parsed);
+
+void parse_commit_record_v14(uint8_t info, struct xl_xact_commit* xlrec, struct xl_xact_parsed_commit_v14* parsed);
+void parse_commit_record_v15(uint8_t info, struct xl_xact_commit* xlrec, struct xl_xact_parsed_commit_v15* parsed);
+
+/**
+ * Parses a version 14 xl_xact_prepare record.
+ */
+void
+pgmoneta_wal_parse_xl_xact_prepare_v14(struct xl_xact_prepare* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v14, rec, sizeof(struct xl_xact_prepare_v14));
+}
+
+/**
+ * Parses a version 15 xl_xact_prepare record.
+ */
+void
+pgmoneta_wal_parse_xl_xact_prepare_v15(struct xl_xact_prepare* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_xact_prepare_v15));
+}
+
+/**
+ * Formats a version 14 xl_xact_prepare record.
+ */
+char*
+pgmoneta_wal_format_xl_xact_prepare_v14(struct xl_xact_prepare* wrapper, char* rec, char* buf)
+{
+   return buf;
+}
+
+/**
+ * Formats a version 15 xl_xact_prepare record.
+ */
+char*
+pgmoneta_wal_format_xl_xact_prepare_v15(struct xl_xact_prepare* wrapper, char* rec, char* buf)
+{
+   return buf;
+}
+
+/**
+ * Creates an xl_xact_prepare wrapper.
+ */
+struct xl_xact_prepare*
+pgmoneta_wal_create_xl_xact_prepare(void)
+{
+   struct xl_xact_prepare* wrapper = malloc(sizeof(struct xl_xact_prepare));
+
+   if (server_config->version >= 15)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_xact_prepare_v15;
+      wrapper->format = pgmoneta_wal_format_xl_xact_prepare_v15;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_xact_prepare_v14;
+      wrapper->format = pgmoneta_wal_format_xl_xact_prepare_v14;
+   }
+
+   return wrapper;
+}
+
+/* Create parsed commit wrapper structure */
+struct xl_xact_parsed_commit*
+pgmoneta_wal_create_xact_parsed_commit(void)
+{
+   struct xl_xact_parsed_commit* wrapper = malloc(sizeof(struct xl_xact_parsed_commit));
+
+   if (server_config->version >= 15)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xact_commit_v15;
+      wrapper->format = pgmoneta_wal_format_xact_commit_v15;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xact_commit_v14;
+      wrapper->format = pgmoneta_wal_format_xact_commit_v14;
+   }
+
+   return wrapper;
+}
+
+/* Parse commit record for version 14 */
+void
+pgmoneta_wal_parse_xact_commit_v14(struct xl_xact_parsed_commit* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v14, rec, sizeof(struct xl_xact_parsed_commit_v14));
+}
+
+/* Parse commit record for version 15 */
+void
+pgmoneta_wal_parse_xact_commit_v15(struct xl_xact_parsed_commit* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_xact_parsed_commit_v15));
+}
+
+/* Format commit record for version 14 */
+char*
+pgmoneta_wal_format_xact_commit_v14(struct xl_xact_parsed_commit* wrapper, char* rec, char* buf)
+{
+   return buf;
+}
+
+/* Format commit record for version 15 */
+char*
+pgmoneta_wal_format_xact_commit_v15(struct xl_xact_parsed_commit* wrapper, char* rec, char* buf)
+{
+   return buf;
+}
+
+struct xl_xact_parsed_abort*
+pgmoneta_wal_create_xl_xact_parsed_abort(void)
+{
+   struct xl_xact_parsed_abort* wrapper = malloc(sizeof(struct xl_xact_parsed_abort));
+
+   if (server_config->version >= 15)
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_xact_parsed_abort_v15;
+      wrapper->format = pgmoneta_wal_format_xl_xact_parsed_abort_v15;
+   }
+   else
+   {
+      wrapper->parse = pgmoneta_wal_parse_xl_xact_parsed_abort_v14;
+      wrapper->format = pgmoneta_wal_format_xl_xact_parsed_abort_v14;
+   }
+
+   return wrapper;
+}
+
+void
+pgmoneta_wal_parse_xl_xact_parsed_abort_v14(struct xl_xact_parsed_abort* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v14, rec, sizeof(struct xl_xact_parsed_abort_v14));
+}
+
+void
+pgmoneta_wal_parse_xl_xact_parsed_abort_v15(struct xl_xact_parsed_abort* wrapper, const void* rec)
+{
+   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_xact_parsed_abort_v15));
+}
+
+char*
+pgmoneta_wal_format_xl_xact_parsed_abort_v14(struct xl_xact_parsed_abort* wrapper, char* rec, char* buf)
+{
+   return buf;
+}
+
+char*
+pgmoneta_wal_format_xl_xact_parsed_abort_v15(struct xl_xact_parsed_abort* wrapper, char* rec, char* buf)
+{
+   return buf;
+}
+
+static char*
+xact_desc_relations(char* buf, char* label, int nrels,
+                    struct rel_file_node* xnodes)
+{
+   int i;
+
+   if (nrels > 0)
+   {
+      buf = pgmoneta_format_and_append(buf, "; %s:", label);
+      for (i = 0; i < nrels; i++)
+      {
+         char* path = RELPATHPERM(xnodes[i], MAIN_FORKNUM);
+
+         buf = pgmoneta_format_and_append(buf, " %s", path);
+         free(path);
+      }
+   }
+   return buf;
+}
+
+static char*
+xact_desc_commit_v14(char* buf, uint8_t info, struct xl_xact_commit* xlrec, rep_origin_id origin_id)
+{
+   struct xl_xact_parsed_commit_v14 parsed;
+   parse_commit_record_v14(info, xlrec, &parsed);
+
+   /* If this is a prepared xact, show the xid of the original xact */
+   if (TRANSACTION_ID_IS_VALID(parsed.twophase_xid))
+   {
+      buf = pgmoneta_format_and_append(buf, "%u: ", parsed.twophase_xid);
+   }
+
+   buf = pgmoneta_format_and_append(buf, pgmoneta_wal_timestamptz_to_str(xlrec->xact_time));
+
+   buf = xact_desc_relations(buf, "rels", parsed.nrels, parsed.xnodes);
+   buf = xact_desc_subxacts(buf, parsed.nsubxacts, parsed.subxacts);
+
+   buf = pgmoneta_wal_standby_desc_invalidations(buf, parsed.nmsgs, parsed.msgs, parsed.db_id,
+                                                 parsed.ts_id,
+                                                 XACT_COMPLETION_RELCACHE_INIT_FILE_INVAL(parsed.xinfo));
+
+   if (XACT_COMPLETION_FORCE_SYNC_COMMIT(parsed.xinfo))
+   {
+      buf = pgmoneta_format_and_append(buf, "; sync");
+   }
+
+   if (parsed.xinfo & XACT_XINFO_HAS_ORIGIN)
+   {
+      buf = pgmoneta_format_and_append(buf, "; origin: node %u, lsn %X/%X, at %s",
+                                       origin_id,
+                                       LSN_FORMAT_ARGS(parsed.origin_lsn),
+                                       pgmoneta_wal_timestamptz_to_str(parsed.origin_timestamp));
+   }
+   return buf;
+}
+
+static char*
+xact_desc_commit_v15(char* buf, uint8_t info, struct xl_xact_commit* xlrec, rep_origin_id origin_id)
+{
+   struct xl_xact_parsed_commit_v15 parsed;
+   parse_commit_record_v15(info, xlrec, &parsed);
+
+   /* If this is a prepared xact, show the xid of the original xact */
+   if (TRANSACTION_ID_IS_VALID(parsed.twophase_xid))
+   {
+      buf = pgmoneta_format_and_append(buf, "%u: ", parsed.twophase_xid);
+   }
+
+   buf = pgmoneta_format_and_append(buf, pgmoneta_wal_timestamptz_to_str(xlrec->xact_time));
+
+   buf = xact_desc_relations(buf, "rels", parsed.nrels, parsed.xnodes);
+   buf = xact_desc_subxacts(buf, parsed.nsubxacts, parsed.subxacts);
+
+   buf = pgmoneta_wal_standby_desc_invalidations(buf, parsed.nmsgs, parsed.msgs, parsed.db_id,
+                                                 parsed.ts_id,
+                                                 XACT_COMPLETION_RELCACHE_INIT_FILE_INVAL(parsed.xinfo));
+
+   if (XACT_COMPLETION_FORCE_SYNC_COMMIT(parsed.xinfo))
+   {
+      buf = pgmoneta_format_and_append(buf, "; sync");
+   }
+
+   if (parsed.xinfo & XACT_XINFO_HAS_ORIGIN)
+   {
+      buf = pgmoneta_format_and_append(buf, "; origin: node %u, lsn %X/%X, at %s",
+                                       origin_id,
+                                       LSN_FORMAT_ARGS(parsed.origin_lsn),
+                                       pgmoneta_wal_timestamptz_to_str(parsed.origin_timestamp));
+   }
+   return buf;
+}
+
+static char*
+xact_desc_abort_v14(char* buf, uint8_t info, struct xl_xact_abort* xlrec)
+{
+   struct xl_xact_parsed_abort_v14 parsed;
+
+   parse_abort_record_v14(info, xlrec, &parsed);
+
+   /* If this is a prepared xact, show the xid of the original xact */
+   if (TRANSACTION_ID_IS_VALID(parsed.twophase_xid))
+   {
+      buf = pgmoneta_format_and_append(buf, "%u: ", parsed.twophase_xid);
+   }
+
+   buf = pgmoneta_format_and_append(buf, pgmoneta_wal_timestamptz_to_str(xlrec->xact_time));
+
+   buf = xact_desc_relations(buf, "rels", parsed.nrels, parsed.xnodes);
+   buf = xact_desc_subxacts(buf, parsed.nsubxacts, parsed.subxacts);
+
+   return buf;
+}
+static char*
+xact_desc_abort_v15(char* buf, uint8_t info, struct xl_xact_abort* xlrec)
+{
+   struct xl_xact_parsed_abort_v15 parsed;
+
+   parse_abort_record_v15(info, xlrec, &parsed);
+
+   /* If this is a prepared xact, show the xid of the original xact */
+   if (TRANSACTION_ID_IS_VALID(parsed.twophase_xid))
+   {
+      buf = pgmoneta_format_and_append(buf, "%u: ", parsed.twophase_xid);
+   }
+
+   buf = pgmoneta_format_and_append(buf, pgmoneta_wal_timestamptz_to_str(xlrec->xact_time));
+
+   buf = xact_desc_relations(buf, "rels", parsed.nrels, parsed.xnodes);
+   buf = xact_desc_subxacts(buf, parsed.nsubxacts, parsed.subxacts);
+
+   return buf;
+}
+
+static char*
+xact_desc_prepare_v14(char* buf, uint8_t info, struct xl_xact_prepare_v14* xlrec)
+{
+   xl_xact_parsed_prepare_v14 parsed;
+
+   parse_prepare_record_v14(info, xlrec, &parsed);
+
+   buf = pgmoneta_format_and_append(buf, "gid %s: ", parsed.twophase_gid);
+   buf = pgmoneta_format_and_append(buf, pgmoneta_wal_timestamptz_to_str(parsed.xact_time));
+
+   buf = xact_desc_relations(buf, "rels(commit)", parsed.nrels, parsed.xnodes);
+   buf = xact_desc_relations(buf, "rels(abort)", parsed.nabortrels,
+                             parsed.abortnodes);
+   buf = xact_desc_subxacts(buf, parsed.nsubxacts, parsed.subxacts);
+
+   buf = pgmoneta_wal_standby_desc_invalidations(buf, parsed.nmsgs, parsed.msgs, parsed.db_id,
+                                                 parsed.ts_id, xlrec);
+   return buf;
+}
+static char*
+xact_desc_prepare_v15(char* buf, uint8_t info, struct xl_xact_prepare_v15* xlrec)
+{
+   xl_xact_parsed_prepare_v15 parsed;
+
+   parse_prepare_record_v15(info, xlrec, &parsed);
+
+   buf = pgmoneta_format_and_append(buf, "gid %s: ", parsed.twophase_gid);
+   buf = pgmoneta_format_and_append(buf, pgmoneta_wal_timestamptz_to_str(parsed.xact_time));
+
+   buf = xact_desc_relations(buf, "rels(commit)", parsed.nrels, parsed.xnodes);
+   buf = xact_desc_relations(buf, "rels(abort)", parsed.nabortrels,
+                             parsed.abortnodes);
+   buf = xact_desc_subxacts(buf, parsed.nsubxacts, parsed.subxacts);
+
+   buf = pgmoneta_wal_standby_desc_invalidations(buf, parsed.nmsgs, parsed.msgs, parsed.db_id,
+                                                 parsed.ts_id, xlrec->initfileinval);
+   return buf;
+}
+
+static char*
+xact_desc_assignment(char* buf, struct xl_xact_assignment* xlrec)
+{
+   int i;
+
+   buf = pgmoneta_format_and_append(buf, "subxacts:");
+
+   for (i = 0; i < xlrec->nsubxacts; i++)
+   {
+      buf = pgmoneta_format_and_append(buf, " %u", xlrec->xsub[i]);
+   }
+   return buf;
+}
+
+static char*
+xact_desc_subxacts(char* buf, int nsubxacts, transaction_id* subxacts)
+{
+   int i;
+
+   if (nsubxacts > 0)
+   {
+      buf = pgmoneta_format_and_append(buf, "; subxacts:");
+      for (i = 0; i < nsubxacts; i++)
+      {
+         buf = pgmoneta_format_and_append(buf, " %u", subxacts[i]);
+      }
+   }
+   return buf;
+}
+
+char*
+pgmoneta_wal_xact_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = XLOG_REC_GET_DATA(record);
+   uint8_t info = XLOG_REC_GET_INFO(record) & XLOG_XACT_OPMASK;
+
+   if (info == XLOG_XACT_COMMIT || info == XLOG_XACT_COMMIT_PREPARED)
+   {
+      struct xl_xact_commit* xlrec = (struct xl_xact_commit*) rec;
+
+      if (server_config->version >= 15)
+      {
+         buf = xact_desc_commit_v15(buf, XLOG_REC_GET_INFO(record), xlrec, XLOG_REC_GET_ORIGIN(record));
+      }
+      else
+      {
+         buf = xact_desc_commit_v14(buf, XLOG_REC_GET_INFO(record), xlrec, XLOG_REC_GET_ORIGIN(record));
+      }
+   }
+   else if (info == XLOG_XACT_ABORT || info == XLOG_XACT_ABORT_PREPARED)
+   {
+      struct xl_xact_abort* xlrec = (struct xl_xact_abort*) rec;
+      if (server_config->version >= 15)
+      {
+         buf = xact_desc_abort_v15(buf, XLOG_REC_GET_INFO(record), xlrec);
+      }
+      else
+      {
+         buf = xact_desc_abort_v14(buf, XLOG_REC_GET_INFO(record), xlrec);
+      }
+
+   }
+   else if (info == XLOG_XACT_PREPARE)
+   {
+
+      if (server_config->version >= 15)
+      {
+         struct xl_xact_prepare_v15* xlrec = (struct xl_xact_prepare_v15*) rec;
+         buf = xact_desc_prepare_v15(buf, XLOG_REC_GET_INFO(record), xlrec);
+      }
+      else
+      {
+         struct xl_xact_prepare_v14* xlrec = (struct xl_xact_prepare_v14*) rec;
+         buf = xact_desc_prepare_v14(buf, XLOG_REC_GET_INFO(record), xlrec);
+      }
+
+   }
+   else if (info == XLOG_XACT_ASSIGNMENT)
+   {
+      struct xl_xact_assignment* xlrec = (struct xl_xact_assignment*) rec;
+
+      /*
+       * Note that we ignore the WAL record's xid, since we're more
+       * interested in the top-level xid that issued the record and which
+       * xids are being reported here.
+       */
+      buf = pgmoneta_format_and_append(buf, "xtop %u: ", xlrec->xtop);
+      buf = xact_desc_assignment(buf, xlrec);
+   }
+   else if (info == XLOG_XACT_INVALIDATIONS)
+   {
+      struct xl_xact_invals* xlrec = (struct xl_xact_invals*) rec;
+
+      buf = pgmoneta_wal_standby_desc_invalidations(buf, xlrec->nmsgs, xlrec->msgs, InvalidOid,
+                                                    InvalidOid, false);
+   }
+   return buf;
+}
+
+// v14
+
+void
+parse_abort_record_v14(uint8_t info, struct xl_xact_abort* xlrec, struct xl_xact_parsed_abort_v14* parsed)
+{
+   char* data = ((char*) xlrec) + MIN_SIZE_OF_XACT_ABORT;
+
+   memset(parsed, 0, sizeof(*parsed));
+
+   parsed->xinfo = 0;         /* default, if no XLOG_XACT_HAS_INFO is
+                               * present */
+
+   parsed->xact_time = xlrec->xact_time;
+
+   if (info & XLOG_XACT_HAS_INFO)
+   {
+      xl_xact_xinfo* xl_xinfo = (xl_xact_xinfo*) data;
+
+      parsed->xinfo = xl_xinfo->xinfo;
+
+      data += sizeof(xl_xact_xinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_DBINFO)
+   {
+      struct xl_xact_dbinfo* xl_dbinfo = (struct xl_xact_dbinfo*) data;
+
+      parsed->dbId = xl_dbinfo->db_id;
+      parsed->tsId = xl_dbinfo->ts_id;
+
+      data += sizeof(struct xl_xact_dbinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_SUBXACTS)
+   {
+      struct xl_xact_subxacts* xl_subxacts = (struct xl_xact_subxacts*) data;
+
+      parsed->nsubxacts = xl_subxacts->nsubxacts;
+      parsed->subxacts = xl_subxacts->subxacts;
+
+      data += MIN_SIZE_OF_XACT_SUBXACTS;
+      data += parsed->nsubxacts * sizeof(transaction_id);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_RELFILENODES)
+   {
+      struct xl_xact_relfilenodes* xl_relfilenodes = (struct xl_xact_relfilenodes*) data;
+
+      parsed->nrels = xl_relfilenodes->nrels;
+      parsed->xnodes = xl_relfilenodes->xnodes;
+
+      data += MIN_SIZE_OF_XACT_RELFILENODES;
+      data += xl_relfilenodes->nrels * sizeof(struct rel_file_node);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_TWOPHASE)
+   {
+      struct xl_xact_twophase* xl_twophase = (struct xl_xact_twophase*) data;
+
+      parsed->twophase_xid = xl_twophase->xid;
+
+      data += sizeof(struct xl_xact_twophase);
+
+      if (parsed->xinfo & XACT_XINFO_HAS_GID)
+      {
+         snprintf(parsed->twophase_gid, sizeof(parsed->twophase_gid), "%s", data);;
+         data += strlen(data) + 1;
+      }
+   }
+
+   /* Note: no alignment is guaranteed after this point */
+
+   if (parsed->xinfo & XACT_XINFO_HAS_ORIGIN)
+   {
+      struct xl_xact_origin xl_origin;
+
+      /* no alignment is guaranteed, so copy onto stack */
+      memcpy(&xl_origin, data, sizeof(xl_origin));
+
+      parsed->origin_lsn = xl_origin.origin_lsn;
+      parsed->origin_timestamp = xl_origin.origin_timestamp;
+
+      data += sizeof(struct xl_xact_origin);
+   }
+}
+
+void
+parse_prepare_record_v14(uint8_t info, struct xl_xact_prepare_v14* xlrec, xl_xact_parsed_prepare_v14* parsed)
+{
+   char* bufptr;
+
+   bufptr = ((char*) xlrec) + MAXALIGN(sizeof(struct xl_xact_prepare));
+
+   memset(parsed, 0, sizeof(*parsed));
+
+   parsed->xact_time = xlrec->prepared_at;
+   parsed->origin_lsn = xlrec->origin_lsn;
+   parsed->origin_timestamp = xlrec->origin_timestamp;
+   parsed->twophase_xid = xlrec->xid;
+   parsed->db_id = xlrec->database;
+   parsed->nsubxacts = xlrec->nsubxacts;
+   parsed->nrels = xlrec->ncommitrels;
+   parsed->nabortrels = xlrec->nabortrels;
+   parsed->nmsgs = xlrec->ninvalmsgs;
+
+   strncpy(parsed->twophase_gid, bufptr, xlrec->gidlen);
+   bufptr += MAXALIGN(xlrec->gidlen);
+
+   parsed->subxacts = (transaction_id*) bufptr;
+   bufptr += MAXALIGN(xlrec->nsubxacts * sizeof(transaction_id));
+
+   parsed->xnodes = (struct rel_file_node*) bufptr;
+   bufptr += MAXALIGN(xlrec->ncommitrels * sizeof(struct rel_file_node));
+
+   parsed->abortnodes = (struct rel_file_node*) bufptr;
+   bufptr += MAXALIGN(xlrec->nabortrels * sizeof(struct rel_file_node));
+
+   parsed->msgs = (union shared_invalidation_message*) bufptr;
+   bufptr += MAXALIGN(xlrec->ninvalmsgs * sizeof(union shared_invalidation_message));
+}
+
+void
+parse_commit_record_v14(uint8_t info, struct xl_xact_commit* xlrec, struct xl_xact_parsed_commit_v14* parsed)
+{
+   char* data = ((char*) xlrec) + MIN_SIZE_OF_XACT_COMMIT;
+
+   memset(parsed, 0, sizeof(*parsed));
+
+   parsed->xinfo = 0;         /* default, if no XLOG_XACT_HAS_INFO is
+                               * present */
+
+   parsed->xact_time = xlrec->xact_time;
+
+   if (info & XLOG_XACT_HAS_INFO)
+   {
+      xl_xact_xinfo* xl_xinfo = (xl_xact_xinfo*) data;
+
+      parsed->xinfo = xl_xinfo->xinfo;
+
+      data += sizeof(xl_xact_xinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_DBINFO)
+   {
+      struct xl_xact_dbinfo* xl_dbinfo = (struct xl_xact_dbinfo*) data;
+
+      parsed->db_id = xl_dbinfo->db_id;
+      parsed->ts_id = xl_dbinfo->ts_id;
+
+      data += sizeof(struct xl_xact_dbinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_SUBXACTS)
+   {
+      struct xl_xact_subxacts* xl_subxacts = (struct xl_xact_subxacts*) data;
+
+      parsed->nsubxacts = xl_subxacts->nsubxacts;
+      parsed->subxacts = xl_subxacts->subxacts;
+
+      data += MIN_SIZE_OF_XACT_SUBXACTS;
+      data += parsed->nsubxacts * sizeof(transaction_id);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_RELFILENODES)
+   {
+      struct xl_xact_relfilenodes* xl_relfilenodes = (struct xl_xact_relfilenodes*) data;
+
+      parsed->nrels = xl_relfilenodes->nrels;
+      parsed->xnodes = xl_relfilenodes->xnodes;
+
+      data += MIN_SIZE_OF_XACT_RELFILENODES;
+      data += xl_relfilenodes->nrels * sizeof(struct rel_file_node);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_INVALS)
+   {
+      struct xl_xact_invals* xl_invals = (struct xl_xact_invals*) data;
+
+      parsed->nmsgs = xl_invals->nmsgs;
+      parsed->msgs = xl_invals->msgs;
+
+      data += MIN_SIZE_OF_XACT_INVALS;
+      data += xl_invals->nmsgs * sizeof(union shared_invalidation_message);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_TWOPHASE)
+   {
+      struct xl_xact_twophase* xl_twophase = (struct xl_xact_twophase*) data;
+
+      parsed->twophase_xid = xl_twophase->xid;
+
+      data += sizeof(struct xl_xact_twophase);
+
+      if (parsed->xinfo & XACT_XINFO_HAS_GID)
+      {
+         snprintf(parsed->twophase_gid, sizeof(parsed->twophase_gid), "%s", data);;
+         data += strlen(data) + 1;
+      }
+   }
+
+   /* Note: no alignment is guaranteed after this point */
+
+   if (parsed->xinfo & XACT_XINFO_HAS_ORIGIN)
+   {
+      struct xl_xact_origin xl_origin;
+
+      /* no alignment is guaranteed, so copy onto stack */
+      memcpy(&xl_origin, data, sizeof(xl_origin));
+
+      parsed->origin_lsn = xl_origin.origin_lsn;
+      parsed->origin_timestamp = xl_origin.origin_timestamp;
+
+      data += sizeof(struct xl_xact_origin);
+   }
+}
+
+// v15
+void
+parse_abort_record_v15(uint8_t info, struct xl_xact_abort* xlrec, struct xl_xact_parsed_abort_v15* parsed)
+{
+   char* data = ((char*) xlrec) + MIN_SIZE_OF_XACT_ABORT;
+
+   memset(parsed, 0, sizeof(*parsed));
+
+   parsed->xinfo = 0;         /* default, if no XLOG_XACT_HAS_INFO is
+                               * present */
+
+   parsed->xact_time = xlrec->xact_time;
+
+   if (info & XLOG_XACT_HAS_INFO)
+   {
+      struct xl_xact_xinfo* xl_xinfo = (xl_xact_xinfo*) data;
+
+      parsed->xinfo = xl_xinfo->xinfo;
+
+      data += sizeof(xl_xact_xinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_DBINFO)
+   {
+      struct xl_xact_dbinfo* xl_dbinfo = (struct xl_xact_dbinfo*) data;
+
+      parsed->db_id = xl_dbinfo->db_id;
+      parsed->ts_id = xl_dbinfo->ts_id;
+
+      data += sizeof(struct xl_xact_dbinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_SUBXACTS)
+   {
+      struct xl_xact_subxacts* xl_subxacts = (struct xl_xact_subxacts*) data;
+
+      parsed->nsubxacts = xl_subxacts->nsubxacts;
+      parsed->subxacts = xl_subxacts->subxacts;
+
+      data += MIN_SIZE_OF_XACT_SUBXACTS;
+      data += parsed->nsubxacts * sizeof(transaction_id);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_RELFILENODES)
+   {
+      struct xl_xact_relfilenodes* xl_relfilenodes = (struct xl_xact_relfilenodes*) data;
+
+      parsed->nrels = xl_relfilenodes->nrels;
+      parsed->xnodes = xl_relfilenodes->xnodes;
+
+      data += MIN_SIZE_OF_XACT_RELFILENODES;
+      data += xl_relfilenodes->nrels * sizeof(struct rel_file_node);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_DROPPED_STATS)
+   {
+      struct xl_xact_stats_items* xl_drops = (struct xl_xact_stats_items*) data;
+
+      parsed->nstats = xl_drops->nitems;
+      parsed->stats = xl_drops->items;
+
+      data += MIN_SIZE_OF_XACT_STATS_ITEMS;
+      data += xl_drops->nitems * sizeof(struct xl_xact_stats_item);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_TWOPHASE)
+   {
+      struct xl_xact_twophase* xl_twophase = (struct xl_xact_twophase*) data;
+
+      parsed->twophase_xid = xl_twophase->xid;
+
+      data += sizeof(struct xl_xact_twophase);
+
+      if (parsed->xinfo & XACT_XINFO_HAS_GID)
+      {
+         snprintf(parsed->twophase_gid, sizeof(parsed->twophase_gid), "%s", data);;
+         data += strlen(data) + 1;
+      }
+   }
+
+   /* Note: no alignment is guaranteed after this point */
+
+   if (parsed->xinfo & XACT_XINFO_HAS_ORIGIN)
+   {
+      struct xl_xact_origin xl_origin;
+
+      /* no alignment is guaranteed, so copy onto stack */
+      memcpy(&xl_origin, data, sizeof(xl_origin));
+
+      parsed->origin_lsn = xl_origin.origin_lsn;
+      parsed->origin_timestamp = xl_origin.origin_timestamp;
+
+      data += sizeof(struct xl_xact_origin);
+   }
+}
+
+/*
+ * ParsePrepareRecord
+ */
+void
+parse_prepare_record_v15(uint8_t info, struct xl_xact_prepare_v15* xlrec, xl_xact_parsed_prepare_v15* parsed)
+{
+   char* bufptr;
+
+   bufptr = ((char*) xlrec) + MAXALIGN(sizeof(struct xl_xact_prepare));
+
+   memset(parsed, 0, sizeof(*parsed));
+
+   parsed->xact_time = xlrec->prepared_at;
+   parsed->origin_lsn = xlrec->origin_lsn;
+   parsed->origin_timestamp = xlrec->origin_timestamp;
+   parsed->twophase_xid = xlrec->xid;
+   parsed->db_id = xlrec->database;
+   parsed->nsubxacts = xlrec->nsubxacts;
+   parsed->nrels = xlrec->ncommitrels;
+   parsed->nabortrels = xlrec->nabortrels;
+   parsed->nmsgs = xlrec->ninvalmsgs;
+
+   strncpy(parsed->twophase_gid, bufptr, xlrec->gidlen);
+   bufptr += MAXALIGN(xlrec->gidlen);
+
+   parsed->subxacts = (transaction_id*) bufptr;
+   bufptr += MAXALIGN(xlrec->nsubxacts * sizeof(transaction_id));
+
+   parsed->xnodes = (struct rel_file_node*) bufptr;
+   bufptr += MAXALIGN(xlrec->ncommitrels * sizeof(struct rel_file_node));
+
+   parsed->abortnodes = (struct rel_file_node*) bufptr;
+   bufptr += MAXALIGN(xlrec->nabortrels * sizeof(struct rel_file_node));
+
+   parsed->stats = (struct xl_xact_stats_item*) bufptr;
+   bufptr += MAXALIGN(xlrec->ncommitstats * sizeof(struct xl_xact_stats_item));
+
+   parsed->abortstats = (struct xl_xact_stats_item*) bufptr;
+   bufptr += MAXALIGN(xlrec->nabortstats * sizeof(struct xl_xact_stats_item));
+
+   parsed->msgs = (union shared_invalidation_message*) bufptr;
+   bufptr += MAXALIGN(xlrec->ninvalmsgs * sizeof(union shared_invalidation_message));
+}
+
+void
+parse_commit_record_v15(uint8_t info, struct xl_xact_commit* xlrec, struct xl_xact_parsed_commit_v15* parsed)
+{
+   char* data = ((char*) xlrec) + MIN_SIZE_OF_XACT_COMMIT;
+
+   memset(parsed, 0, sizeof(*parsed));
+
+   parsed->xinfo = 0;         /* default, if no XLOG_XACT_HAS_INFO is
+                               * present */
+
+   parsed->xact_time = xlrec->xact_time;
+
+   if (info & XLOG_XACT_HAS_INFO)
+   {
+      xl_xact_xinfo* xl_xinfo = (xl_xact_xinfo*) data;
+
+      parsed->xinfo = xl_xinfo->xinfo;
+
+      data += sizeof(xl_xact_xinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_DBINFO)
+   {
+      struct xl_xact_dbinfo* xl_dbinfo = (struct xl_xact_dbinfo*) data;
+
+      parsed->db_id = xl_dbinfo->db_id;
+      parsed->ts_id = xl_dbinfo->ts_id;
+
+      data += sizeof(struct xl_xact_dbinfo);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_SUBXACTS)
+   {
+      struct xl_xact_subxacts* xl_subxacts = (struct xl_xact_subxacts*) data;
+
+      parsed->nsubxacts = xl_subxacts->nsubxacts;
+      parsed->subxacts = xl_subxacts->subxacts;
+
+      data += MIN_SIZE_OF_XACT_SUBXACTS;
+      data += parsed->nsubxacts * sizeof(transaction_id);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_RELFILENODES)
+   {
+      struct xl_xact_relfilenodes* xl_relfilenodes = (struct xl_xact_relfilenodes*) data;
+
+      parsed->nrels = xl_relfilenodes->nrels;
+      parsed->xnodes = xl_relfilenodes->xnodes;
+
+      data += MIN_SIZE_OF_XACT_RELFILENODES;
+      data += xl_relfilenodes->nrels * sizeof(struct rel_file_node);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_DROPPED_STATS)
+   {
+      struct xl_xact_stats_items* xl_drops = (struct xl_xact_stats_items*) data;
+
+      parsed->nstats = xl_drops->nitems;
+      parsed->stats = xl_drops->items;
+
+      data += MIN_SIZE_OF_XACT_STATS_ITEMS;
+      data += xl_drops->nitems * sizeof(struct xl_xact_stats_item);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_INVALS)
+   {
+      struct xl_xact_invals* xl_invals = (struct xl_xact_invals*) data;
+
+      parsed->nmsgs = xl_invals->nmsgs;
+      parsed->msgs = xl_invals->msgs;
+
+      data += MIN_SIZE_OF_XACT_INVALS;
+      data += xl_invals->nmsgs * sizeof(union shared_invalidation_message);
+   }
+
+   if (parsed->xinfo & XACT_XINFO_HAS_TWOPHASE)
+   {
+      struct xl_xact_twophase* xl_twophase = (struct xl_xact_twophase*) data;
+
+      parsed->twophase_xid = xl_twophase->xid;
+
+      data += sizeof(struct xl_xact_twophase);
+
+      if (parsed->xinfo & XACT_XINFO_HAS_GID)
+      {
+         snprintf(parsed->twophase_gid, sizeof(parsed->twophase_gid), "%s", data);;
+         data += strlen(data) + 1;
+      }
+   }
+
+   /* Note: no alignment is guaranteed after this point */
+
+   if (parsed->xinfo & XACT_XINFO_HAS_ORIGIN)
+   {
+      struct xl_xact_origin xl_origin;
+
+      /* no alignment is guaranteed, so copy onto stack */
+      memcpy(&xl_origin, data, sizeof(xl_origin));
+
+      parsed->origin_lsn = xl_origin.origin_lsn;
+      parsed->origin_timestamp = xl_origin.origin_timestamp;
+
+      data += sizeof(struct xl_xact_origin);
+   }
+}

--- a/src/libpgmoneta/wal/rm_xlog.c
+++ b/src/libpgmoneta/wal/rm_xlog.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <logging.h>
+#include <pgmoneta.h>
+#include <utils.h>
+#include <wal/walfile/pg_control.h>
+#include <wal/walfile/rm.h>
+#include <wal/walfile/rm_xlog.h>
+#include <wal/walfile/wal_reader.h>
+
+const struct config_enum_entry wal_level_options[] = {
+   {"minimal", WAL_LEVEL_MINIMAL, false},
+   {"replica", WAL_LEVEL_REPLICA, false},
+   {"archive", WAL_LEVEL_REPLICA, true},        /* deprecated */
+   {"hot_standby", WAL_LEVEL_REPLICA, true},       /* deprecated */
+   {"logical", WAL_LEVEL_LOGICAL, false},
+   {NULL, 0, false}
+};
+
+static const char*
+get_wal_level_string(int wal_level)
+{
+   const struct config_enum_entry* entry;
+   const char* wal_level_str = "?";
+
+   for (entry = wal_level_options; entry->name; entry++)
+   {
+      if (entry->val == wal_level)
+      {
+         wal_level_str = entry->name;
+         break;
+      }
+   }
+
+   return wal_level_str;
+};
+
+struct xl_end_of_recovery*
+create_xl_end_of_recovery(void)
+{
+   struct xl_end_of_recovery* wrapper = (struct xl_end_of_recovery*)malloc(sizeof(struct xl_end_of_recovery));
+
+   if (server_config->version >= 17)
+   {
+      wrapper->parse = xl_end_of_recovery_parse_v17;
+      wrapper->format = xl_end_of_recovery_format_v17;
+   }
+   else
+   {
+      wrapper->parse = xl_end_of_recovery_parse_v16;
+      wrapper->format = xl_end_of_recovery_format_v16;
+   }
+   return wrapper;
+}
+
+struct check_point*
+create_check_point(void)
+{
+   struct check_point* wrapper = (struct check_point*)malloc(sizeof(struct check_point));
+
+   if (server_config->version >= 17)
+   {
+      wrapper->parse = check_point_parse_v17;
+      wrapper->format = check_point_format_v17;
+   }
+   else
+   {
+      wrapper->parse = check_point_parse_v16;
+      wrapper->format = check_point_format_v16;
+   }
+   return wrapper;
+}
+char*
+check_point_format_v16(struct check_point* wrapper, char* buf)
+{
+   struct check_point_v16 checkpoint = wrapper->data.v16;
+
+   buf = pgmoneta_format_and_append(buf, "redo %X/%X; "
+                                    "tli %u; prev tli %u; fpw %s; xid %u:%u; oid %u; multi %u; offset %u; "
+                                    "oldest xid %u in DB %u; oldest multi %u in DB %u; "
+                                    "oldest/newest commit timestamp xid: %u/%u; "
+                                    "oldest running xid %u;",
+                                    LSN_FORMAT_ARGS(checkpoint.redo),
+                                    checkpoint.this_timeline_id,
+                                    checkpoint.prev_timeline_id,
+                                    checkpoint.full_page_writes ? "true" : "false",
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(checkpoint.next_xid),
+                                    XID_FROM_FULL_TRANSACTION_ID(checkpoint.next_xid),
+                                    checkpoint.next_oid,
+                                    checkpoint.next_multi,
+                                    checkpoint.next_multi_offset,
+                                    checkpoint.oldest_xid,
+                                    checkpoint.oldest_xid_db,
+                                    checkpoint.oldest_multi,
+                                    checkpoint.oldest_multi_db,
+                                    checkpoint.oldest_commit_ts_xid,
+                                    checkpoint.newest_commit_ts_xid,
+                                    checkpoint.oldest_active_xid);
+   return buf;
+
+}
+
+char*
+check_point_format_v17(struct check_point* wrapper, char* buf)
+{
+   struct check_point_v17 checkpoint = wrapper->data.v17;
+
+   buf = pgmoneta_format_and_append(buf, "redo %X/%X; "
+                                    "tli %u; prev tli %u; fpw %s; wal_level %s; xid %u:%u; oid %u; multi %u; offset %u; "
+                                    "oldest xid %u in DB %u; oldest multi %u in DB %u; "
+                                    "oldest/newest commit timestamp xid: %u/%u; "
+                                    "oldest running xid %u",
+                                    LSN_FORMAT_ARGS(checkpoint.redo),
+                                    checkpoint.this_timeline_id,
+                                    checkpoint.prev_timeline_id,
+                                    checkpoint.full_page_writes ? "true" : "false",
+                                    get_wal_level_string(checkpoint.wal_level),
+                                    EPOCH_FROM_FULL_TRANSACTION_ID(checkpoint.next_xid),
+                                    XID_FROM_FULL_TRANSACTION_ID(checkpoint.next_xid),
+                                    checkpoint.next_oid,
+                                    checkpoint.next_multi,
+                                    checkpoint.next_multi_offset,
+                                    checkpoint.oldest_xid,
+                                    checkpoint.oldest_xid_db,
+                                    checkpoint.oldest_multi,
+                                    checkpoint.oldest_multi_db,
+                                    checkpoint.oldest_commit_ts_xid,
+                                    checkpoint.newest_commit_ts_xid,
+                                    checkpoint.oldest_active_xid);
+   return buf;
+}
+
+void
+check_point_parse_v16(struct check_point* wrapper, const void* rec)
+{
+   struct check_point_v16* checkpoint = (struct check_point_v16*) rec;
+   wrapper->data.v16 = *checkpoint;
+}
+
+void
+check_point_parse_v17(struct check_point* wrapper, const void* rec)
+{
+   struct check_point_v17* checkpoint = (struct check_point_v17*) rec;
+   wrapper->data.v17 = *checkpoint;
+}
+
+void
+xl_end_of_recovery_parse_v17(struct xl_end_of_recovery* wrapper, const void* rec)
+{
+   struct xl_end_of_recovery_v17 xlrec;
+   memcpy(&xlrec, rec, sizeof(struct xl_end_of_recovery_v17));
+   wrapper->data.v17 = xlrec;
+}
+
+void
+xl_end_of_recovery_parse_v16(struct xl_end_of_recovery* wrapper, const void* rec)
+{
+   struct xl_end_of_recovery_v16 xlrec;
+   memcpy(&xlrec, rec, sizeof(struct xl_end_of_recovery_v16));
+   wrapper->data.v16 = xlrec;
+}
+
+char*
+xl_end_of_recovery_format_v17(struct xl_end_of_recovery* wrapper, char* buf)
+{
+   struct xl_end_of_recovery_v17 xlrec = wrapper->data.v17;
+   buf = pgmoneta_format_and_append(buf, "tli %u; prev tli %u; time %s; wal_level %s",
+                                    xlrec.this_timeline_id, xlrec.prev_timeline_id,
+                                    pgmoneta_wal_timestamptz_to_str(xlrec.end_time),
+                                    get_wal_level_string(xlrec.wal_level));
+   return buf;
+}
+
+char*
+xl_end_of_recovery_format_v16(struct xl_end_of_recovery* wrapper, char* buf)
+{
+   struct xl_end_of_recovery_v16 xlrec = wrapper->data.v16;
+   buf = pgmoneta_format_and_append(buf, "tli %u; prev tli %u; time %s",
+                                    xlrec.this_timeline_id, xlrec.prev_timeline_id,
+                                    pgmoneta_wal_timestamptz_to_str(xlrec.end_time));
+   return buf;
+}
+
+char*
+pgmoneta_wal_xlog_desc(char* buf, struct decoded_xlog_record* record)
+{
+   char* rec = record->main_data;
+   uint8_t info = record->header.xl_info & ~XLR_INFO_MASK;
+   buf = pgmoneta_append(buf, "");
+
+   if (info == XLOG_CHECKPOINT_SHUTDOWN ||
+       info == XLOG_CHECKPOINT_ONLINE)
+   {
+      struct check_point* checkpoint = create_check_point();
+      checkpoint->parse(checkpoint, rec);
+      buf = checkpoint->format(checkpoint, buf);
+      buf = pgmoneta_format_and_append(buf, " %s", (info == XLOG_CHECKPOINT_SHUTDOWN) ? "shutdown" : "online");
+      free(checkpoint);
+   }
+   else if (info == XLOG_NEXTOID)
+   {
+      oid nextOid;
+
+      memcpy(&nextOid, rec, sizeof(oid));
+      buf = pgmoneta_format_and_append(buf, "%u", nextOid);
+   }
+   else if (info == XLOG_RESTORE_POINT)
+   {
+      struct xl_restore_point* xlrec = (struct xl_restore_point*) rec;
+
+      buf = pgmoneta_format_and_append(buf, xlrec->rp_name);
+   }
+   else if (info == XLOG_FPI || info == XLOG_FPI_FOR_HINT)
+   {
+      /* no further information to print */
+   }
+   else if (info == XLOG_BACKUP_END)
+   {
+      xlog_rec_ptr startpoint;
+
+      memcpy(&startpoint, rec, sizeof(xlog_rec_ptr));
+      buf = pgmoneta_format_and_append(buf, "%X/%X", LSN_FORMAT_ARGS(startpoint));
+   }
+   else if (info == XLOG_PARAMETER_CHANGE)
+   {
+      struct xl_parameter_change xlrec;
+      const char* wal_level_str;
+      const struct config_enum_entry* entry;
+
+      memcpy(&xlrec, rec, sizeof(struct xl_parameter_change));
+
+      /* Find a string representation for wal_level */
+      wal_level_str = "?";
+      for (entry = wal_level_options; entry->name; entry++)
+      {
+         if (entry->val == xlrec.wal_level)
+         {
+            wal_level_str = entry->name;
+            break;
+         }
+      }
+
+      buf = pgmoneta_format_and_append(buf, "max_connections=%d max_worker_processes=%d "
+                                       "max_wal_senders=%d max_prepared_xacts=%d "
+                                       "max_locks_per_xact=%d wal_level=%s "
+                                       "wal_log_hints=%s track_commit_timestamp=%s",
+                                       xlrec.max_connections,
+                                       xlrec.max_worker_processes,
+                                       xlrec.max_wal_senders,
+                                       xlrec.max_prepared_xacts,
+                                       xlrec.max_locks_per_xact,
+                                       wal_level_str,
+                                       xlrec.wal_log_hints ? "on" : "off",
+                                       xlrec.track_commit_timestamp ? "on" : "off");
+   }
+   else if (info == XLOG_FPW_CHANGE)
+   {
+      bool fpw;
+
+      memcpy(&fpw, rec, sizeof(bool));
+      buf = pgmoneta_format_and_append(buf, fpw ? "true" : "false");
+   }
+   else if (info == XLOG_END_OF_RECOVERY)
+   {
+      struct xl_end_of_recovery* xlrec = create_xl_end_of_recovery();
+      xlrec->parse(xlrec, rec);
+      xlrec->format(xlrec, buf);
+      free(xlrec);
+   }
+   else if (info == XLOG_OVERWRITE_CONTRECORD)
+   {
+      struct xl_overwrite_contrecord xlrec;
+
+      memcpy(&xlrec, rec, sizeof(struct xl_overwrite_contrecord));
+      buf = pgmoneta_format_and_append(buf, "lsn %X/%X; time %s",
+                                       LSN_FORMAT_ARGS(xlrec.overwritten_lsn),
+                                       pgmoneta_wal_timestamptz_to_str(xlrec.overwrite_time));
+   }
+   return buf;
+}
+
+pg_time_t
+timestamptz_to_time_t(timestamp_tz t)
+{
+   pg_time_t result;
+
+   result = (pg_time_t) (t / USECS_PER_SEC +
+                         ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * SECS_PER_DAY));
+   return result;
+}
+
+const char*
+pgmoneta_wal_timestamptz_to_str(timestamp_tz dt)
+{
+   static char buf[MAXDATELEN + 1];
+   char ts[MAXDATELEN + 1];
+   char zone[MAXDATELEN + 1];
+   time_t result = (time_t) timestamptz_to_time_t(dt);
+   struct tm* ltime = localtime(&result);
+
+   strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", ltime);
+   strftime(zone, sizeof(zone), "%Z", ltime);
+
+   int written = snprintf(buf, sizeof(buf), "%s.%06d %s",
+                          ts, (int) (dt % USECS_PER_SEC), zone);
+
+   if (written < 0 || written >= sizeof(buf))
+   {
+      // Handle the truncation or error
+      pgmoneta_log_fatal("Buffer overflow or encoding error in timestamptz_to_str\n");
+      buf[0] = '\0';   // Ensure buffer is null-terminated
+   }
+
+   return buf;
+}

--- a/src/libpgmoneta/wal/wal_reader.c
+++ b/src/libpgmoneta/wal/wal_reader.c
@@ -1,0 +1,761 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <logging.h>
+#include <utils.h>
+#include <wal/walfile/rmgr.h>
+#include <wal/walfile/wal_reader.h>
+
+#include <assert.h>
+#include <string.h>
+
+struct server* server_config;
+
+void
+print_short_page_header(struct xlog_page_header_data* header)
+{
+   pgmoneta_log_trace("Page Header:\n");
+   pgmoneta_log_trace("  xlp_magic: %u\n", header->xlp_magic);
+   pgmoneta_log_trace("  xlp_info: %u\n", header->xlp_info);
+   pgmoneta_log_trace("  xlp_tli: %u\n", header->xlp_tli);
+   pgmoneta_log_trace("  xlp_pageaddr: %llu\n", (unsigned long long) header->xlp_pageaddr);
+   pgmoneta_log_trace("  xlp_rem_len: %u\n", header->xlp_rem_len);
+   pgmoneta_log_trace("-----------------\n");
+}
+
+void
+print_long_page_header(struct xlog_long_page_header_data* header)
+{
+   pgmoneta_log_trace("Long Page Header:\n");
+   print_short_page_header(&header->std);
+   pgmoneta_log_trace("  xlp_sysid: %llu\n", (unsigned long long) header->xlp_sysid);
+   pgmoneta_log_trace("  xlp_seg_size: %u\n", header->xlp_seg_size);
+   pgmoneta_log_trace("  xlp_xlog_blcksz: %u\n", header->xlp_xlog_blcksz);
+   pgmoneta_log_trace("-----------------\n");
+}
+
+void
+print_record(struct xlog_record* record)
+{
+   pgmoneta_log_trace("%s\t", RmgrTable[record->xl_rmid].name);
+   pgmoneta_log_trace("len: %u\t", record->xl_tot_len);
+   pgmoneta_log_trace("xl_xid: %u\n", record->xl_xid);
+   pgmoneta_log_trace("xl_info: %u\n", record->xl_info);
+   pgmoneta_log_trace("xl_prev: %llu\n", (unsigned long long) record->xl_prev);
+   pgmoneta_log_trace("xl_rmid: %u\n", record->xl_rmid);
+}
+
+bool
+pgmoneta_wal_is_bkp_image_compressed(struct server* server_info, uint8_t bimg_info)
+{
+   if (server_info->version >= 15)
+   {
+      return (bimg_info & (BKPIMAGE_COMPRESS_PGLZ | BKPIMAGE_COMPRESS_LZ4 | BKPIMAGE_COMPRESS_ZSTD)) != 0;
+   }
+   else
+   {
+      return ((bimg_info & BKPIMAGE_IS_COMPRESSED) != 0);
+   }
+}
+
+char*
+pgmoneta_wal_array_desc(char* buf, void* array,
+                        size_t elem_size,
+                        int count
+                        )
+{
+   if (count == 0)
+   {
+      buf = pgmoneta_format_and_append(buf, " []");
+      return buf;
+   }
+   buf = pgmoneta_format_and_append(buf, " [");
+   for (int i = 0; i < count; i++)
+   {
+      buf = pgmoneta_format_and_append(buf, "%u", *(offset_number*) ((char*) array + elem_size * i));
+      if (i < count - 1)
+      {
+         buf = pgmoneta_format_and_append(buf, ", ");
+      }
+   }
+   buf = pgmoneta_format_and_append(buf, "]");
+   return buf;
+}
+
+void
+pgmoneta_wal_parse_wal_file(char* path, struct server* server_info)
+{
+#define MALLOC(pointer, size) \
+        pointer = malloc(size); \
+        if (pointer == NULL) \
+        { \
+           pgmoneta_log_fatal("Error: Could not allocate memory for %s\n", #pointer); \
+           goto finish; \
+        }
+
+   struct xlog_record* record = NULL;
+   struct xlog_long_page_header_data* long_header = NULL;
+   char* buffer = NULL;
+   struct decoded_xlog_record* decoded = NULL;
+   struct xlog_page_header_data* page_header = NULL;
+   int count = 0;
+   server_config = server_info;
+
+   FILE* file = fopen(path, "rb");
+   if (file == NULL)
+   {
+      pgmoneta_log_fatal("Error: Could not open file %s\n", path);
+   }
+
+   MALLOC(long_header, SIZE_OF_XLOG_LONG_PHD);
+   fread(long_header, SIZE_OF_XLOG_LONG_PHD, 1, file);
+
+   uint32_t next_record = ftell(file);
+   int page_number = 0;
+
+   while (true)
+   {
+      pgmoneta_log_trace("next_record: %u\n", next_record);
+      // Check if next record is beyond the current page
+      if (next_record >= (long_header->xlp_xlog_blcksz * (page_number + 1)))
+      {
+         page_number++;
+         fseek(file, page_number * long_header->xlp_xlog_blcksz, SEEK_SET);
+         MALLOC(page_header, SIZE_OF_XLOG_SHORT_PHD);
+         fread(page_header, SIZE_OF_XLOG_SHORT_PHD, 1, file);
+         next_record = MAXALIGN(ftell(file) + page_header->xlp_rem_len);
+         free(page_header);
+         continue;
+      }
+      fseek(file, next_record, SEEK_SET);
+
+      // Check if record crosses the page boundary
+      if (ftell(file) + SIZE_OF_XLOG_RECORD > long_header->xlp_xlog_blcksz * (page_number + 1))
+      {
+         char* temp_buffer = NULL;
+         MALLOC(temp_buffer, SIZE_OF_XLOG_RECORD)
+         uint32_t end_of_page = (page_number + 1) * long_header->xlp_xlog_blcksz;
+         size_t bytes_read = fread(temp_buffer, 1, end_of_page - ftell(file), file);
+
+         fseek(file, SIZE_OF_XLOG_SHORT_PHD, SEEK_CUR);
+         bytes_read += fread(temp_buffer + bytes_read, 1, SIZE_OF_XLOG_RECORD - bytes_read, file);
+
+         assert(bytes_read == SIZE_OF_XLOG_RECORD);
+         record = (struct xlog_record*) temp_buffer;
+         page_number++;
+      }
+      else
+      {
+         MALLOC(record, SIZE_OF_XLOG_RECORD)
+         fread(record, SIZE_OF_XLOG_RECORD, 1, file);
+      }
+
+      if (record->xl_tot_len == 0)
+      {
+         goto finish;
+      }
+      uint32_t data_length = record->xl_tot_len - SIZE_OF_XLOG_RECORD;
+      next_record = ftell(file) + MAXALIGN(record->xl_tot_len - SIZE_OF_XLOG_RECORD);
+      uint32_t end_of_page = (page_number + 1) * long_header->xlp_xlog_blcksz;
+
+      MALLOC(buffer, data_length)
+
+      // Read record data, possibly across page boundaries
+      if (data_length + ftell(file) >= end_of_page)
+      {
+         size_t bytes_read = 0;
+         size_t total_bytes_read = 0;
+         uint32_t remaining_data_length = data_length;
+         bytes_read = fread(buffer, 1, end_of_page - ftell(file), file);
+         total_bytes_read += bytes_read;
+         remaining_data_length -= bytes_read;
+         while (remaining_data_length != 0)
+         {
+            fseek(file, SIZE_OF_XLOG_SHORT_PHD, SEEK_CUR);
+            bytes_read = fread(buffer + total_bytes_read, 1,
+                               MIN(remaining_data_length, long_header->xlp_xlog_blcksz - SIZE_OF_XLOG_SHORT_PHD), file);
+            remaining_data_length -= bytes_read;
+            total_bytes_read += bytes_read;
+         }
+         assert(total_bytes_read == data_length);
+      }
+      else
+      {
+         size_t bytes_read = fread(buffer, 1, data_length, file);
+
+         assert(bytes_read == data_length);
+      }
+
+      decoded = calloc(1, sizeof(struct decoded_xlog_record));
+
+      if (!pgmoneta_wal_decode_xlog_record(buffer, decoded, record, long_header->xlp_xlog_blcksz, server_info))
+      {
+         pgmoneta_log_fatal("error in decoding\n");
+         continue;
+      }
+      else
+      {
+         pgmoneta_wal_display_decoded_record(decoded, ++count, server_info);
+      }
+
+      free(buffer);
+      if (decoded->main_data != NULL)
+      {
+         free(decoded->main_data);
+      }
+      for (int i = 0; i <= decoded->max_block_id; i++)
+      {
+         if (decoded->blocks[i].has_data)
+         {
+            free(decoded->blocks[i].data);
+         }
+      }
+      free(decoded);
+      free(record);
+   }
+
+finish:
+   free(record);
+   free(long_header);
+   fclose(file);
+
+}
+
+void
+pgmoneta_wal_display_decoded_record(struct decoded_xlog_record* record, int count, struct server* server_info)
+{
+
+   uint32_t rec_len;
+   uint32_t fpi_len;
+
+   print_record(&record->header);
+   pgmoneta_wal_get_record_length(record, &rec_len, &fpi_len);
+   pgmoneta_log_trace("record: %d\n", count);
+   pgmoneta_log_trace("rec/tot_len: %u/%u\t", rec_len, record->header.xl_tot_len);
+
+   char* buf = NULL;
+   buf = RmgrTable[record->header.xl_rmid].rm_desc(buf, record);
+   buf = pgmoneta_wal_get_record_block_ref_info(buf, record, false, true, &fpi_len, server_info);
+   if (buf)
+   {
+      pgmoneta_log_trace("%s\n", buf);
+      free(buf);
+   }
+   pgmoneta_log_trace("------------------------------\n");
+}
+
+bool
+pgmoneta_wal_decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlog_record* record, uint32_t block_size, struct server* server_info)
+{
+#define COPY_HEADER_FIELD(_dst, _size)          \
+        do {                                        \
+           if (remaining < _size)                  \
+           goto shortdata_err;                 \
+           memcpy(_dst, ptr, _size);               \
+           ptr += _size;                           \
+           remaining -= _size;                     \
+        } while (0)
+
+   decoded->header = *record;
+//    decoded->lsn = lsn;
+   decoded->next = NULL;
+   decoded->record_origin = INVALID_REP_ORIGIN_ID;
+   decoded->toplevel_xid = INVALID_TRANSACTION_ID;
+   decoded->main_data = NULL;
+   decoded->main_data_len = 0;
+   decoded->max_block_id = -1;
+
+   //read id
+   int remaining = 0;
+   uint32_t datatotal = 0;
+   char* ptr = NULL;
+//   char* out = NULL;
+   struct rel_file_locator* rlocator = NULL;
+   uint8_t block_id;
+
+   remaining = record->xl_tot_len - SIZE_OF_XLOG_RECORD;
+   ptr = buffer;
+
+   while (remaining > datatotal)
+   {
+      COPY_HEADER_FIELD(&block_id, sizeof(uint8_t));
+
+      if (block_id == XLR_BLOCK_ID_DATA_SHORT)
+      {
+         /* xlog_record_data_header_short */
+         uint8_t main_data_len;
+         COPY_HEADER_FIELD(&main_data_len, sizeof(uint8_t));
+         decoded->main_data_len = main_data_len;
+         datatotal += main_data_len;
+      }
+      else if (block_id == XLR_BLOCK_ID_DATA_LONG)
+      {
+         /* xlog_record_data_header_long */
+         uint32_t main_data_len;
+         COPY_HEADER_FIELD(&main_data_len, sizeof(uint32_t));
+         decoded->main_data_len = main_data_len;
+         datatotal += main_data_len;
+      }
+      else if (block_id == XLR_BLOCK_ID_ORIGIN)
+      {
+         COPY_HEADER_FIELD(&decoded->record_origin, sizeof(rep_origin_id));
+      }
+      else if (block_id == XLR_BLOCK_ID_TOPLEVEL_XID)
+      {
+         COPY_HEADER_FIELD(&decoded->toplevel_xid, sizeof(transaction_id));
+      }
+      else if (block_id <= XLR_MAX_BLOCK_ID)
+      {
+         /* xlog_record_bloch_header */
+         struct decoded_bkp_block* blk;
+         uint8_t fork_flags;
+
+         /* mark any intervening block IDs as not in use */
+         for (int i = decoded->max_block_id + 1; i < block_id; ++i)
+         {
+            decoded->blocks[i].in_use = false;
+         }
+
+         if (block_id <= decoded->max_block_id)
+         {
+            goto err;
+         }
+         decoded->max_block_id = block_id;
+
+         blk = &decoded->blocks[block_id];
+         blk->in_use = true;
+         blk->apply_image = false;
+
+         COPY_HEADER_FIELD(&fork_flags, sizeof(uint8_t));
+         blk->forknum = fork_flags & BKPBLOCK_FORK_MASK;
+         blk->flags = fork_flags;
+         blk->has_image = ((fork_flags & BKPBLOCK_HAS_IMAGE) != 0);
+         blk->has_data = ((fork_flags & BKPBLOCK_HAS_DATA) != 0);
+
+         blk->prefetch_buffer = InvalidBuffer;
+         COPY_HEADER_FIELD(&blk->data_len, sizeof(uint16_t));
+         /* cross-check that the HAS_DATA flag is set iff data_length > 0 */
+         if (blk->has_data && blk->data_len == 0)
+         {
+            pgmoneta_log_fatal("BKPBLOCK_HAS_DATA set, but no data included");
+            goto err;
+         }
+         if (!blk->has_data && blk->data_len != 0)
+         {
+            pgmoneta_log_fatal("BKPBLOCK_HAS_DATA not set, but data length is not zero");
+            goto err;
+         }
+         datatotal += blk->data_len;
+
+         if (blk->has_image)
+         {
+            COPY_HEADER_FIELD(&blk->bimg_len, sizeof(uint16_t));
+            COPY_HEADER_FIELD(&blk->hole_offset, sizeof(uint16_t));
+            COPY_HEADER_FIELD(&blk->bimg_info, sizeof(uint8_t));
+
+            blk->apply_image = ((blk->bimg_info & BKPIMAGE_APPLY) != 0);
+
+            if (pgmoneta_wal_is_bkp_image_compressed(server_info, blk->bimg_info))
+            {
+               if (blk->bimg_info & BKPIMAGE_HAS_HOLE)
+               {
+                  COPY_HEADER_FIELD(&blk->hole_length, sizeof(uint16_t));
+               }
+               else
+               {
+                  blk->hole_length = 0;
+               }
+            }
+            else
+            {
+               blk->hole_length = block_size - blk->bimg_len;
+            }
+            datatotal += blk->bimg_len;
+
+            /*
+             * cross-check that hole_offset > 0, hole_length > 0 and
+             * bimg_len < BLCKSZ if the HAS_HOLE flag is set.
+             */
+            if ((blk->bimg_info & BKPIMAGE_HAS_HOLE) &&
+                (blk->hole_offset == 0 ||
+                 blk->hole_length == 0 ||
+                 blk->bimg_len == block_size))
+            {
+               pgmoneta_log_fatal(
+                  "BKPIMAGE_HAS_HOLE set, but hole offset %u length %u block image length %u at %X/%X");
+               goto err;
+            }
+
+            /*
+             * cross-check that hole_offset == 0 and hole_length == 0 if
+             * the HAS_HOLE flag is not set.
+             */
+            if (!(blk->bimg_info & BKPIMAGE_HAS_HOLE) &&
+                (blk->hole_offset != 0 || blk->hole_length != 0))
+            {
+               pgmoneta_log_fatal("BKPIMAGE_HAS_HOLE not set, but hole offset %u length %u at %X/%X");
+               goto err;
+            }
+
+            /*
+             * Cross-check that bimg_len < BLCKSZ if it is compressed.
+             */
+            if (pgmoneta_wal_is_bkp_image_compressed(server_info, blk->bimg_info) &&
+                blk->bimg_len == block_size)
+            {
+               pgmoneta_log_fatal("BKPIMAGE_COMPRESSED set, but block image length %u at %X/%X");
+               goto err;
+            }
+
+            /*
+             * cross-check that bimg_len = BLCKSZ if neither HAS_HOLE is
+             * set nor COMPRESSED().
+             */
+            if (!(blk->bimg_info & BKPIMAGE_HAS_HOLE) &&
+                !pgmoneta_wal_is_bkp_image_compressed(server_info, blk->bimg_info) &&
+                blk->bimg_len != block_size)
+            {
+               pgmoneta_log_fatal(
+                  "neither BKPIMAGE_HAS_HOLE nor BKPIMAGE_COMPRESSED set, but block image length is %u at %X/%X");
+               goto err;
+            }
+         }
+         if (!(fork_flags & BKPBLOCK_SAME_REL))
+         {
+            COPY_HEADER_FIELD(&blk->rlocator, sizeof(struct rel_file_locator));
+            rlocator = &blk->rlocator;
+         }
+         else
+         {
+            if (rlocator == NULL)
+            {
+               pgmoneta_log_fatal("BKPBLOCK_SAME_REL set but no previous rel at %X/%X");
+               goto err;
+            }
+
+            blk->rlocator = *rlocator;
+         }
+         COPY_HEADER_FIELD(&blk->blkno, sizeof(block_number));
+      }
+      else
+      {
+         pgmoneta_log_fatal("invalid block_id %u at %X/%X");
+         goto err;
+      }
+   }
+   assert(remaining == datatotal);
+
+   for (block_id = 0; block_id <= decoded->max_block_id; block_id++)
+   {
+      struct decoded_bkp_block* blk = &decoded->blocks[block_id];
+
+      if (!blk->in_use)
+      {
+         continue;
+      }
+
+      assert(blk->has_image || !blk->apply_image);
+
+      if (blk->has_image)
+      {
+         /* no need to align image */
+         blk->bkp_image = ptr;
+         ptr += blk->bimg_len;
+      }
+      if (blk->has_data)
+      {
+         blk->data = malloc(blk->data_len);
+         memcpy(blk->data, ptr, blk->data_len);
+         ptr += blk->data_len;
+      }
+   }
+
+   if (decoded->main_data_len > 0)
+   {
+      decoded->main_data = malloc(decoded->main_data_len);
+      if (decoded->main_data == NULL)
+      {
+         goto
+         shortdata_err;
+      }
+      memcpy(decoded->main_data, ptr, decoded->main_data_len);
+      ptr += decoded->main_data_len;
+   }
+
+   return true;
+
+shortdata_err:
+   pgmoneta_log_fatal("shortdata_err\n");
+   return false;
+
+err:
+   pgmoneta_log_fatal("err\n");
+   return false;
+}
+
+char*
+pgmoneta_wal_get_record_block_data(struct decoded_xlog_record* record, uint8_t block_id, size_t* len)
+{
+   {
+      struct decoded_bkp_block* bkpb;
+
+      if (block_id > record->max_block_id ||
+          !record->blocks[block_id].in_use)
+      {
+         return NULL;
+      }
+
+      bkpb = &record->blocks[block_id];
+
+      if (!bkpb->has_data)
+      {
+         if (len)
+         {
+            *len = 0;
+         }
+         return NULL;
+      }
+      else
+      {
+         if (len)
+         {
+            *len = bkpb->data_len;
+         }
+         return bkpb->data;
+      }
+   }
+}
+
+void
+pgmoneta_wal_get_record_length(struct decoded_xlog_record* record, uint32_t* rec_len, uint32_t* fpi_len)
+{
+   int block_id;
+
+   *fpi_len = 0;
+   for (block_id = 0; block_id <= record->max_block_id; block_id++)
+   {
+      if (!XLogRecHasBlockRef(record, block_id))
+      {
+         continue;
+      }
+
+      if (XLogRecHasBlockImage(record, block_id))
+      {
+         *fpi_len += record->blocks[block_id].bimg_len;
+      }
+   }
+
+/*
+ * Calculate the length of the record as the total length - the length of
+ * all the block images.
+ */
+   *rec_len = record->header.xl_tot_len - *fpi_len;
+}
+
+char*
+pgmoneta_wal_get_record_block_ref_info(char* buf, struct decoded_xlog_record* record, bool pretty, bool detailed_format, uint32_t* fpi_len,
+                                       struct server* server_info)
+{
+   int block_id;
+
+   assert(record != NULL);
+
+   if (detailed_format && pretty)
+   {
+      buf = pgmoneta_format_and_append(buf, "\n");
+   }
+
+   for (block_id = 0; block_id <= record->max_block_id; block_id++)
+   {
+      struct rel_file_locator rlocator;
+      enum fork_number forknum;
+      block_number blk;
+
+      if (!pgmoneta_wal_get_record_block_tag_extended(record, block_id, &rlocator, &forknum, &blk, NULL))
+      {
+         continue;
+      }
+
+      if (detailed_format)
+      {
+         /* Get block references in detailed format. */
+
+         if (pretty)
+         {
+            buf = pgmoneta_format_and_append(buf, "\t");
+         }
+         else if (block_id > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, " ");
+         }
+
+         buf = pgmoneta_format_and_append(buf, "blkref #%d: rel %u/%u/%u forknum %d blk %u",
+                                          block_id,
+                                          rlocator.spcOid, rlocator.dbOid, rlocator.relNumber,
+                                          forknum,
+                                          blk);
+
+         if (XLogRecHasBlockImage(record, block_id))
+         {
+            uint8_t bimg_info = record->blocks[block_id].bimg_info;
+
+            /* Calculate the amount of FPI data in the record. */
+            if (fpi_len)
+            {
+               *fpi_len += record->blocks[block_id].bimg_len;
+            }
+
+            if (pgmoneta_wal_is_bkp_image_compressed(server_info, bimg_info))
+            {
+               const char* method;
+
+               if ((bimg_info & BKPIMAGE_COMPRESS_PGLZ) != 0)
+               {
+                  method = "pglz";
+               }
+               else if ((bimg_info & BKPIMAGE_COMPRESS_LZ4) != 0)
+               {
+                  method = "lz4";
+               }
+               else if ((bimg_info & BKPIMAGE_COMPRESS_ZSTD) != 0)
+               {
+                  method = "zstd";
+               }
+               else
+               {
+                  method = "unknown";
+               }
+
+               buf = pgmoneta_format_and_append(buf,
+                                                " (FPW%s); hole: offset: %u, length: %u, "
+                                                "compression saved: %u, method: %s",
+                                                record->blocks[block_id].apply_image ?
+                                                "" : " for WAL verification",
+                                                record->blocks[block_id].hole_offset,
+                                                record->blocks[block_id].hole_length,
+                                                8192 -
+                                                record->blocks[block_id].hole_length -
+                                                record->blocks[block_id].bimg_len,
+                                                method);
+            }
+            else
+            {
+               buf = pgmoneta_format_and_append(buf,
+                                                " (FPW%s); hole: offset: %u, length: %u",
+                                                XLOG_REC_BLOCK_IMAGE_APPLY(record, block_id) ?
+                                                "" : " for WAL verification",
+                                                XLOG_REC_GET_BLOCK(record, block_id)->hole_offset,
+                                                XLOG_REC_GET_BLOCK(record, block_id)->hole_length);
+            }
+         }
+
+         if (pretty)
+         {
+            buf = pgmoneta_format_and_append(buf, "\n");
+         }
+      }
+      else
+      {
+         /* Get block references in short format. */
+
+         if (forknum != MAIN_FORKNUM)
+         {
+            buf = pgmoneta_format_and_append(buf,
+                                             ", blkref #%d: rel %u/%u/%u fork %d blk %u",
+                                             block_id,
+                                             rlocator.spcOid, rlocator.dbOid, rlocator.relNumber,
+                                             forknum,
+                                             blk);
+         }
+         else
+         {
+            buf = pgmoneta_format_and_append(buf,
+                                             ", blkref #%d: rel %u/%u/%u blk %u",
+                                             block_id,
+                                             rlocator.spcOid, rlocator.dbOid, rlocator.relNumber,
+                                             blk);
+         }
+
+         if (XLogRecHasBlockImage(record, block_id))
+         {
+            /* Calculate the amount of FPI data in the record. */
+            if (fpi_len)
+            {
+               *fpi_len += XLOG_REC_GET_BLOCK(record, block_id)->bimg_len;
+            }
+
+            if (XLOG_REC_BLOCK_IMAGE_APPLY(record, block_id))
+            {
+               buf = pgmoneta_format_and_append(buf, " FPW");
+            }
+            else
+            {
+               buf = pgmoneta_format_and_append(buf, " FPW for WAL verification");
+            }
+         }
+      }
+   }
+
+   if (!detailed_format && pretty)
+   {
+      buf = pgmoneta_format_and_append(buf, "\n");
+   }
+   return buf;
+
+}
+
+bool
+pgmoneta_wal_get_record_block_tag_extended(struct decoded_xlog_record* pRecord, int id, struct rel_file_locator* pLocator, enum fork_number* pNumber,
+                                           block_number* pInt, buffer* pVoid)
+{
+   struct decoded_bkp_block* bkpb;
+
+   if (!XLogRecHasBlockRef(pRecord, id))
+   {
+      return false;
+   }
+
+   bkpb = XLOG_REC_GET_BLOCK(pRecord, id);
+   if (pLocator)
+   {
+      *pLocator = bkpb->rlocator;
+   }
+   if (pNumber)
+   {
+      *pNumber = bkpb->forknum;
+   }
+   if (pInt)
+   {
+      *pInt = bkpb->blkno;
+   }
+   if (pVoid)
+   {
+      *pVoid = bkpb->prefetch_buffer;
+   }
+   return true;
+}

--- a/uncrustify.sh
+++ b/uncrustify.sh
@@ -9,5 +9,5 @@ function indent()
 }
 
 indent "src/*.c"
-indent "src/include/*.h"
-indent "src/libpgmoneta/*.c"
+indent "src/include/**/*.h"
+indent "src/libpgmoneta/**/*.c"


### PR DESCRIPTION
This PR is addressing issues #296, #299, #300, #301.

It introduces the infrastructure for parsing a WAL (Write-Ahead Log) file into WAL record data structures. It supports multiple PostgreSQL versions, from 13 to 17, by utilizing official magic values.

Key Features:
- Parses each page header, record header, and the associated data.
- Handles WAL records that span multiple pages.
- Implements a factory pattern (wrapper method) to manage version-specific structural changes across different PostgreSQL versions.

Benefits: Merging this PR will enable the parsing of WAL files into a list of WAL records. This parsed data can be leveraged in the future for rewriting WAL files or extracting the logical meaning of the records.