### PR TITLE
[#392] Correct the base64 functions signature

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -440,26 +440,26 @@ char*
 pgmoneta_get_password(void);
 
 /**
- * BASE64 encode a string
- * @param raw The string
- * @param raw_length The length of the raw string
+ * BASE64 encode a data
+ * @param raw The data
+ * @param raw_length The length of the raw data
  * @param encoded The encoded string
  * @param encoded_length The length of the encoded string
  * @return 0 if success, otherwise 1
  */
 int
-pgmoneta_base64_encode(char* raw, size_t raw_length, char** encoded, size_t* encoded_length);
+pgmoneta_base64_encode(void* raw, size_t raw_length, char** encoded, size_t* encoded_length);
 
 /**
  * BASE64 decode a string
  * @param encoded The encoded string
  * @param encoded_length The length of the encoded string
- * @param raw The raw string
- * @param raw_length The length of the raw string
+ * @param raw The raw data
+ * @param raw_length The length of the raw data
  * @return 0 if success, otherwise 1
  */
 int
-pgmoneta_base64_decode(char* encoded, size_t encoded_length, char** raw, size_t* raw_length);
+pgmoneta_base64_decode(char* encoded, size_t encoded_length, void** raw, size_t* raw_length);
 
 /**
  * Set process title.

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -1631,7 +1631,7 @@ pgmoneta_read_users_configuration(void* shm, char* filename)
             goto error;
          }
 
-         if (pgmoneta_base64_decode(ptr, strlen(ptr), &decoded, &decoded_length))
+         if (pgmoneta_base64_decode(ptr, strlen(ptr), (void**)&decoded, &decoded_length))
          {
             goto error;
          }
@@ -1822,7 +1822,7 @@ pgmoneta_read_admins_configuration(void* shm, char* filename)
             goto error;
          }
 
-         if (pgmoneta_base64_decode(ptr, strlen(ptr), &decoded, &decoded_length))
+         if (pgmoneta_base64_decode(ptr, strlen(ptr), (void**)&decoded, &decoded_length))
          {
             goto error;
          }

--- a/src/libpgmoneta/se_azure.c
+++ b/src/libpgmoneta/se_azure.c
@@ -312,7 +312,7 @@ azure_send_upload_request(char* local_root, char* azure_root, char* relative_pat
    string_to_sign = pgmoneta_append(string_to_sign, azure_path);
 
    // Decode the Azure storage account shared key.
-   pgmoneta_base64_decode(config->azure_shared_key, strlen(config->azure_shared_key), &signing_key, &signing_key_length);
+   pgmoneta_base64_decode(config->azure_shared_key, strlen(config->azure_shared_key), (void**)&signing_key, &signing_key_length);
 
    // Construct the signature.
    if (pgmoneta_generate_string_hmac_sha256_hash(signing_key, signing_key_length, string_to_sign, strlen(string_to_sign), &signature_hmac, &hmac_length))

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -504,7 +504,7 @@ pgmoneta_remote_management_scram_sha256(char* username, char* password, int serv
       goto error;
    }
 
-   pgmoneta_base64_decode(base64_salt, strlen(base64_salt), &salt, &salt_length);
+   pgmoneta_base64_decode(base64_salt, strlen(base64_salt), (void**)&salt, &salt_length);
 
    iteration = atoi(iteration_string);
 
@@ -553,7 +553,7 @@ pgmoneta_remote_management_scram_sha256(char* username, char* password, int serv
 
    /* Get 'v' attribute */
    base64_server_signature = sasl_final->data + 11;
-   pgmoneta_base64_decode(base64_server_signature, sasl_final->length - 11, &server_signature_received, &server_signature_received_length);
+   pgmoneta_base64_decode(base64_server_signature, sasl_final->length - 11, (void**)&server_signature_received, &server_signature_received_length);
 
    if (server_signature(password_prep, salt, salt_length, iteration,
                         NULL, 0,
@@ -931,7 +931,7 @@ retry:
    }
 
    get_scram_attribute('p', (char*)msg->data + 5, msg->length - 5, &base64_client_proof);
-   pgmoneta_base64_decode(base64_client_proof, strlen(base64_client_proof), &client_proof_received, &client_proof_received_length);
+   pgmoneta_base64_decode(base64_client_proof, strlen(base64_client_proof), (void**)&client_proof_received, &client_proof_received_length);
 
    client_final_message_without_proof = malloc(58);
    memset(client_final_message_without_proof, 0, 58);
@@ -1569,7 +1569,7 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
       goto error;
    }
 
-   pgmoneta_base64_decode(base64_salt, strlen(base64_salt), &salt, &salt_length);
+   pgmoneta_base64_decode(base64_salt, strlen(base64_salt), (void**)&salt, &salt_length);
 
    iteration = atoi(iteration_string);
 
@@ -1629,7 +1629,7 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
    /* Get 'v' attribute */
    base64_server_signature = sasl_final->data + 11;
    pgmoneta_base64_decode(base64_server_signature, sasl_final->length - 11,
-                          &server_signature_received, &server_signature_received_length);
+                          (void**)&server_signature_received, &server_signature_received_length);
 
    if (server_signature(password_prep, salt, salt_length, iteration,
                         NULL, 0,
@@ -1796,7 +1796,7 @@ pgmoneta_get_master_key(char** masterkey)
       goto error;
    }
 
-   pgmoneta_base64_decode(&line[0], strlen(&line[0]), &mk, &mk_length);
+   pgmoneta_base64_decode(&line[0], strlen(&line[0]), (void**)&mk, &mk_length);
 
    *masterkey = mk;
 

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -869,7 +869,7 @@ pgmoneta_get_password(void)
 }
 
 int
-pgmoneta_base64_encode(char* raw, size_t raw_length, char** encoded, size_t* encoded_length)
+pgmoneta_base64_encode(void* raw, size_t raw_length, char** encoded, size_t* encoded_length)
 {
    BIO* b64_bio;
    BIO* mem_bio;
@@ -919,7 +919,7 @@ error:
 }
 
 int
-pgmoneta_base64_decode(char* encoded, size_t encoded_length, char** raw, size_t* raw_length)
+pgmoneta_base64_decode(char* encoded, size_t encoded_length, void** raw, size_t* raw_length)
 {
    BIO* b64_bio;
    BIO* mem_bio;
@@ -954,7 +954,7 @@ pgmoneta_base64_decode(char* encoded, size_t encoded_length, char** raw, size_t*
 
    BIO_free_all(b64_bio);
 
-   *raw = decoded;
+   *raw = (void*)decoded;
    *raw_length = index;
 
    return 0;


### PR DESCRIPTION
Update the base64 encode and decode function signatures to make them more compatible with different data types.