### PR TITLE
Adding support for MacOS build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Palak Chaturvedi <palakchaturvedi2843@gmail.com>
 Jakub Jirutka <jakub@jirutka.cz>
 Ashutosh Sharma <ash2003sharma@gmail.com>
 Mario Rodas
+Annupamaa <annu242005@gmail.com>

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -28,6 +28,7 @@ Iury Santos <iuryroberto@gmail.com>
 Palak Chaturvedi <palakchaturvedi2843@gmail.com>
 Jakub Jirutka <jakub@jirutka.cz>
 Mario Rodas
+Annupamaa <annu242005@gmail.com>
 ```
 
 ## Committers

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -28,6 +28,7 @@ Iury Santos <iuryroberto@gmail.com>
 Palak Chaturvedi <palakchaturvedi2843@gmail.com>
 Jakub Jirutka <jakub@jirutka.cz>
 Mario Rodas
+Annupamaa <annu242005@gmail.com>
 ```
 
 ## Committers

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,8 @@ if (check)
 
   if(EXISTS "/etc/debian_version")
     target_link_libraries(pgmoneta_test Check::check subunit pthread rt m)
+  elseif(APPLE)
+    target_link_libraries(pgmoneta_test Check::check m)
   else()
     target_link_libraries(pgmoneta_test Check::check pthread rt m)
   endif()


### PR DESCRIPTION
When building the project on macOS, the build process fails during the rt library linking step. After investigating, I discovered that linking the rt library is only necessary for Linux systems. To address this, I added a condition to handle macOS specifically.