### PR TITLE
[#389] Add new type for unknown format type

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -421,9 +421,14 @@ main(int argc, char** argv)
             {
                output_format = MANAGEMENT_OUTPUT_FORMAT_JSON;
             }
-            else
+            else if (!strncmp(optarg, "text", MISC_LENGTH))
             {
                output_format = MANAGEMENT_OUTPUT_FORMAT_TEXT;
+            }
+            else
+            {
+               warnx("pgmoneta-cli: Format type is not correct");
+               exit(1);
             }
             break;
          case '?':


### PR DESCRIPTION
Add a new type for the unknown format type to restrict user input.

Also, add `(void)bytes_read;` to avoid the unused variable error.