### PR TITLE
[#401] CLI: conf get | set | ls

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -34,6 +34,9 @@ extern "C" {
 #endif
 
 #include <stdlib.h>
+#include "management.h"
+#include "network.h"
+#include "pgmoneta.h"
 
 /**
  * Initialize the configuration structure
@@ -101,6 +104,10 @@ pgmoneta_validate_admins_configuration(void* shmem);
  */
 int
 pgmoneta_reload_configuration(bool* restart);
+
+void 
+pgmoneta_conf_get_value(SSL* ssl, int client_fd, uint8_t compression,struct json* payload);
+
 
 #ifdef __cplusplus
 }

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -76,6 +76,9 @@ extern "C" {
 #define MANAGEMENT_INFO           18
 #define MANAGEMENT_VERIFY         19
 #define MANAGEMENT_ANNOTATE       20
+#define MANAGEMENT_CONFIG_GET     21
+#define MANAGEMENT_CONFIG_SET     22
+#define MANAGEMENT_CONFIG_LS      23
 
 /**
  * Management categories
@@ -152,6 +155,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_VALID                 "Valid"
 #define MANAGEMENT_ARGUMENT_WAL                   "WAL"
 #define MANAGEMENT_ARGUMENT_WORKERS               "Workers"
+#define MANAGEMENT_ARGUMENT_CONFIG_KEY            "ConfigKey"
 
 /**
  * Management error
@@ -269,6 +273,8 @@ extern "C" {
 #define MANAGEMENT_ERROR_ANNOTATE_FAILED   2003
 #define MANAGEMENT_ERROR_ANNOTATE_NETWORK  2004
 #define MANAGEMENT_ERROR_ANNOTATE_ERROR    2005
+
+#define MANAGEMENT_ERROR_CONF_NOFORK       2100
 
 /**
  * Output formats
@@ -424,6 +430,18 @@ pgmoneta_management_request_reset(SSL* ssl, int socket, uint8_t compression, int
  */
 int
 pgmoneta_management_request_reload(SSL* ssl, int socket, uint8_t compression, int32_t output_format);
+
+/**
+ * Get a specific config key's value 
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param config_key The config key
+ * @param compression The compress method for json format
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_conf_get(SSL* ssl, int socket,char* config_key, uint8_t compression, int32_t output_format);
 
 /**
  * Create a retain request

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1200,6 +1200,22 @@ pgmoneta_atoi(const char* input);
 char*
 pgmoneta_indent(char* str, char* tag, int indent);
 
+char* 
+get_encryption_string(int encryption);
+
+char* 
+get_compression_string(int compression_type);
+
+char* 
+get_storage_engine_string(int storage_engine);
+
+char* 
+get_create_slot_string(int create_slot);
+
+char* 
+get_hugepage_string(int hugepage);
+
+
 #ifdef DEBUG
 
 /**

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -464,6 +464,40 @@ error:
 }
 
 int
+pgmoneta_management_conf_get(SSL* ssl, int socket,char* config_key, uint8_t compression, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (create_header(MANAGEMENT_CONFIG_GET, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_put(request,MANAGEMENT_ARGUMENT_CONFIG_KEY,(uintptr_t) config_key,ValueString);
+   
+   if (pgmoneta_management_write_json(ssl, socket, compression, j))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgmoneta_json_destroy(j);
+
+   return 1;
+}
+
+int
 pgmoneta_management_request_retain(SSL* ssl, int socket, char* server, char* backup_id, uint8_t compression, int32_t output_format)
 {
    struct json* j = NULL;

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -4037,6 +4037,66 @@ pgmoneta_indent(char* str, char* tag, int indent)
    return str;
 }
 
+char* 
+get_encryption_string(int encryption) {
+    switch (encryption) {
+        case ENCRYPTION_NONE: return "None";
+        case ENCRYPTION_AES_256_CBC: return "AES-256-CBC";
+        case ENCRYPTION_AES_192_CBC: return "AES-192-CBC";
+        case ENCRYPTION_AES_128_CBC: return "AES-128-CBC";
+        case ENCRYPTION_AES_256_CTR: return "AES-256-CTR";
+        case ENCRYPTION_AES_192_CTR: return "AES-192-CTR";
+        case ENCRYPTION_AES_128_CTR: return "AES-128-CTR";
+        default: return "Unknown Encryption Type";
+    }
+}
+
+char* 
+get_compression_string(int compression_type) {
+    switch (compression_type) {
+        case COMPRESSION_NONE: return "None";
+        case COMPRESSION_CLIENT_GZIP: return "Client GZIP";
+        case COMPRESSION_CLIENT_ZSTD: return "Client ZSTD";
+        case COMPRESSION_CLIENT_LZ4: return "Client LZ4";
+        case COMPRESSION_CLIENT_BZIP2: return "Client BZIP2";
+        case COMPRESSION_SERVER_GZIP: return "Server GZIP";
+        case COMPRESSION_SERVER_ZSTD: return "Server ZSTD";
+        case COMPRESSION_SERVER_LZ4: return "Server LZ4";
+        default: return "Unknown Compression Type";
+    }
+}
+
+char* 
+get_storage_engine_string(int storage_engine) {
+    switch (storage_engine) {
+        case STORAGE_ENGINE_LOCAL: return "Local";
+        case STORAGE_ENGINE_SSH: return "SSH";
+        case STORAGE_ENGINE_S3: return "S3";
+        case STORAGE_ENGINE_AZURE: return "Azure";
+        default: return "Unknown Storage Engine";
+    }
+}
+
+char* 
+get_create_slot_string(int create_slot) {
+    switch (create_slot) {
+        case CREATE_SLOT_UNDEFINED: return "Undefined";
+        case CREATE_SLOT_YES: return "Yes";
+        case CREATE_SLOT_NO: return "No";
+        default: return "Unknown Create Slot Value";
+    }
+}
+
+char* 
+get_hugepage_string(int hugepage) {
+    switch (hugepage) {
+        case HUGEPAGE_OFF: return "Off";
+        case HUGEPAGE_TRY: return "Try";
+        case HUGEPAGE_ON: return "On";
+        default: return "Unknown Hugepage Value";
+    }
+}
+
 #ifdef DEBUG
 
 int

--- a/src/main.c
+++ b/src/main.c
@@ -1148,6 +1148,27 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
       pgmoneta_management_response_ok(NULL, client_fd, start_time, end_time, compression, payload);
    }
+   else if(id == MANAGEMENT_CONFIG_GET)
+   {
+      pid = fork();
+      if (pid == -1)
+      {
+         pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_CONF_NOFORK, compression, payload);
+         pgmoneta_log_error("Conf get: No fork %s (%d)", server, MANAGEMENT_ERROR_CONF_NOFORK);
+         goto error;
+      }
+      else if (pid == 0)
+      {
+         struct json* pyl = NULL;
+
+         shutdown_ports();
+
+         pgmoneta_json_clone(payload, &pyl);
+
+         pgmoneta_set_proc_title(1, ai->argv, "conf get", NULL);
+         pgmoneta_conf_get_value(NULL, client_fd, compression, pyl);
+      }
+   }
    else if (id == MANAGEMENT_STATUS)
    {
       pid = fork();


### PR DESCRIPTION
Currently this contains the logic for ``conf get`` which works as expected and similar to the other commands. If all is good with this way it will basically be the same idea for ``conf set`` and ``conf ls``  

Got a problem with double free though not sure I tried debugging through the changed parts and even stopped freeing anything myself in ``configuration.c`` , But still this comes up ``free(): double free detected in tcache 2`` so any ideas how I can fix this ? Is there a better way to look through this other than gdb or manual printing/debugging ? 