### PR TITLE
[#396] Add pgmoneta-walinfo CLI to read WAL files

### DIFF
--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -362,6 +362,23 @@ pgmoneta-cli -c pgmoneta.conf status details
 pgmoneta-cli -c pgmoneta.conf shutdown
 ```
 
+## pgmoneta-walinfo
+
+Alongside pgmoneta, you can use the `pgmoneta-walinfo` tool to read and display PostgreSQL Write-Ahead Log (WAL) files. This utility supports output in either `raw` or `json` format, making it an essential tool for examining WAL file contents.
+
+In the `raw` format, the output is structured as:
+
+### Usage
+
+```sh
+pgmoneta-walinfo [ -F FORMAT ] <file>
+
+-F, --format: Specify the output format ('raw' or 'json').
+<file>: The path to the WAL file to read.
+```
+
+
+For more details, please refer to the [wal documentation](./manual/dev-06-wal.md).
 ## End
 
 Now that we've attempted our first backup, take a moment to relax. There are a few things we need to pay attention to:

--- a/doc/WAL.md
+++ b/doc/WAL.md
@@ -1,4 +1,4 @@
 
-# WAL Reader
+# pgmoneta-walinfo
 
-Please refer to [WAL developer guide](./manual/dev-06-wal.md) for all information about how to read WAL files and the WAL format.
+Please refer to [WAL developer guide](./manual/dev-06-wal.md) for all information about how to use pgmoneta-walinfo tool, and details about how to use the high level API defined in `walinfo.h`.

--- a/doc/man/pgmoneta-walinfo.1.rst
+++ b/doc/man/pgmoneta-walinfo.1.rst
@@ -1,0 +1,60 @@
+=====================
+pgmoneta-walinfo
+=====================
+
+-------------------------------------------------
+Command line utility to read and display Write-Ahead Log (WAL) files
+-------------------------------------------------
+
+:Manual section: 1
+
+SYNOPSIS
+========
+
+pgmoneta-walinfo [ -F FORMAT ] <file>
+
+DESCRIPTION
+===========
+
+pgmoneta-walinfo is a command line utility to read and display information about PostgreSQL Write-Ahead Log (WAL) files. It provides details of the WAL file in either raw or JSON format.
+
+OPTIONS
+=======
+
+-F, --format raw|json
+  Set the output format. Default is `raw`.
+
+-?, --help
+  Display help and usage information.
+
+ARGUMENTS
+=========
+
+<file>
+  The path to the WAL file to be analyzed.
+
+USAGE
+=====
+
+To display information about a WAL file in raw format:
+
+    pgmoneta-walinfo /path/to/walfile
+
+To display information in JSON format:
+
+    pgmoneta-walinfo -F json /path/to/walfile
+
+REPORTING BUGS
+==============
+
+pgmoneta is maintained on GitHub at https://github.com/pgmoneta/pgmoneta
+
+COPYRIGHT
+=========
+
+pgmoneta-walinfo is licensed under the 3-clause BSD License.
+
+SEE ALSO
+========
+
+pgmoneta.conf(5), pgmoneta(1), pgmoneta-admin(1)

--- a/doc/manual/dev-06-wal.md
+++ b/doc/manual/dev-06-wal.md
@@ -6,6 +6,53 @@
 
 This document provides an overview of the `wal_reader` tool, with a focus on the `parse_wal_file` function, which serves as the main entry point for parsing Write-Ahead Log (WAL) files. Currently, the function only parses the given WAL file and prints the description of each record. In the future, it will be integrated with other parts of the code.
 
+
+## pgmoneta-walinfo
+
+`pgmoneta-walinfo` is a command line utility designed to read and display information about PostgreSQL Write-Ahead Log (WAL) files. The tool provides output in either raw or JSON format, making it easy to analyze WAL files for debugging, auditing, or general information purposes.
+
+In addition to standard WAL files, `pgmoneta-walinfo` also supports compressed WAL files in the following formats: **zstd**, **gz**, **lz4**, and **bz2**.
+
+#### Usage
+
+```bash
+pgmoneta-walinfo [ -F FORMAT ] <file>
+
+-F, --format: Specify the output format ('raw' or 'json').
+<file>: The path to the WAL file to read.
+```
+
+#### Raw Output Format
+
+In `raw` format, the output is structured as follows:
+
+```
+Resource Manager | rec len | tot len | xid | prev lsn | description (data and backup)
+```
+
+- **Resource Manager**: The name of the resource manager handling the log record.
+- **rec len**: The length of the WAL record.
+- **tot len**: The total length of the WAL record, including the header.
+- **xid**: The transaction ID associated with the record.
+- **prev lsn**: The previous Log Sequence Number (LSN).
+- **description (data and backup)**: A detailed description of the operation, along with any related backup block information.
+
+Each part of the output is color-coded:
+
+- **Red**: Header information (resource manager, record length, transaction ID, etc.).
+- **Green**: Description of the WAL record.
+- **Blue**: Backup block references or additional data.
+
+This format makes it easy to visually distinguish different parts of the WAL file for quick analysis.
+
+#### Example
+
+To view WAL file details in JSON format:
+
+```bash
+pgmoneta-walinfo -F json /path/to/walfile
+```
+
 ## High-Level API Overview
 
 The following section provides a high-level overview of how users can interact with the functions and structures defined in the `walfile.h` file. These APIs allow you to read, write, and manage Write-Ahead Log (WAL) files.

--- a/pgmoneta.spec
+++ b/pgmoneta.spec
@@ -77,16 +77,19 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-admin.1 %{buildroot}%{_mandir}/man1/pgmoneta-admin.1
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-cli.1 %{buildroot}%{_mandir}/man1/pgmoneta-cli.1
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta.conf.5 %{buildroot}%{_mandir}/man5/pgmoneta.conf.5
+%{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-walinfo.1 %{buildroot}%{_mandir}/man5/pgmoneta-walinfo.1
 
 %{__install} -m 755 %{_builddir}/%{name}-%{version}/build/src/pgmoneta %{buildroot}%{_bindir}/pgmoneta
 %{__install} -m 755 %{_builddir}/%{name}-%{version}/build/src/pgmoneta-cli %{buildroot}%{_bindir}/pgmoneta-cli
 %{__install} -m 755 %{_builddir}/%{name}-%{version}/build/src/pgmoneta-admin %{buildroot}%{_bindir}/pgmoneta-admin
+%{__install} -m 755 %{_builddir}/%{name}-%{version}/build/src/pgmoneta-walinfo %{buildroot}%{_bindir}/pgmoneta-walinfo
 
 %{__install} -m 755 %{_builddir}/%{name}-%{version}/build/src/libpgmoneta.so.%{version} %{buildroot}%{_libdir}/libpgmoneta.so.%{version}
 
 chrpath -r %{_libdir} %{buildroot}%{_bindir}/pgmoneta
 chrpath -r %{_libdir} %{buildroot}%{_bindir}/pgmoneta-cli
 chrpath -r %{_libdir} %{buildroot}%{_bindir}/pgmoneta-admin
+chrpath -r %{_libdir} %{buildroot}%{_bindir}/pgmoneta-walinfo
 
 cd %{buildroot}%{_libdir}/
 %{__ln_s} -f libpgmoneta.so.%{version} libpgmoneta.so.0
@@ -130,10 +133,12 @@ cd %{buildroot}%{_libdir}/
 %{_mandir}/man1/pgmoneta-admin.1*
 %{_mandir}/man1/pgmoneta-cli.1*
 %{_mandir}/man5/pgmoneta.conf.5*
+%{_mandir}/man5/pgmoneta-walinfo.1*
 %config %{_sysconfdir}/pgmoneta/pgmoneta.conf
 %{_bindir}/pgmoneta
 %{_bindir}/pgmoneta-cli
 %{_bindir}/pgmoneta-admin
+%{_bindir}/pgmoneta-walinfo
 %{_libdir}/libpgmoneta.so
 %{_libdir}/libpgmoneta.so.0
 %{_libdir}/libpgmoneta.so.%{version}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -303,3 +303,16 @@ endif()
 target_link_libraries(pgmoneta-admin-bin pgmoneta)
 
 install(TARGETS pgmoneta-admin-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+#
+# Build pgmoneta-walinfo
+#
+add_executable(pgmoneta-walinfo-bin walinfo.c ${RESOURCE_OBJECT})
+if (CMAKE_C_LINK_PIE_SUPPORTED)
+  set_target_properties(pgmoneta-walinfo-bin PROPERTIES LINKER_LANGUAGE C OUTPUT_NAME pgmoneta-walinfo POSITION_INDEPENDENT_CODE TRUE)
+else()
+  set_target_properties(pgmoneta-walinfo-bin PROPERTIES LINKER_LANGUAGE C OUTPUT_NAME pgmoneta-walinfo POSITION_INDEPENDENT_CODE FALSE)
+endif()
+target_link_libraries(pgmoneta-walinfo-bin pgmoneta)
+
+install(TARGETS pgmoneta-admin-bin DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/include/compression.h
+++ b/src/include/compression.h
@@ -26,41 +26,25 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PGMONETA_TRANSACTION_H
-#define PGMONETA_TRANSACTION_H
+#ifndef PGMONETA_COMPRESSION_H
+#define PGMONETA_COMPRESSION_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+typedef int (*compression_func)(char*, char*);
 
-// Typedefs
-typedef uint32_t transaction_id;
-typedef transaction_id multi_xact_id;
-typedef uint32_t multi_xact_offset;
-
-// #define variables
-#define INVALID_TRANSACTION_ID              ((transaction_id) 0)
-
-// #define macros
-#define EPOCH_FROM_FULL_TRANSACTION_ID(x)   ((uint32_t) ((x).value >> 32))
-#define XID_FROM_FULL_TRANSACTION_ID(x)     ((uint32_t) (x).value)
-#define TRANSACTION_ID_IS_VALID(xid)        ((xid) != INVALID_TRANSACTION_ID)
-
-// Structs
 /**
- * @struct full_transaction_id
- * @brief Represents a full transaction identifier.
+ * Decompress a file using the appropriate decompression method.
  *
- * Fields:
- * - value: The full 64-bit transaction ID value.
+ * This function determines the compression type of the input file by calling
+ * `pgmoneta_decompression_file_callback`, and then uses the resulting callback to
+ * decompress the file from the `from` path to the `to` path.
+ * If no appropriate decompression callback is found, an error is logged.
+ *
+ * @param from   The source file path, expected to be a compressed file.
+ * @param to     The destination file path where the decompressed output will be saved.
+ *
+ * @return 0 if decompression succeeds, 1 if no matching decompression callback is found or decompression fails.
  */
-struct full_transaction_id
-{
-   uint64_t value;   /**< The full 64-bit transaction ID value */
-};
+int
+pgmoneta_decompress(char* from, char* to);
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif // PGMONETA_TRANSACTION_H
+#endif //PGMONETA_COMPRESSION_H

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -46,6 +46,29 @@ extern "C" {
 #define LONG_TIME_LENGHT  16 + 1
 #define UTC_TIME_LENGTH   29 + 1
 
+/** Define Windows 20 palette colors as constants using ANSI codes **/
+#define COLOR_BLACK         "\033[30m"
+#define COLOR_DARK_RED      "\033[31m"
+#define COLOR_DARK_GREEN    "\033[32m"
+#define COLOR_DARK_YELLOW   "\033[33m"
+#define COLOR_DARK_BLUE     "\033[34m"
+#define COLOR_DARK_MAGENTA  "\033[35m"
+#define COLOR_DARK_CYAN     "\033[36m"
+#define COLOR_LIGHT_GREY    "\033[37m"
+#define COLOR_MONEY_GREEN   "\033[32m"   /* Close approximation */
+#define COLOR_SKY_BLUE      "\033[36m"   /* Close approximation */
+#define COLOR_CREAM         "\033[97m"   /* Close approximation */
+#define COLOR_MEDIUM_GREY   "\033[90m"
+#define COLOR_DARK_GREY     "\033[90m"
+#define COLOR_RED           "\033[31m"
+#define COLOR_GREEN         "\033[32m"
+#define COLOR_YELLOW        "\033[33m"
+#define COLOR_BLUE          "\033[34m"
+#define COLOR_MAGENTA       "\033[35m"
+#define COLOR_CYAN          "\033[36m"
+#define COLOR_WHITE         "\033[97m"
+#define COLOR_RESET         "\033[0m"    /* Reset to default color */
+
 /** @struct signal_info
  * Defines the signal structure
  */
@@ -1207,6 +1230,14 @@ pgmoneta_indent(char* str, char* tag, int indent);
  */
 char*
 pgmoneta_escape_string(char* str);
+
+/**
+ * Generate the lsn string in a %X/%X format given a lsn integer
+ * @param  lsn integer value
+ * @return The lsn string in the described format
+ */
+char*
+pgmoneta_lsn_to_string(uint64_t lsn);
 
 #ifdef DEBUG
 

--- a/src/include/walfile.h
+++ b/src/include/walfile.h
@@ -32,8 +32,6 @@
 #include <deque.h>
 #include <walfile/wal_reader.h>
 
-#include <stdint.h>
-
 /**
  * @struct xlog_long_page_header_data
  * @brief Extended XLOG page header.
@@ -49,10 +47,10 @@
  */
 struct xlog_long_page_header_data
 {
-   struct xlog_page_header_data std;      /**< Standard header fields. */
-   uint64_t xlp_sysid;                    /**< System identifier from pg_control. */
-   uint32_t xlp_seg_size;                 /**< Segment size for cross-checking. */
-   uint32_t xlp_xlog_blcksz;              /**< XLOG block size for cross-checking. */
+   struct xlog_page_header_data std;       /**< Standard header fields. */
+   uint64_t xlp_sysid;                     /**< System identifier from pg_control. */
+   uint32_t xlp_seg_size;                  /**< Segment size for cross-checking. */
+   uint32_t xlp_xlog_blcksz;               /**< XLOG block size for cross-checking. */
 };
 
 /**
@@ -113,5 +111,14 @@ pgmoneta_write_walfile(struct walfile* wf, int server, char* path);
  */
 void
 pgmoneta_destroy_walfile(struct walfile* wf);
+
+/**
+ * Describe a WAL file
+ * @param path The path to the WAL file
+ * @param type The type of output description
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_describe_walfile(char* path, enum value_type type);
 
 #endif //PGMONETA_WALFILE_H

--- a/src/include/walfile/rm_database.h
+++ b/src/include/walfile/rm_database.h
@@ -39,6 +39,11 @@ extern "C" {
 #define XLOG_DBASE_CREATE                    0x00     /**< Create database log type */
 #define XLOG_DBASE_DROP                      0x10     /**< Drop database log type */
 
+// v17 and later
+#define XLOG_DBASE_CREATE_FILE_COPY         0x00     /**< Create database log type */
+#define XLOG_DBASE_CREATE_WAL_LOG           0x10     /**< Create database log type */
+#define XLOG_DBASE_DROP_V17                 0x20     /**< Drop database log type */
+
 // #define macros
 #define MIN_SIZE_OF_DBASE_DROP_REC           offsetof(xl_dbase_drop_rec, tablespace_ids) /**< Minimum size of xl_dbase_drop_rec */
 
@@ -75,6 +80,38 @@ struct xl_dbase_drop_rec
    oid db_id;                          /**< Database ID */
    int ntablespaces;                   /**< Number of tablespace IDs */
    oid tablespace_ids[FLEXIBLE_ARRAY_MEMBER];   /**< Array of tablespace IDs */
+};
+
+/**
+ * @struct xl_dbase_create_file_copy_rec
+ * @brief Represents the record for copying a file during database creation, copying both the database and tablespace.
+ *
+ * Fields:
+ * - db_id: Identifier for the database being created.
+ * - tablespace_id: Identifier for the tablespace associated with the database being created.
+ * - src_db_id: Identifier for the source database being copied.
+ * - src_tablespace_id: Identifier for the source tablespace associated with the source database.
+ */
+struct xl_dbase_create_file_copy_rec
+{
+   oid db_id;                  /**< Database ID */
+   oid tablespace_id;          /**< Tablespace ID */
+   oid src_db_id;              /**< Source Database ID */
+   oid src_tablespace_id;      /**< Source Tablespace ID */
+};
+
+/**
+ * @struct xl_dbase_create_wal_log_rec
+ * @brief Represents a write-ahead log (WAL) record for creating a database and logging the new tablespace.
+ *
+ * Fields:
+ * - db_id: Identifier for the database being created.
+ * - tablespace_id: Identifier for the tablespace associated with the new database.
+ */
+struct xl_dbase_create_wal_log_rec
+{
+   oid db_id;                  /**< Database ID */
+   oid tablespace_id;          /**< Tablespace ID */
 };
 
 // Functions

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -4096,6 +4096,22 @@ pgmoneta_escape_string(char* str)
    return translated_ec_string;
 }
 
+char*
+pgmoneta_lsn_to_string(uint64_t lsn)
+{
+   char* result = NULL;
+   result = (char*)malloc(64 * sizeof(char));
+
+   if (result == NULL)
+   {
+      pgmoneta_log_fatal("pgmoneta_lsn_to_string: malloc failed");
+      return NULL;
+   }
+   memset(result, 0, 64);
+   snprintf(result, 64, "%X/%X", (uint32_t)(lsn >> 32), (uint32_t)lsn);
+   return result;
+}
+
 #ifdef DEBUG
 
 int

--- a/src/libpgmoneta/walfile.c
+++ b/src/libpgmoneta/walfile.c
@@ -26,23 +26,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <compression.h>
 #include <deque.h>
+#include <json.h>
 #include <logging.h>
+#include <utils.h>
 #include <walfile.h>
+#include <walfile/wal_reader.h>
 
-#include <assert.h>
+#include <libgen.h>
 #include <stdlib.h>
-
-static char*
-pgmoneta_wal_encode_xlog_record(struct decoded_xlog_record* decoded, struct server* server_info, char* buffer);
 
 int
 pgmoneta_read_walfile(int server, char* path, struct walfile** wf)
 {
    struct walfile* new_wf = NULL;
-   struct configuration* config;
-
-   config = (struct configuration*)shmem;
 
    new_wf = malloc(sizeof(struct walfile));
    if (new_wf == NULL)
@@ -55,7 +53,7 @@ pgmoneta_read_walfile(int server, char* path, struct walfile** wf)
       goto error;
    }
 
-   if (pgmoneta_wal_parse_wal_file(path, &config->servers[server], new_wf))
+   if (pgmoneta_wal_parse_wal_file(path, server, new_wf))
    {
       goto error;
    }
@@ -75,9 +73,6 @@ pgmoneta_write_walfile(struct walfile* wf, int server, char* path)
    struct xlog_page_header_data* page_header = NULL;
    struct deque_iterator* page_header_iterator = NULL;
    FILE* file = NULL;
-   struct configuration* config;
-
-   config = (struct configuration*)shmem;
 
    file = fopen(path, "wb");
    if (file == NULL)
@@ -110,7 +105,7 @@ pgmoneta_write_walfile(struct walfile* wf, int server, char* path)
    {
       char* encoded_record = NULL;
       struct decoded_xlog_record* record = (struct decoded_xlog_record*) record_iterator->value->data;
-      encoded_record = pgmoneta_wal_encode_xlog_record(record, &config->servers[server], encoded_record);
+      encoded_record = pgmoneta_wal_encode_xlog_record(record, wf->long_phd->std.xlp_magic, encoded_record);
 
       uint32_t total_length = record->header.xl_tot_len;
       uint32_t written = 0;
@@ -145,13 +140,6 @@ pgmoneta_write_walfile(struct walfile* wf, int server, char* path)
 
    pgmoneta_deque_iterator_destroy(record_iterator);
 
-   pgmoneta_log_trace("Done writing\n");
-   pgmoneta_log_trace("total pages: %d\n", page_number);
-   pgmoneta_log_trace("total records: %d\n", pgmoneta_deque_size(wf->records));
-   pgmoneta_log_trace("total page headers: %d\n", pgmoneta_deque_size(wf->page_headers) + 1);
-   pgmoneta_log_trace("xlp seg size: %d\n", wf->long_phd->xlp_seg_size);
-   pgmoneta_log_trace("xlp xlog blcksz: %d\n", wf->long_phd->xlp_xlog_blcksz);
-
    /* Fill the rest of the file until xlp_seg_size with zeros */
    long num_zeros = wf->long_phd->xlp_seg_size - ftell(file);
    char* zeros = (char*)calloc(num_zeros, sizeof(char));
@@ -165,183 +153,16 @@ error:
    return 1;
 }
 
-static char*
-pgmoneta_wal_encode_xlog_record(struct decoded_xlog_record* decoded, struct server* server_info, char* buffer)
-{
-   uint32_t total_length = 0;
-   uint8_t block_id;
-   char* ptr = NULL;
-   struct xlog_record record = decoded->header;
-
-   /* Compute total length required for the buffer */
-   total_length = record.xl_tot_len;
-
-   /* Allocate buffer */
-   buffer = malloc(total_length);
-   if (!buffer)
-   {
-      /* Handle allocation failure */
-      return NULL;
-   }
-   ptr = buffer;
-
-   /* Write header */
-   memcpy(ptr, &record, SIZE_OF_XLOG_RECORD);
-   ptr += SIZE_OF_XLOG_RECORD;
-
-   assert(ptr - buffer == SIZE_OF_XLOG_RECORD);
-
-   /* Write record_origin */
-   if (decoded->record_origin != INVALID_REP_ORIGIN_ID)
-   {
-      /* Write block_id */
-      *ptr = (uint8_t)XLR_BLOCK_ID_ORIGIN;
-      ptr += sizeof(uint8_t);
-
-      /* Write record_origin */
-      memcpy(ptr, &decoded->record_origin, sizeof(rep_origin_id));
-      ptr += sizeof(rep_origin_id);
-   }
-
-   /* Write toplevel_xid */
-   if (decoded->toplevel_xid != INVALID_TRANSACTION_ID)
-   {
-      /* Write block_id */
-      *ptr = (uint8_t)XLR_BLOCK_ID_TOPLEVEL_XID;
-      ptr += sizeof(uint8_t);
-
-      /* Write toplevel_xid */
-      memcpy(ptr, &decoded->toplevel_xid, sizeof(transaction_id));
-      ptr += sizeof(transaction_id);
-   }
-
-   /* Write blocks */
-   for (block_id = 0; block_id <= decoded->max_block_id; block_id++)
-   {
-      struct decoded_bkp_block* blk = &decoded->blocks[block_id];
-
-      if (!blk->in_use)
-      {
-         continue;
-      }
-
-      /* Write block_id */
-      memcpy(ptr, &block_id, sizeof(uint8_t));
-      ptr += sizeof(uint8_t);
-
-      /* Write fork_flags */
-      memcpy(ptr, &blk->flags, sizeof(uint8_t));
-      ptr += sizeof(uint8_t);
-
-      /* Write data_len */
-      uint16_t data_len = blk->data_len;
-      memcpy(ptr, &data_len, sizeof(uint16_t));
-      ptr += sizeof(uint16_t);
-
-      /* Write image data if present */
-      if (blk->has_image)
-      {
-         /* Write bimg_len */
-         uint16_t bimg_len = blk->bimg_len;
-         memcpy(ptr, &bimg_len, sizeof(uint16_t));
-         ptr += sizeof(uint16_t);
-
-         /* Write hole_offset */
-         uint16_t hole_offset = blk->hole_offset;
-         memcpy(ptr, &hole_offset, sizeof(uint16_t));
-         ptr += sizeof(uint16_t);
-
-         /* Write bimg_info */
-         uint8_t bimg_info = blk->bimg_info;
-         memcpy(ptr, &bimg_info, sizeof(uint8_t));
-         ptr += sizeof(uint8_t);
-
-         if (pgmoneta_wal_is_bkp_image_compressed(server_info, blk->bimg_info))
-         {
-            if (blk->bimg_info & BKPIMAGE_HAS_HOLE)
-            {
-               uint16_t hole_length = blk->hole_length;
-               memcpy(ptr, &hole_length, sizeof(uint16_t));
-               ptr += sizeof(uint16_t);
-            }
-         }
-      }
-
-      /* Write rlocator if not SAME_REL */
-      if (!(blk->flags & BKPBLOCK_SAME_REL))
-      {
-         memcpy(ptr, &blk->rlocator, sizeof(struct rel_file_locator));
-         ptr += sizeof(struct rel_file_locator);
-
-      }
-
-      /* Write blkno */
-      memcpy(ptr, &blk->blkno, sizeof(block_number));
-      ptr += sizeof(block_number);
-   }
-
-   if (decoded->main_data_len > 0)
-   {
-      if (decoded->main_data_len <= UINT8_MAX)
-      {
-         /* Write block_id */
-         int block_data_short = XLR_BLOCK_ID_DATA_SHORT;
-         memcpy(ptr, &block_data_short, sizeof(uint8_t));
-         ptr += sizeof(uint8_t);
-
-         /* Write main_data_len (uint8_t) */
-
-         uint8_t main_data_len = decoded->main_data_len;
-         memcpy(ptr, &main_data_len, sizeof(uint8_t));
-         ptr += sizeof(uint8_t);
-      }
-      else
-      {
-         /* Write block_id */
-         int block_data_long = XLR_BLOCK_ID_DATA_LONG;
-         memcpy(ptr, &block_data_long, sizeof(uint8_t));
-         ptr += sizeof(uint8_t);
-
-         /* Write main_data_len (uint32_t) */
-         uint32_t main_data_len = decoded->main_data_len;
-         memcpy(ptr, &main_data_len, sizeof(uint32_t));
-         ptr += sizeof(uint32_t);
-      }
-   }
-
-   for (block_id = 0; block_id <= decoded->max_block_id; block_id++)
-   {
-      struct decoded_bkp_block* blk = &decoded->blocks[block_id];
-      if (blk->has_data)
-      {
-         memcpy(ptr, blk->data, blk->data_len);
-         ptr += blk->data_len;
-      }
-      /* Write backup image if present */
-      if (blk->has_image)
-      {
-         memcpy(ptr, blk->bkp_image, blk->bimg_len);
-         ptr += blk->bimg_len;
-      }
-   }
-
-   if (decoded->main_data_len > 0)
-   {
-      memcpy(ptr, decoded->main_data, decoded->main_data_len);
-      ptr += decoded->main_data_len;
-   }
-
-   /* Ensure we've written the correct amount of data */
-   assert(ptr - buffer == total_length);
-
-   return buffer;
-}
-
 void
 pgmoneta_destroy_walfile(struct walfile* wf)
 {
    struct deque_iterator* record_iterator = NULL;
    struct deque_iterator* page_header_iterator = NULL;
+
+   if (wf == NULL)
+   {
+      return;
+   }
 
    if (pgmoneta_deque_iterator_create(wf->records, &record_iterator) || pgmoneta_deque_iterator_create(wf->page_headers, &page_header_iterator))
    {
@@ -351,6 +172,11 @@ pgmoneta_destroy_walfile(struct walfile* wf)
    while (pgmoneta_deque_iterator_next(record_iterator))
    {
       struct decoded_xlog_record* record = (struct decoded_xlog_record*) record_iterator->value->data;
+      if (record->partial)
+      {
+         free(record);
+         continue;
+      }
       if (record->main_data != NULL)
       {
          free(record->main_data);
@@ -381,4 +207,87 @@ pgmoneta_destroy_walfile(struct walfile* wf)
 
    free(wf->long_phd);
    free(wf);
+}
+
+int
+pgmoneta_describe_walfile(char* path, enum value_type type)
+{
+   char* decompressed_wal_path = NULL;
+   char* tmp_compressed_wal = NULL;
+   struct walfile* wf = NULL;
+   struct deque_iterator* record_iterator = NULL;
+   struct decoded_xlog_record* record = NULL;
+
+   if (!pgmoneta_is_file(path))
+   {
+      pgmoneta_log_fatal("WAL file at %s does not exist", path);
+      goto error;
+   }
+
+   // Based on the file extension, if it's a compressed file, decompress it in /tmp
+   if (pgmoneta_is_file_archive(path))
+   {
+      tmp_compressed_wal = pgmoneta_format_and_append(tmp_compressed_wal, "/tmp/%s", basename(path));
+      // Temporarily copying the compressed WAL file, because the decompress functions delete the source file
+      pgmoneta_copy_file(path, tmp_compressed_wal, NULL);
+
+      decompressed_wal_path = "/tmp/decompressed_wal";
+      if (pgmoneta_decompress(tmp_compressed_wal, decompressed_wal_path))
+      {
+         pgmoneta_log_fatal("Failed to decompress WAL file at %s", path);
+         goto error;
+      }
+   }
+   else
+   {
+      decompressed_wal_path = path;
+   }
+
+   if (pgmoneta_read_walfile(-1, decompressed_wal_path, &wf))
+   {
+      pgmoneta_log_fatal("Failed to read WAL file at %s", path);
+      goto error;
+   }
+   if (pgmoneta_deque_iterator_create(wf->records, &record_iterator))
+   {
+      pgmoneta_log_fatal("Failed to create deque iterator");
+      goto error;
+   }
+
+   if (type == ValueJSON)
+   {
+      printf("{ \"WAL\": [\n");
+      int count = 0;
+      while (pgmoneta_deque_iterator_next(record_iterator))
+      {
+         printf("{\"Record\": ");
+         record = (struct decoded_xlog_record*) record_iterator->value->data;
+         pgmoneta_wal_record_display(record, wf->long_phd->std.xlp_magic, type);
+         printf("}");
+         if (++count < pgmoneta_deque_size(wf->records))
+         {
+            printf(",\n");
+         }
+      }
+      printf("\n]}");
+   }
+   else
+   {
+      while (pgmoneta_deque_iterator_next(record_iterator))
+      {
+         record = (struct decoded_xlog_record*) record_iterator->value->data;
+         pgmoneta_wal_record_display(record, wf->long_phd->std.xlp_magic, type);
+      }
+   }
+
+   free(tmp_compressed_wal);
+   pgmoneta_deque_iterator_destroy(record_iterator);
+   pgmoneta_destroy_walfile(wf);
+   return 0;
+
+error:
+   free(tmp_compressed_wal);
+   pgmoneta_destroy_walfile(wf);
+   pgmoneta_deque_iterator_destroy(record_iterator);
+   return 1;
 }

--- a/src/libpgmoneta/walfile/rm_btree.c
+++ b/src/libpgmoneta/walfile/rm_btree.c
@@ -136,19 +136,19 @@ pgmoneta_wal_create_xl_btree_delete(void)
 void
 pgmoneta_wal_parse_xl_btree_delete_v13(struct xl_btree_delete* wrapper, const void* rec)
 {
-   memcpy(&wrapper->data.v13, rec, sizeof(struct xl_btree_delete_v13));
+   wrapper->data.v13 = *(struct xl_btree_delete_v13*) rec;
 }
 
 void
 pgmoneta_wal_parse_xl_btree_delete_v15(struct xl_btree_delete* wrapper, const void* rec)
 {
-   memcpy(&wrapper->data.v15, rec, sizeof(struct xl_btree_delete_v15));
+   wrapper->data.v15 = *(struct xl_btree_delete_v15*) rec;
 }
 
 void
 pgmoneta_wal_parse_xl_btree_delete_v16(struct xl_btree_delete* wrapper, const void* rec)
 {
-   memcpy(&wrapper->data.v16, rec, sizeof(struct xl_btree_delete_v16));
+   wrapper->data.v16 = *(struct xl_btree_delete_v16*) rec;
 }
 
 char*

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgmoneta.h>
+#include <configuration.h>
+#include <shmem.h>
+#include <walfile.h>
+#include <utils.h>
+
+#include <err.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void
+usage(void)
+{
+   printf("pgmoneta-walinfo %s\n", VERSION);
+   printf("  Command line utility to read and display Write-Ahead Log (WAL) files\n");
+   printf("\n");
+
+   printf("Usage:\n");
+   printf("  pgmoneta-walinfo <file>\n");
+   printf("\n");
+   printf("Options:\n");
+   printf("  -F, --format Output format (raw, json)\n");
+   printf("  -?, --help   Display help\n");
+   printf("\n");
+}
+
+int
+main(int argc, char** argv)
+{
+   int c;
+   int option_index = 0;
+   char* format = NULL;
+   size_t size;
+
+   if (argc < 2)
+   {
+      usage();
+      goto error;
+   }
+
+   while (1)
+   {
+      static struct option long_options[] =
+      {
+         {"help", no_argument, 0, '?'},
+         {"format", required_argument, 0, 'F'},
+         {0, 0, 0, 0}
+      };
+
+      c = getopt_long(argc, argv, "?v:F:",
+                      long_options, &option_index);
+
+      if (c == -1)
+      {
+         break;
+      }
+
+      switch (c)
+      {
+         case 'F':
+            format = strdup(optarg);
+            break;
+         case '?':
+            usage();
+            exit(0);
+         default:
+            break;
+      }
+   }
+
+   if (format == NULL)
+   {
+      format = pgmoneta_append(format, "raw");
+   }
+
+   size = sizeof(struct configuration);
+   if (pgmoneta_create_shared_memory(size, HUGEPAGE_OFF, &shmem))
+   {
+      warnx("pgmoneta-cli: Error creating shared memory");
+      goto error;
+   }
+   pgmoneta_init_configuration(shmem);
+
+   if (strcmp(format, "raw") != 0 && strcmp(format, "json") != 0)
+   {
+      fprintf(stderr, "Invalid format specified. Supported formats: raw, json\n");
+      goto error;
+   }
+
+   enum value_type type;
+
+   if (strcmp(format, "json") == 0)
+   {
+      type = ValueJSON;
+   }
+   else
+   {
+      type = ValueString;
+   }
+
+   if (optind < argc)
+   {
+      char* file_path = argv[optind];
+
+      if (pgmoneta_describe_walfile(file_path, type))
+      {
+         fprintf(stderr, "Error while reading/describing WAL file\n");
+         goto error;
+      }
+   }
+   else
+   {
+      fprintf(stderr, "Missing <file> argument\n");
+      usage();
+      goto error;
+   }
+   pgmoneta_destroy_shared_memory(shmem, size);
+
+   free(format);
+   return 0;
+
+error:
+   if (shmem != NULL)
+   {
+      pgmoneta_destroy_shared_memory(shmem, size);
+   }
+   if (format != NULL)
+   {
+      free(format);
+   }
+   return 1;
+}


### PR DESCRIPTION
### Add pgmoneta-walinfo CLI to read and display WAL files

This PR introduces the `pgmoneta-walinfo` command-line tool for reading and displaying information from PostgreSQL WAL files. Key features include:

- WAL file decompression
- JSON and raw output support
- Display with color palette
- Documentation updates for the new CLI