### PR TITLE
[#475] Make config argument optional and set default configuration path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Jakub Jirutka <jakub@jirutka.cz>
 Ashutosh Sharma <ash2003sharma@gmail.com>
 Mario Rodas
 Annupamaa <annu242005@gmail.com>
+Mohab Yaser <mohabyaserofficial2003@gmail.com>

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -30,6 +30,7 @@ Jakub Jirutka <jakub@jirutka.cz>
 Mario Rodas
 Annupamaa <annu242005@gmail.com>
 Ashutosh Sharma <ash2003sharma@gmail.com>
+Mohab Yaser <mohabyaserofficial2003@gmail.com>
 ```
 
 ## Committers

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -30,6 +30,7 @@ Jakub Jirutka <jakub@jirutka.cz>
 Mario Rodas
 Annupamaa <annu242005@gmail.com>
 Ashutosh Sharma <ash2003sharma@gmail.com>
+Mohab Yaser <mohabyaserofficial2003@gmail.com>
 ```
 
 ## Committers

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -37,6 +37,9 @@ extern "C" {
 
 #include <stdlib.h>
 
+/* The path of pgmoneta's main configuration file */
+#define PGMONETA_MAIN_CONFIG_FILE_PATH                "/etc/pgmoneta/pgmoneta.conf"
+
 /* Main configuration fields */
 #define CONFIGURATION_ARGUMENT_HOST                   "host"
 #define CONFIGURATION_ARGUMENT_UNIX_SOCKET_DIR        "unix_socket_dir"


### PR DESCRIPTION
When the config file is not provided then it will print warning on the console and also set `configuration_path` to the default value `/etc/pgmoneta/pgmoneta.conf` so that it is truly optional and that it don't throw and error down below when the system start actually using `configuration_path` (at line 273 or so)

This PR solves #475 

Kindly review. @jesperpedersen