### PR TITLE
[#147] Native incremental backup/restore support for PostgreSQL 17

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -58,7 +58,7 @@ Commands:
 
 Backup a server
 
-Command
+The command for a full backup is
 
 ``` sh
 pgmoneta-cli backup <server>
@@ -68,6 +68,20 @@ Example
 
 ``` sh
 pgmoneta-cli backup primary
+```
+
+The command for an incremental backup is
+
+``` sh
+pgmoneta-cli backup <server> <identifier>
+```
+
+where the `identifier` is the identifier for a backup.
+
+Example
+
+``` sh
+pgmoneta-cli backup primary 20250101120000
 ```
 
 ## list-backup

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -274,6 +274,8 @@ There are a few short tutorials available to help you better understand and conf
 - [Working with Transport Level Security](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/12_tls.md)
 - [Hot standby](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/13_hot_standby.md)
 - [Annotate](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/14_annotate.md)
+- [Extra files](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/15_extra.md)
+- [Incremental backup and restore](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/16_incremental_backup_restore.md)
 
 ## Closing
 

--- a/doc/manual/99-references.md
+++ b/doc/manual/99-references.md
@@ -62,6 +62,8 @@
   [t_tls]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/12_tls.md
   [t_hot_standby]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/13_hot_standby.md
   [t_annotate]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/14_annotate.md
+  [t_extra]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/15_extra.md
+  [t_incremental]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/16_incremental_backup_restore.md
 <!-- doc/etc -->
   [sample]: https://github.com/pgmoneta/pgmoneta/blob/main/doc/etc/pgmoneta.conf
 

--- a/doc/manual/advanced/05-backup.md
+++ b/doc/manual/advanced/05-backup.md
@@ -2,9 +2,9 @@
 
 # Backup
 
-## Create backup
+## Create a full backup
 
-We can take a backup from the primary with the following command
+We can take a full backup from the primary with the following command
 
 ```
 pgmoneta-cli backup primary
@@ -63,6 +63,85 @@ Response:
       Comments: ''
       Compression: 2
       Encryption: 0
+      Incremental: false
+      Keep: false
+      RestoreSize: 48799744
+      Server: primary
+      Valid: 1
+      WAL: 0
+  MajorVersion: 17
+  MinorVersion: 0
+  Server: primary
+  ServerVersion: 0.16.0
+```
+
+## Create an incremental backup
+
+We can take an incremental backup from the primary with the following command
+
+```
+pgmoneta-cli backup primary 20240928065644
+```
+
+and you will get output like
+
+```
+Header: 
+  ClientVersion: 0.16.0
+  Command: 1
+  Output: 0
+  Timestamp: 20240928065730
+Outcome: 
+  Status: true
+  Time: 00:00:20
+Request: 
+  Server: primary
+Response: 
+  Backup: 20240928065750
+  BackupSize: 124312
+  Compression: 2
+  Encryption: 0
+  Incremental: true
+  MajorVersion: 17
+  MinorVersion: 0
+  RestoreSize: 48799744
+  Server: primary
+  ServerVersion: 0.16.0
+```
+
+Incremental backups are supported when using [PostgreSQL 17+](https://www.postgresql.org). Note that currently
+branching is not allowed for incremental backup -- a backup can have at most 1
+incremental backup child.
+
+## View backups
+
+We can list all backups for a server with the following command
+
+```
+pgmoneta-cli list-backup primary
+```
+
+and you will get output like
+
+```
+Header: 
+  ClientVersion: 0.16.0
+  Command: 2
+  Output: 0
+  Timestamp: 20240928065812
+Outcome: 
+  Status: true
+  Time: 00:00:00
+Request: 
+  Server: primary
+Response: 
+  Backups: 
+    - Backup: 20240928065644
+      BackupSize: 8531968
+      Comments: ''
+      Compression: 2
+      Encryption: 0
+      Incremental: false
       Keep: false
       RestoreSize: 48799744
       Server: primary
@@ -108,6 +187,7 @@ Response:
   EndHiLSN: 0
   EndLoLSN: 4F000158
   EndTimeline: 1
+  Incremental: false
   Keep: true
   MajorVersion: 17
   MinorVersion: 0

--- a/doc/manual/advanced/06-retention.md
+++ b/doc/manual/advanced/06-retention.md
@@ -31,6 +31,10 @@ This is a very hard property to configure since it depends on the size of the da
 
 If you want to restore from the latest backup plus the Write-Ahead Log (WAL) then the default [**pgmoneta**](pgmoneta) policy maybe is enough.
 
+Note that currently if a backup has an incremental backup child that depends on it, it will be kept even if it doesn't
+
+fall under retention policy. We will support incremental backup deletion in later releases.
+
 ## Retention check
 
 The retention check runs every 5 minutes, and will delete one backup per run.

--- a/doc/manual/advanced/07-keep.md
+++ b/doc/manual/advanced/07-keep.md
@@ -81,6 +81,9 @@ Response:
 
 and you can see that the backup has a `Keep` flag of `true`.
 
+Note that `Keep` currently only works on full backups, we will
+support keeping incremental backups in later releases.
+
 ## Describe a backup
 
 Now, you may want to add a description to your backup, and as you can see

--- a/doc/manual/user-10-cli.md
+++ b/doc/manual/user-10-cli.md
@@ -60,7 +60,7 @@ Report bugs: https://github.com/pgmoneta/pgmoneta/issues
 
 Backup a server
 
-Command
+The command for a full backup is
 
 ``` sh
 pgmoneta-cli backup <server>
@@ -70,6 +70,20 @@ Example
 
 ``` sh
 pgmoneta-cli backup primary
+```
+
+The command for an incremental backup is
+
+``` sh
+pgmoneta-cli backup <server> <identifier>
+```
+
+where the `identifier` is the identifier for a backup.
+
+Example
+
+``` sh
+pgmoneta-cli backup primary 20250101120000
 ```
 
 ## list-backup

--- a/doc/tutorial/07_delete.md
+++ b/doc/tutorial/07_delete.md
@@ -17,4 +17,7 @@ pgmoneta-cli -c pgmoneta.conf delete primary oldest
 
 will delete the oldest backup on `[primary]`.
 
+Note that currently delete will fail if the backup has an incremental backup child that depends on it.
+We will support incremental backup deletion in later releases.
+
 (`pgmoneta` user)

--- a/doc/tutorial/09_retention.md
+++ b/doc/tutorial/09_retention.md
@@ -17,6 +17,9 @@ all the backups within the nearest 7 days, the latest backup on each Monday with
 the latest backup on the first day of each month in the last 12 months and the latest backup on the first
 day of each year in the last 5 years. If you input more than 4 values, [**pgmoneta**](https://github.com/pgmoneta/pgmoneta) will only read the first 4.
 
+Note that currently if a backup has an incremental backup child that depends on it, it will be kept even if it doesn't
+fall under retention policy. We will support incremental backup deletion in later releases.
+
 There are a lot of ways to leave a parameter unspecified. For trailing parameters, you can simply omit them. 
 And for parameters in between, you can use placeholders. Currently, placeholders we allow are: `-`, `X`, `x`, `0` 
 or whitespaces (spaces or tabs). 

--- a/doc/tutorial/13_hot_standby.md
+++ b/doc/tutorial/13_hot_standby.md
@@ -27,6 +27,8 @@ hot_standby_overrides = /your/local/hot/standby/overrides/
 
 to override files in the `hot_standby` directory.
 
+Note that currently hot standby doesn't work with incremental backups, this will be supported in later releases.
+
 ### Tablespaces
 
 By default tablespaces will be mapped to a similar path than the original one, for example `/tmp/mytblspc` becomes `/tmp/mytblspchs`.

--- a/doc/tutorial/16_incremental_backup_restore.md
+++ b/doc/tutorial/16_incremental_backup_restore.md
@@ -1,21 +1,42 @@
-## Backup and restore
+## Incremental backup and restore
 
-This tutorial will show you how to do a backup and a restore using [**pgmoneta**](https://github.com/pgmoneta/pgmoneta).
+This tutorial will show you how to do an incremental backup and a restore using [**pgmoneta**](https://github.com/pgmoneta/pgmoneta).
 
 ### Preface
 
-This tutorial assumes that you have an installation of PostgreSQL 13+ and [**pgmoneta**](https://github.com/pgmoneta/pgmoneta).
+This tutorial assumes that you have an installation of PostgreSQL 17+ and [**pgmoneta**](https://github.com/pgmoneta/pgmoneta).
 
 See [Install pgmoneta](https://github.com/pgmoneta/pgmoneta/blob/main/doc/tutorial/01_install.md)
 for more detail.
 
-### Backup
+### Full backup
 
 ```
 pgmoneta-cli -c pgmoneta.conf backup primary
 ```
 
-will take a backup of the `[primary]` host.
+will take a full backup of the `[primary]` host.
+
+(`pgmoneta` user)
+
+### List backups
+
+```
+pgmoneta-cli -c pgmoneta.conf list-backup primary
+```
+
+(`pgmoneta` user)
+
+### Incremental backup
+
+```
+pgmoneta-cli -c pgmoneta.conf backup primary newest
+```
+
+will take an incremental backup of the `[primary]` host.
+
+Note that currently branching is not allowed for incremental 
+backup -- a backup can have at most 1 incremental backup child.
 
 (`pgmoneta` user)
 
@@ -30,7 +51,7 @@ pgmoneta-cli -c pgmoneta.conf list-backup primary
 ### Restore
 
 ```
-pgmoneta-cli -c pgmoneta.conf restore primary newest current /tmp/ 
+pgmoneta-cli -c pgmoneta.conf restore primary newest current /tmp/
 ```
 
 will take the latest backup and all Write-Ahead Log (WAL) segments and restore it

--- a/pgmoneta.spec
+++ b/pgmoneta.spec
@@ -72,6 +72,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/tutorial/13_hot_standby.md %{buildroot}%{_docdir}/%{name}/tutorial/13_hot_standby.md
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/tutorial/14_annotate.md %{buildroot}%{_docdir}/%{name}/tutorial/14_annotate.md
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/tutorial/15_extra.md %{buildroot}%{_docdir}/%{name}/tutorial/15_extra.md
+%{__install} -m 644 %{_builddir}/%{name}-%{version}/doc/tutorial/16_incremental_backup_restore.md %{buildroot}%{_docdir}/%{name}/tutorial/16_incremental_backup_restore.md
 
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta.1 %{buildroot}%{_mandir}/man1/pgmoneta.1
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-admin.1 %{buildroot}%{_mandir}/man1/pgmoneta-admin.1
@@ -129,6 +130,7 @@ cd %{buildroot}%{_libdir}/
 %{_docdir}/%{name}/tutorial/13_hot_standby.md
 %{_docdir}/%{name}/tutorial/14_annotate.md
 %{_docdir}/%{name}/tutorial/15_extra.md
+%{_docdir}/%{name}/tutorial/16_incremental_backup_restore.md
 %{_mandir}/man1/pgmoneta.1*
 %{_mandir}/man1/pgmoneta-admin.1*
 %{_mandir}/man1/pgmoneta-cli.1*

--- a/src/cli.c
+++ b/src/cli.c
@@ -108,7 +108,7 @@ static void help_info(void);
 static void help_annotate(void);
 static void display_helper(char* command);
 
-static int backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, char* incremental, int32_t output_format);
 static int list_backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int restore(SSL* ssl, int socket, char* server, char* backup_id, char* position, char* directory, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int verify(SSL* ssl, int socket, char* server, char* backup_id, char* directory, char* files, uint8_t compression, uint8_t encryption, int32_t output_format);
@@ -230,7 +230,7 @@ const struct pgmoneta_command command_table[] = {
    {
       .command = "backup",
       .subcommand = "",
-      .accepted_argument_count = {1},
+      .accepted_argument_count = {1, 2},
       .action = MANAGEMENT_BACKUP,
       .deprecated = false,
       .log_message = "<backup> [%s]",
@@ -780,7 +780,14 @@ password:
 execute:
    if (parsed.cmd->action == MANAGEMENT_BACKUP)
    {
-      exit_code = backup(s_ssl, socket, parsed.args[0], compression, encryption, output_format);
+      if (parsed.args[1])
+      {
+         exit_code = backup(s_ssl, socket, parsed.args[0], compression, encryption, parsed.args[1], output_format);
+      }
+      else
+      {
+         exit_code = backup(s_ssl, socket, parsed.args[0], compression, encryption, NULL, output_format);
+      }
    }
    else if (parsed.cmd->action == MANAGEMENT_LIST_BACKUP)
    {
@@ -970,7 +977,7 @@ static void
 help_backup(void)
 {
    printf("Backup a server\n");
-   printf("  pgmoneta-cli backup <server>\n");
+   printf("  pgmoneta-cli backup <server> [identifier]\n");
 }
 
 static void
@@ -1188,9 +1195,9 @@ display_helper(char* command)
 }
 
 static int
-backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format)
+backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, char* incremental, int32_t output_format)
 {
-   if (pgmoneta_management_request_backup(ssl, socket, server, compression, encryption, output_format))
+   if (pgmoneta_management_request_backup(ssl, socket, server, compression, encryption, incremental, output_format))
    {
       goto error;
    }

--- a/src/include/info.h
+++ b/src/include/info.h
@@ -73,6 +73,11 @@ extern "C" {
 #define INFO_STATUS                    "STATUS"
 #define INFO_TABLESPACES               "TABLESPACES"
 #define INFO_WAL                       "WAL"
+#define INFO_TYPE                      "TYPE"
+#define INFO_PARENT                    "PARENT"
+
+#define TYPE_FULL        0
+#define TYPE_INCREMENTAL 1
 
 #define VALID_UNKNOWN -1
 #define VALID_FALSE    0
@@ -121,6 +126,8 @@ struct backup
    int encryption;                                                /**< The encryption type */
    char comments[MAX_COMMENT];                                    /**< The comments */
    char extra[MAX_EXTRA_PATH];                                    /**< The extra directory */
+   int type;                                                      /**< The backup type */
+   char parent_label[MISC_LENGTH];                                /**< The label of backup's parent, only used when backup is incremental */
 } __attribute__ ((aligned (64)));
 
 /**
@@ -236,6 +243,36 @@ pgmoneta_get_backup_file(char* fn, struct backup** backup);
  */
 int
 pgmoneta_get_number_of_valid_backups(int server);
+
+/**
+ * Get the parent for a backup
+ * @param server The server
+ * @param backup The backup
+ * @param parent The parent
+ * @return The result
+ */
+int
+pgmoneta_get_backup_parent(int server, struct backup* backup, struct backup** parent);
+
+/**
+ * Get the root for a backup
+ * @param server The server
+ * @param backup The backup
+ * @param root The root
+ * @return The result
+ */
+int
+pgmoneta_get_backup_root(int server, struct backup* backup, struct backup** root);
+
+/**
+ * Get the child for a backup
+ * @param server The server
+ * @param backup The backup
+ * @param child The child
+ * @return The result
+ */
+int
+pgmoneta_get_backup_child(int server, struct backup* backup, struct backup** child);
 
 /**
  * Create an info request

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -135,6 +135,8 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_FREE_SPACE            "FreeSpace"
 #define MANAGEMENT_ARGUMENT_HASH_ALGORITHM        "HashAlgorithm"
 #define MANAGEMENT_ARGUMENT_HOT_STANDBY_SIZE      "HotStandbySize"
+#define MANAGEMENT_ARGUMENT_INCREMENTAL           "Incremental"
+#define MANAGEMENT_ARGUMENT_INCREMENTAL_PARENT    "IncrementalParent"
 #define MANAGEMENT_ARGUMENT_KEEP                  "Keep"
 #define MANAGEMENT_ARGUMENT_KEY                   "Key"
 #define MANAGEMENT_ARGUMENT_MAJOR_VERSION         "MajorVersion"
@@ -180,17 +182,20 @@ extern "C" {
 #define MANAGEMENT_ERROR_UNKNOWN_COMMAND 2
 #define MANAGEMENT_ERROR_ALLOCATION      3
 
-#define MANAGEMENT_ERROR_BACKUP_INVALID  100
-#define MANAGEMENT_ERROR_BACKUP_WAL      101
-#define MANAGEMENT_ERROR_BACKUP_ACTIVE   102
-#define MANAGEMENT_ERROR_BACKUP_SETUP    103
-#define MANAGEMENT_ERROR_BACKUP_EXECUTE  104
-#define MANAGEMENT_ERROR_BACKUP_TEARDOWN 105
-#define MANAGEMENT_ERROR_BACKUP_NETWORK  106
-#define MANAGEMENT_ERROR_BACKUP_OFFLINE  107
-#define MANAGEMENT_ERROR_BACKUP_NOSERVER 108
-#define MANAGEMENT_ERROR_BACKUP_NOFORK   109
-#define MANAGEMENT_ERROR_BACKUP_ERROR    110
+#define MANAGEMENT_ERROR_BACKUP_INVALID      100
+#define MANAGEMENT_ERROR_BACKUP_WAL          101
+#define MANAGEMENT_ERROR_BACKUP_ACTIVE       102
+#define MANAGEMENT_ERROR_BACKUP_NOBACKUPS    103
+#define MANAGEMENT_ERROR_BACKUP_NOCHILD      104
+#define MANAGEMENT_ERROR_BACKUP_ALREADYCHILD 105
+#define MANAGEMENT_ERROR_BACKUP_SETUP        106
+#define MANAGEMENT_ERROR_BACKUP_EXECUTE      107
+#define MANAGEMENT_ERROR_BACKUP_TEARDOWN     108
+#define MANAGEMENT_ERROR_BACKUP_NETWORK      109
+#define MANAGEMENT_ERROR_BACKUP_OFFLINE      110
+#define MANAGEMENT_ERROR_BACKUP_NOSERVER     111
+#define MANAGEMENT_ERROR_BACKUP_NOFORK       111
+#define MANAGEMENT_ERROR_BACKUP_ERROR        112
 
 #define MANAGEMENT_ERROR_LIST_BACKUP_DEQUE_CREATE 200
 #define MANAGEMENT_ERROR_LIST_BACKUP_BACKUPS      201
@@ -361,11 +366,12 @@ pgmoneta_management_create_outcome_failure(struct json* json, int32_t error, str
  * @param server The server
  * @param compression The compress method for wire protocol
  * @param encryption The encrypt method for wire protocol
+ * @param incremental The base of incremental backup
  * @param output_format The output format
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_management_request_backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
+pgmoneta_management_request_backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, char* incremental, int32_t output_format);
 
 /**
  * Create a list backup request

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -357,6 +357,7 @@ pgmoneta_create_standby_status_update_message(int64_t received, int64_t flushed,
 /**
  * Create a base backup message
  * @param server_version The version of the PostgreSQL server to backup
+ * @param incremental If the backup is incremental
  * @param label The label of the backup
  * @param include_wal The indication of whether to also include WAL
  * @param checksum_algorithm The checksum algorithm to be applied to backup manifest
@@ -366,7 +367,7 @@ pgmoneta_create_standby_status_update_message(int64_t received, int64_t flushed,
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_create_base_backup_message(int server_version, char* label, bool include_wal, int checksum_algorithm,
+pgmoneta_create_base_backup_message(int server_version, bool incremental, char* label, bool include_wal, int checksum_algorithm,
                                     int compression, int compression_level,
                                     struct message** msg);
 
@@ -406,6 +407,17 @@ pgmoneta_send_copy_done_message(SSL* ssl, int socket);
  */
 int
 pgmoneta_create_query_message(char* query, struct message** msg);
+
+/**
+ * Create and send a copy data message with the given content
+ * @param ssl The SSL structure
+ * @param socket The socket
+ * @param buffer The content buffer
+ * @param nbytes The number of bytes
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_send_copy_data(SSL* ssl, int socket, const char* buffer, size_t nbytes);
 
 /**
  * Has a message

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -131,6 +131,8 @@ extern "C" {
 #define FORMAT_JSON_COMPACT   2
 #define BULLET_POINT          "- "
 
+#define INCREMENTAL_PREFIX "INCREMENTAL."
+
 #define likely(x)    __builtin_expect (!!(x), 1)
 #define unlikely(x)  __builtin_expect (!!(x), 0)
 

--- a/src/include/restore.h
+++ b/src/include/restore.h
@@ -70,6 +70,21 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
 int
 pgmoneta_restore_backup(int server, char* identifier, char* position, char* directory, char** output, char** label);
 
+/**
+ * Combine the provided backups
+ * @param server The server
+ * @param base The base directory that contains data and tablespaces
+ * @param input_dir The base directory of the current input incremental backup
+ * @param output_dir The base directory of the output incremental backup
+ * (the last level of directory should not be followed by back slash)
+ * @param prior_backup_dirs The root directory of prior incremental/full backups, from newest to oldest
+ * @param bck The backup to be restored
+ * @param manifest The manifest of the incremental backup to be combined
+ * @return 0 on success, 1 if otherwise
+ */
+int
+pgmoneta_combine_backups(int server, char* base, char* input_dir, char* output_dir, struct deque* prior_backup_dirs, struct backup* bck, struct json* manifest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1288,6 +1288,14 @@ pgmoneta_escape_string(char* str);
 char*
 pgmoneta_lsn_to_string(uint64_t lsn);
 
+/**
+ * Check if the path to a file is an incremental path
+ * @param path The file path
+ * @return true if the file is an incremental path, false if otherwise
+ */
+bool
+pgmoneta_is_incremental_path(char* path);
+
 #ifdef DEBUG
 
 /**

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -39,19 +39,22 @@ extern "C" {
 #include <stdlib.h>
 #include <stdbool.h>
 
-#define WORKFLOW_TYPE_BACKUP        0
-#define WORKFLOW_TYPE_RESTORE       1
-#define WORKFLOW_TYPE_ARCHIVE       2
-#define WORKFLOW_TYPE_DELETE_BACKUP 3
-#define WORKFLOW_TYPE_RETENTION     4
-#define WORKFLOW_TYPE_WAL_SHIPPING  5
-#define WORKFLOW_TYPE_VERIFY        6
+#define WORKFLOW_TYPE_BACKUP                0
+#define WORKFLOW_TYPE_RESTORE               1
+#define WORKFLOW_TYPE_ARCHIVE               2
+#define WORKFLOW_TYPE_DELETE_BACKUP         3
+#define WORKFLOW_TYPE_RETENTION             4
+#define WORKFLOW_TYPE_WAL_SHIPPING          5
+#define WORKFLOW_TYPE_VERIFY                6
+#define WORKFLOW_TYPE_INCREMENTAL_BACKUP    7
+#define WORKFLOW_TYPE_RESTORE_INCREMENTAL   8
 
-#define PERMISSION_TYPE_BACKUP  0
-#define PERMISSION_TYPE_RESTORE 1
-#define PERMISSION_TYPE_ARCHIVE 2
+#define PERMISSION_TYPE_BACKUP              0
+#define PERMISSION_TYPE_RESTORE             1
+#define PERMISSION_TYPE_ARCHIVE             2
+#define PERMISSION_TYPE_RESTORE_INCREMENTAL 3
 
-#define CLEANUP_TYPE_RESTORE 0
+#define CLEANUP_TYPE_RESTORE             0
 
 #define NODE_ALL           "all"
 #define NODE_BACKUP        "backup"
@@ -70,6 +73,9 @@ extern "C" {
 #define NODE_SERVER_BACKUP "server_backup"
 #define NODE_SERVER_BASE   "server_base"
 #define NODE_TARFILE       "tarfile"
+#define NODE_BACKUPS       "backups"
+#define NODE_COMBINE_BASE  "combine_base" // the base directory that contains combine output directory
+#define NODE_MANIFEST      "manifest"
 
 typedef int (* setup)(int, char*, struct deque*);
 typedef int (* execute)(int, char*, struct deque*);
@@ -90,11 +96,12 @@ struct workflow
 /**
  * Create a workflow
  * @param workflow_type The workflow type
+ * @param server The server
  * @param backup The backup
  * @return The workflow
  */
 struct workflow*
-pgmoneta_workflow_create(int workflow_type, struct backup* backup);
+pgmoneta_workflow_create(int workflow_type, int server, struct backup* backup);
 
 /**
  * Create standard workflow nodes

--- a/src/include/workflow_funcs.h
+++ b/src/include/workflow_funcs.h
@@ -53,6 +53,20 @@ struct workflow*
 pgmoneta_create_restore(void);
 
 /**
+ * Create a workflow for batch restore relay
+ * @return The workflow
+ */
+struct workflow*
+pgmoneta_create_batch_restore_relay(void);
+
+/**
+ * Create a workflow for restoring incremental backup
+ * @return The workflow
+ */
+struct workflow*
+pgmoneta_create_combine_incremental(void);
+
+/**
  * Create a workflow for the verify
  * @return The workflow
  */

--- a/src/libpgmoneta/archive.c
+++ b/src/libpgmoneta/archive.c
@@ -135,7 +135,7 @@ pgmoneta_archive(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
          goto error;
       }
 
-      workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_ARCHIVE, backup);
+      workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_ARCHIVE, server, backup);
 
       current = workflow;
       while (current != NULL)

--- a/src/libpgmoneta/delete.c
+++ b/src/libpgmoneta/delete.c
@@ -58,7 +58,7 @@ pgmoneta_delete(int srv, char* label)
    struct workflow* current = NULL;
    struct deque* nodes = NULL;
 
-   workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_DELETE_BACKUP, NULL);
+   workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_DELETE_BACKUP, srv, NULL);
 
    pgmoneta_deque_create(false, &nodes);
 

--- a/src/libpgmoneta/keep.c
+++ b/src/libpgmoneta/keep.c
@@ -140,7 +140,7 @@ keep(char* prefix, SSL* ssl, int client_fd, int srv, bool k, uint8_t compression
       goto error;
    }
 
-   if (backups[backup_index]->valid == VALID_TRUE)
+   if (backups[backup_index]->valid == VALID_TRUE && backups[backup_index]->type == TYPE_FULL)
    {
       d = pgmoneta_get_server_backup_identifier(srv, backups[backup_index]->label);
 

--- a/src/libpgmoneta/link.c
+++ b/src/libpgmoneta/link.c
@@ -88,9 +88,10 @@ pgmoneta_link_manifest(char* base_from, char* base_to, char* from, struct art* c
             struct worker_input* wi = NULL;
             from_file = pgmoneta_remove_prefix(from_entry, base_from);
             from_file_trimmed = trim_suffix(from_file);
-            // file in newer dir is not added nor changed
+            // file in newer dir is not added nor changed, nor is an incremental file
             if (!pgmoneta_art_contains_key(added, (unsigned char*)from_file_trimmed, strlen(from_file_trimmed) + 1) &&
-                !pgmoneta_art_contains_key(changed, (unsigned char*)from_file_trimmed, strlen(from_file_trimmed) + 1))
+                !pgmoneta_art_contains_key(changed, (unsigned char*)from_file_trimmed, strlen(from_file_trimmed) + 1) &&
+                !pgmoneta_is_incremental_path(from_file_trimmed))
             {
                to_entry = pgmoneta_append(to_entry, base_to);
                if (!pgmoneta_ends_with(to_entry, "/"))

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -54,7 +54,7 @@ static int write_socket(int socket, void* buf, size_t size);
 static int write_ssl(SSL* ssl, void* buf, size_t size);
 
 int
-pgmoneta_management_request_backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format)
+pgmoneta_management_request_backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, char* incremental, int32_t output_format)
 {
    struct json* j = NULL;
    struct json* request = NULL;
@@ -70,6 +70,7 @@ pgmoneta_management_request_backup(SSL* ssl, int socket, char* server, uint8_t c
    }
 
    pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_BACKUP, (uintptr_t)incremental, ValueString);
 
    if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
    {

--- a/src/libpgmoneta/message.c
+++ b/src/libpgmoneta/message.c
@@ -791,7 +791,7 @@ pgmoneta_create_standby_status_update_message(int64_t received, int64_t flushed,
 }
 
 int
-pgmoneta_create_base_backup_message(int server_version, char* label, bool include_wal, int checksum_algorithm,
+pgmoneta_create_base_backup_message(int server_version, bool incremental, char* label, bool include_wal, int checksum_algorithm,
                                     int compression, int compression_level,
                                     struct message** msg)
 {
@@ -805,6 +805,10 @@ pgmoneta_create_base_backup_message(int server_version, char* label, bool includ
    // other options are
    if (use_new_format)
    {
+      if (incremental)
+      {
+         options = pgmoneta_append(options, "INCREMENTAL, ");
+      }
       options = pgmoneta_append(options, "LABEL '");
       options = pgmoneta_append(options, label);
       options = pgmoneta_append(options, "', ");
@@ -1051,6 +1055,32 @@ pgmoneta_create_query_message(char* query, struct message** msg)
    *msg = m;
 
    return MESSAGE_STATUS_OK;
+}
+
+int
+pgmoneta_send_copy_data(SSL* ssl, int socket, const char* buffer, size_t nbytes)
+{
+   struct message* msg = NULL;
+   size_t size = 1 + 4 + nbytes;
+   msg = allocate_message(size);
+   msg->kind = 'd';
+
+   pgmoneta_write_byte(msg->data, 'd');
+   pgmoneta_write_int32(msg->data + 1, size - 1);
+   memcpy(msg->data + 5, &buffer[0], nbytes);
+
+   if (pgmoneta_write_message(ssl, socket, msg) != MESSAGE_STATUS_OK)
+   {
+      pgmoneta_log_error("Could not send CopyData message");
+      goto error;
+   }
+
+   pgmoneta_free_message(msg);
+   return 0;
+
+error:
+   pgmoneta_free_message(msg);
+   return 1;
 }
 
 int
@@ -2160,7 +2190,6 @@ pgmoneta_consume_data_row_messages(SSL* ssl, int socket, struct stream_buffer* b
    while (config->running && (msg == NULL || msg->kind != 'C'))
    {
       status = pgmoneta_consume_copy_stream_start(ssl, socket, buffer, msg, NULL);
-
       if (status != MESSAGE_STATUS_OK)
       {
          goto error;
@@ -2225,13 +2254,16 @@ pgmoneta_consume_data_row_messages(SSL* ssl, int socket, struct stream_buffer* b
       pgmoneta_consume_copy_stream_end(buffer, msg);
    }
    *response = r;
-   pgmoneta_free_message(msg);
+   // msg is reusable, it doesn't actually hold data,
+   // but merely points to somewhere in the stream buffer
+   // So no need for pgmoneta_free_message :)
+   free(msg);
    msg = NULL;
 
    return 0;
 error:
    pgmoneta_close_ssl(ssl);
-   pgmoneta_free_message(msg);
+   free(msg);
    pgmoneta_disconnect(socket);
    pgmoneta_free_query_response(r);
    return 1;

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -34,21 +34,141 @@
 #include <management.h>
 #include <network.h>
 #include <restore.h>
-#include <stdint.h>
+#include <security.h>
 #include <string.h>
 #include <utils.h>
 #include <value.h>
 #include <workflow.h>
 
 /* system */
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 
 #define RESTORE_OK            0
 #define RESTORE_MISSING_LABEL 1
 #define RESTORE_NO_DISK_SPACE 2
+#define INCREMENTAL_MAGIC 0xd3ae1f0d
+#define INCREMENTAL_PREFIX_LENGTH (sizeof(INCREMENTAL_PREFIX) - 1)
+#define MANIFEST_FILES "Files"
+#define MAX_PATH_INCREMENTAL (MAX_PATH * 2)
+
+/**
+ * An rfile stores the metadata we need to use a file on disk for reconstruction.
+ * For full backup file in the chain, only file name and file pointer are initialized.
+ *
+ * num_blocks is the number of blocks present inside an incremental file.
+ * These are the blocks that have changed since the last checkpoint.
+ * truncation_block_length is basically the shortest length this file has been between this and last checkpoint.
+ * Note that truncation_block_length could be even greater than the number of blocks the original file has.
+ * Because the tables are not locked during the backup, so blocks could be truncated during the process,
+ * while truncation_block_length only reflects length until the checkpoint before backup starts.
+ * relative_block_numbers are the relative BlockNumber of each block in the file. Relative here means relative to
+ * the starting BlockNumber of this file.
+ */
+struct rfile
+{
+   char* filepath;
+   FILE* fp;
+   size_t header_length;
+   uint32_t num_blocks;
+   uint32_t* relative_block_numbers;
+   uint32_t truncation_block_length;
+};
 
 static char* restore_last_files_names[] = {"/global/pg_control"};
+
+static void clear_manifest_incremental_entries(struct json* manifest);
+static int get_file_manifest(char* path, char* manifest_path, int algorithm, struct json** file);
+/**
+ * Combine the provided backups or each of the user defined table-spaces
+ * The function will be called for two rounds, the first round would construct the data directory
+ * including pg_tblspc/ and the tsoid directory underneath. And the second round
+ * will combine each user defined tablespaces
+ * @param tsoid The table space oid, if we are reconstructing a tablespace
+ * @param server The server
+ * @param input_dir The base directory of the current input incremental backup
+ * @param output_dir The base directory of the output incremental backup
+ * @param relative_dir The internal directory relative to base directory
+ * (the last level of directory should not be followed by back slash)
+ * @param algorithm The manifest hash algorithm used for the backup
+ * @param prior_backup_dirs The root directory of prior incremental/full backups, from newest to oldest
+ * @param files The file array inside manifest of the backup
+ * @return 0 on success, 1 if otherwise
+ */
+static int combine_backups_recursive(uint32_t tsoid,
+                                     int server,
+                                     char* input_dir,
+                                     char* output_dir,
+                                     char* relative_dir,
+                                     int algorithm,
+                                     struct deque* prior_backup_dirs,
+                                     struct json* files);
+
+/**
+ * Reconstruct an incremental backup file from itself and its prior incremental/full backup files to a full backup file
+ * @param server The server
+ * @param input_file_path The absolute path to the incremental backup file
+ * @param output_file_path The absolute path to the reconstructed full backup file
+ * @param relative_dir The directory containing the incremental file relative to the root dir, should be the same across all backups
+ * @param bare_file_name The name of the file without "INCREMENTAL." prefix
+ * @param prior_backup_dirs The root directory of prior incremental/full backups, from newest to oldest
+ * @return 0 on success, 1 if otherwise
+ */
+static int
+reconstruct_backup_file(int server,
+                        char* input_file_path,
+                        char* output_file_path,
+                        char* relative_dir,
+                        char* bare_file_name,
+                        struct deque* prior_backup_dirs);
+
+/**
+ * Get the number of blocks that the final reconstructed full backup file should have.
+ * Normally it is the same as truncation_block_length.
+ * But the table could be going through truncation during the backup process. In that case
+ * the reconstructed file could have more blocks than truncation_block_length.
+ * So anyway extend the file length to include those blocks.
+ * @param s The rfile of the incremental file
+ * @return The block length
+ */
+static uint32_t
+find_reconstructed_block_length(struct rfile* s);
+
+static int
+rfile_create(char* file_path, struct rfile** rfile);
+
+static void
+rfile_destroy(struct rfile* rf);
+
+static void
+rfile_destroy_cb(uintptr_t data);
+
+static int
+incremental_rfile_initialize(int server, char* file_path, struct rfile** rf);
+
+static bool
+is_full_file(struct rfile* rf);
+
+static int
+read_block(struct rfile* rf, off_t offset, uint32_t blocksz, uint8_t* buffer);
+
+static int
+write_reconstructed_file(char* output_file_path,
+                         uint32_t block_length,
+                         struct rfile** source_map,
+                         off_t* offset_map,
+                         uint32_t blocksz);
+
+static int
+write_backup_label(char* from_dir, char* to_dir);
+
+static uint32_t
+parse_oid(char* name);
 
 int
 pgmoneta_get_restore_last_files_names(char*** output)
@@ -135,6 +255,8 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
       pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMMENTS, (uintptr_t)backup->comments, ValueString);
       pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMPRESSION, (uintptr_t)backup->compression, ValueInt32);
       pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_ENCRYPTION, (uintptr_t)backup->encryption, ValueInt32);
+      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL, (uintptr_t)backup->type, ValueBool);
+      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL_PARENT, (uintptr_t)backup->parent_label, ValueString);
 
       clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
 
@@ -208,9 +330,17 @@ pgmoneta_restore_backup(int server, char* identifier, char* position, char* dire
    struct workflow* current = NULL;
    struct deque* nodes = NULL;
    struct backup* backup = NULL;
+   char directory_incremental[MAX_PATH];
+   char directory_combine[MAX_PATH];
+   char* manifest_path = NULL;
+   struct json* manifest = NULL;
    struct configuration* config;
 
    config = (struct configuration*)shmem;
+
+   memset(directory_incremental, 0, MAX_PATH);
+   memset(directory_combine, 0, MAX_PATH);
+   directory = pgmoneta_remove_suffix(directory, "/");
 
    *output = NULL;
    *label = NULL;
@@ -218,12 +348,6 @@ pgmoneta_restore_backup(int server, char* identifier, char* position, char* dire
    pgmoneta_deque_create(false, &nodes);
 
    if (pgmoneta_deque_add(nodes, NODE_POSITION, (uintptr_t)position, ValueString))
-   {
-      ret = RESTORE_MISSING_LABEL;
-      goto error;
-   }
-
-   if (pgmoneta_deque_add(nodes, NODE_DIRECTORY, (uintptr_t)directory, ValueString))
    {
       ret = RESTORE_MISSING_LABEL;
       goto error;
@@ -264,7 +388,60 @@ pgmoneta_restore_backup(int server, char* identifier, char* position, char* dire
       goto error;
    }
 
-   workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_RESTORE, backup);
+   if (pgmoneta_deque_add(nodes, NODE_POSITION, (uintptr_t)position, ValueString))
+   {
+      goto error;
+   }
+
+   if (backup->type == TYPE_FULL)
+   {
+      if (pgmoneta_deque_add(nodes, NODE_DIRECTORY, (uintptr_t)directory, ValueString))
+      {
+         goto error;
+      }
+   }
+   else if (backup->type == TYPE_INCREMENTAL)
+   {
+      snprintf(directory_incremental, MAX_PATH, "%s/tmp_%s_incremental_%s", directory, config->servers[server].name, &backup->label[0]);
+      snprintf(directory_combine, MAX_PATH, "%s/%s-%s", directory, config->servers[server].name, &backup->label[0]);
+      manifest_path = pgmoneta_get_server_backup_identifier_data(server, backup->label);
+      manifest_path = pgmoneta_append(manifest_path, "backup_manifest");
+
+      if (pgmoneta_deque_add(nodes, NODE_DIRECTORY, (uintptr_t)directory_incremental, ValueString))
+      {
+         goto error;
+      }
+
+      if (pgmoneta_deque_add(nodes, NODE_COMBINE_BASE, (uintptr_t)directory, ValueString))
+      {
+         goto error;
+      }
+      // read the manifest for later usage
+      if (pgmoneta_json_read_file(manifest_path, &manifest))
+      {
+         goto error;
+      }
+      pgmoneta_deque_add(nodes, NODE_MANIFEST, (uintptr_t)manifest, ValueJSON);
+   }
+   else
+   {
+      pgmoneta_log_error("Unidentified backup type %d", backup->type);
+      goto error;
+   }
+
+   if (backup->type == TYPE_FULL)
+   {
+      workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_RESTORE, server, backup);
+   }
+   else if (backup->type == TYPE_INCREMENTAL)
+   {
+      workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_RESTORE_INCREMENTAL, server, backup);
+   }
+   else
+   {
+      pgmoneta_log_error("unidentified backup type %d", backup->type);
+      goto error;
+   }
 
    current = workflow;
    while (current != NULL)
@@ -329,7 +506,18 @@ pgmoneta_restore_backup(int server, char* identifier, char* position, char* dire
    memset(*label, 0, strlen(backup->label) + 1);
    memcpy(*label, backup->label, strlen(backup->label));
 
+   if (backup != NULL && backup->type == TYPE_INCREMENTAL)
+   {
+      // clean up the temporary workspace we used to combine backups
+      if (strlen(directory_incremental) != 0 && pgmoneta_exists(directory_incremental))
+      {
+         pgmoneta_delete_directory(directory_incremental);
+      }
+   }
+
    free(backup);
+   free(directory);
+   free(manifest_path);
 
    pgmoneta_workflow_destroy(workflow);
 
@@ -338,11 +526,911 @@ pgmoneta_restore_backup(int server, char* identifier, char* position, char* dire
    return RESTORE_OK;
 
 error:
+   if (backup != NULL && backup->type == TYPE_INCREMENTAL)
+   {
+      if (strlen(directory_incremental) != 0)
+      {
+         pgmoneta_delete_directory(directory_incremental);
+      }
+      if (strlen(directory_combine) != 0)
+      {
+         pgmoneta_delete_directory(directory_combine);
+         // purge each table space
+         for (int i = 0; i < backup->number_of_tablespaces; i++)
+         {
+            char tblspc[MAX_PATH];
+            memset(tblspc, 0, MAX_PATH);
+            snprintf(tblspc, MAX_PATH, "%s/%s-%s-%s",
+                     directory, config->servers[server].name, backup->label, backup->tablespaces[i]);
+            if (pgmoneta_exists(tblspc))
+            {
+               pgmoneta_delete_directory(tblspc);
+            }
+         }
+      }
+   }
    free(backup);
-
+   free(directory);
+   free(manifest_path);
    pgmoneta_workflow_destroy(workflow);
 
    pgmoneta_deque_destroy(nodes);
 
    return ret;
+}
+
+int
+pgmoneta_combine_backups(int server, char* base, char* input_dir, char* output_dir, struct deque* prior_backup_dirs, struct backup* bck, struct json* manifest)
+{
+   uint32_t tsoid = 0;
+   char relative_tablespace_path[MAX_PATH];
+   char full_tablespace_path[MAX_PATH];
+   char itblspc_dir[MAX_PATH];
+   char otblspc_dir[MAX_PATH];
+   char manifest_path[MAX_PATH];
+   struct json* files = NULL;
+   struct configuration* config;
+
+   if (manifest == NULL || prior_backup_dirs == NULL || base == NULL || input_dir == NULL || output_dir == NULL)
+   {
+      goto error;
+   }
+
+   config = (struct configuration*)shmem;
+
+   memset(manifest_path, 0, MAX_PATH);
+   snprintf(manifest_path, MAX_PATH, "%s/backup_manifest", output_dir);
+
+   clear_manifest_incremental_entries(manifest);
+   files = (struct json*)pgmoneta_json_get(manifest, MANIFEST_FILES);
+   if (files == NULL)
+   {
+      goto error;
+   }
+
+   // It is actually ok even if we don't explicitly create the top level directory
+   // since pgmoneta_mkdir creates parent directory if it doesn't exist.
+   // We do this to make the code clearer and safer
+   if (pgmoneta_mkdir(output_dir))
+   {
+      pgmoneta_log_error("Combine incremental: Unable to create directory %s", output_dir);
+      goto error;
+   }
+
+   // round 1 for base data directory
+   if (combine_backups_recursive(0, server, input_dir, output_dir, NULL, bck->hash_algorithm, prior_backup_dirs, files))
+   {
+      goto error;
+   }
+
+   // round 2 for each tablespaces
+   for (int i = 0; i < bck->number_of_tablespaces; i++)
+   {
+      tsoid = parse_oid(bck->tablespaces_oids[i]);
+
+      memset(relative_tablespace_path, 0, MAX_PATH);
+      memset(full_tablespace_path, 0, MAX_PATH);
+      memset(otblspc_dir, 0, MAX_PATH);
+      memset(itblspc_dir, 0, MAX_PATH);
+
+      snprintf(otblspc_dir, MAX_PATH, "%s/%s/%u", output_dir, "pg_tblspc", tsoid);
+      snprintf(itblspc_dir, MAX_PATH, "%s/%s/%u", input_dir, "pg_tblspc", tsoid);
+      snprintf(relative_tablespace_path, MAX_PATH, "../../%s-%s-%s",
+               config->servers[server].name, bck->label, bck->tablespaces[i]);
+      snprintf(full_tablespace_path, MAX_PATH, "%s/%s-%s-%s", base, config->servers[server].name, bck->label, bck->tablespaces[i]);
+
+      // create and link the actual tablespace directory
+      if (pgmoneta_mkdir(full_tablespace_path))
+      {
+         pgmoneta_log_error("Combine backups: unable to create directory %s", full_tablespace_path);
+         goto error;
+      }
+
+      if (pgmoneta_symlink_at_file(otblspc_dir, relative_tablespace_path))
+      {
+         pgmoneta_log_error("Combine backups: unable to create symlink %s->%s", otblspc_dir, relative_tablespace_path);
+      }
+
+      if (combine_backups_recursive(tsoid, server, itblspc_dir, full_tablespace_path, NULL, bck->hash_algorithm, prior_backup_dirs, files))
+      {
+         goto error;
+      }
+   }
+
+   if (write_backup_label(input_dir, output_dir))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_json_write_file(manifest_path, manifest))
+   {
+      pgmoneta_log_error("Fail to write manifest to %s", manifest_path);
+      goto error;
+   }
+
+   return 0;
+error:
+   return 1;
+}
+
+static int
+combine_backups_recursive(uint32_t tsoid,
+                          int server,
+                          char* input_dir,
+                          char* output_dir,
+                          char* relative_dir,
+                          int algorithm,
+                          struct deque* prior_backup_dirs,
+                          struct json* files)
+{
+   bool is_pg_tblspc = false;
+   bool is_incremental_dir = false;
+   char ifulldir[MAX_PATH];
+   char ofulldir[MAX_PATH];
+   // Current directory of the file to be reconstructed relative to backup base directory.
+   // In normal cases it's the same as relative_dir, except for having an ending backup slash
+   // For table spaces the relative_dir is relative to the table space oid directory,
+   // so the relative_prefix should be pg_tblspc/oid/relative_dir/ instead
+   char relative_prefix[MAX_PATH];
+   DIR* dir = NULL;
+   struct dirent* entry;
+   struct json* file = NULL;
+
+   memset(ifulldir, 0, MAX_PATH);
+   memset(ofulldir, 0, MAX_PATH);
+   memset(relative_prefix, 0, MAX_PATH);
+
+   // categorize current directory
+   is_pg_tblspc = pgmoneta_compare_string(relative_dir, "pg_tblspc");
+   // incremental directories are subdirectories of base/ (files directly under base/ itself doesn't count),
+   // the pg_global directory itself (subdirectories doesn't count, only files directly under global),
+   // and subdirectories of pg_tblspc/
+   is_incremental_dir = pgmoneta_starts_with(relative_dir, "base/") ||
+                        pgmoneta_compare_string(relative_dir, "global") ||
+                        pgmoneta_starts_with(relative_dir, "pg_tblspc/") ||
+                        tsoid != 0;
+   if (relative_dir == NULL)
+   {
+      memcpy(ifulldir, input_dir, strlen(input_dir));
+      memcpy(ofulldir, output_dir, strlen(output_dir));
+
+      // Since relative_dir is either relative to data directory or the pg_tblspc/oid dir,
+      // when relative directory is NULL, either it's the data root directory,
+      // or it's the tablespace directory(pg_tblspc), only the latter case
+      // we'll need to deal with incremental files within, the former case is invalid
+      if (tsoid != 0)
+      {
+         snprintf(relative_prefix, MAX_PATH, "%s/%u/", "pg_tblspc", tsoid);
+      }
+   }
+   else
+   {
+      snprintf(ifulldir, MAX_PATH, "%s/%s", input_dir, relative_dir);
+      snprintf(ofulldir, MAX_PATH, "%s/%s", output_dir, relative_dir);
+      if (tsoid == 0)
+      {
+         snprintf(relative_prefix, MAX_PATH, "%s/", relative_dir);
+      }
+      else
+      {
+         snprintf(relative_prefix, MAX_PATH, "%s/%u/%s/", "pg_tblspc", tsoid, relative_dir);
+      }
+   }
+
+   // top level output directories should have been created
+   if (relative_dir != NULL)
+   {
+      if (pgmoneta_mkdir(ofulldir))
+      {
+         pgmoneta_log_error("combine backup: could not create directory %s", ofulldir);
+         goto error;
+      }
+   }
+
+   if (!(dir = opendir(ifulldir)))
+   {
+      pgmoneta_log_error("combine backup: could not open directory %s", ofulldir);
+      goto error;
+   }
+   while ((entry = readdir(dir)) != NULL)
+   {
+      char ifullpath[MAX_PATH_INCREMENTAL];
+      char ofullpath[MAX_PATH_INCREMENTAL];
+      char manifest_path[MAX_PATH_INCREMENTAL];
+
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
+      {
+         continue;
+      }
+
+      memset(ifullpath, 0, MAX_PATH_INCREMENTAL);
+      memset(ofullpath, 0, MAX_PATH_INCREMENTAL);
+      memset(manifest_path, 0, MAX_PATH_INCREMENTAL);
+
+      snprintf(ifullpath, MAX_PATH_INCREMENTAL, "%s/%s", ifulldir, entry->d_name);
+
+      // Right now we only care about copying everything directly underneath pg_tblspc dir that's not a symlink
+      if (is_pg_tblspc &&
+          (entry->d_type == DT_DIR || entry->d_type == DT_LNK) &&
+          parse_oid(entry->d_name) != 0)
+      {
+         continue;
+      }
+
+      if (entry->d_type == DT_DIR)
+      {
+         // go into the next level directory
+         char new_relative_dir[MAX_PATH];
+         memset(new_relative_dir, 0, MAX_PATH);
+         if (relative_dir == NULL)
+         {
+            memcpy(new_relative_dir, entry->d_name, strlen(entry->d_name));
+         }
+         else
+         {
+            snprintf(new_relative_dir, MAX_PATH, "%s/%s", relative_dir, entry->d_name);
+         }
+         combine_backups_recursive(tsoid, server, input_dir, output_dir, new_relative_dir, algorithm, prior_backup_dirs, files);
+         continue;
+      }
+
+      if (entry->d_type != DT_REG)
+      {
+         if (entry->d_type == DT_LNK)
+         {
+            pgmoneta_log_warn("skipping symbolic link \"%s\"", ifullpath);
+         }
+         else
+         {
+            pgmoneta_log_warn("skipping special file \"%s\"", ifullpath);
+         }
+         continue;
+      }
+
+      // skip these, backup_label requires special handling
+      if (relative_dir == NULL &&
+          (pgmoneta_compare_string(entry->d_name, "backup_label") ||
+           pgmoneta_compare_string(entry->d_name, "backup_manifest")))
+      {
+         continue;
+      }
+      if (is_incremental_dir && pgmoneta_starts_with(entry->d_name, INCREMENTAL_PREFIX))
+      {
+         // finally found an incremental file
+         snprintf(ofullpath, MAX_PATH_INCREMENTAL, "%s/%s", ofulldir, entry->d_name + INCREMENTAL_PREFIX_LENGTH);
+         snprintf(manifest_path, MAX_PATH_INCREMENTAL, "%s%s", relative_prefix, entry->d_name + INCREMENTAL_PREFIX_LENGTH);
+         if (reconstruct_backup_file(server,
+                                     ifullpath,
+                                     ofullpath,
+                                     relative_prefix,
+                                     entry->d_name + INCREMENTAL_PREFIX_LENGTH,
+                                     prior_backup_dirs))
+         {
+            pgmoneta_log_error("unable to reconstruct file %s", ifullpath);
+            goto error;
+         }
+         // Update file entry in manifest
+         if (get_file_manifest(ofullpath, manifest_path, algorithm, &file))
+         {
+            pgmoneta_log_error("Unable to get manifest for file %s", ofullpath);
+         }
+         else
+         {
+            pgmoneta_json_append(files, (uintptr_t)file, ValueJSON);
+         }
+      }
+      else
+      {
+         // copy the full file from input dir to output dir
+         snprintf(ofullpath, MAX_PATH_INCREMENTAL, "%s/%s", ofulldir, entry->d_name);
+         pgmoneta_copy_file(ifullpath, ofullpath, NULL);
+      }
+   }
+
+   if (dir != NULL)
+   {
+      closedir(dir);
+   }
+   return 0;
+error:
+   if (dir != NULL)
+   {
+      closedir(dir);
+   }
+   return 1;
+}
+
+static int
+reconstruct_backup_file(int server,
+                        char* input_file_path,
+                        char* output_file_path,
+                        char* relative_dir,
+                        char* bare_file_name,
+                        struct deque* prior_backup_dirs)
+{
+   struct deque* sources = NULL; // bookkeeping of each incr/full backup rfile, so that we can free them conveniently
+   struct deque_iterator* bck_iter = NULL; // the iterator for backup directories
+   struct rfile* latest_source = NULL; // the metadata of current incr backup file
+   struct rfile** source_map = NULL; // source to find each block
+   off_t* offset_map = NULL; // offsets to find each block in corresponding file
+   uint32_t block_length = 0; // total number of blocks in the reconstructed file
+   bool full_copy_possible = true; // whether we could just copy over directly instead of block by block
+   uint32_t b = 0; // temp variable for block numbers
+   struct configuration* config;
+   size_t blocksz = 0;
+   char path[MAX_PATH];
+   uint32_t nblocks = 0;
+   size_t file_size = 0;
+   struct rfile* copy_source = NULL;
+   struct value_config rfile_config = {.destroy_data = rfile_destroy_cb, .to_string = NULL};
+
+   config = (struct configuration*)shmem;
+
+   blocksz = config->servers[server].block_size;
+
+   pgmoneta_deque_create(false, &sources);
+
+   // handle the latest file specially, it is the only file that can only be incremental
+   if (incremental_rfile_initialize(server, input_file_path, &latest_source))
+   {
+      goto error;
+   }
+
+   // The key insight is that the blocks are always consecutive.
+   // Blocks deleted but not vacuumed are treated as modified.
+   // Vacuum will move data around, rearrange free spaces
+   // so that there's no void in the middle (also leading
+   // to some blocks getting modified), and then
+   // if a block is the new limit block will be updated
+   block_length = find_reconstructed_block_length(latest_source);
+   pgmoneta_deque_add_with_config(sources, NULL, (uintptr_t)latest_source, &rfile_config);
+
+   source_map = malloc(sizeof(struct rfile*) * block_length);
+   offset_map = malloc(sizeof(off_t) * block_length);
+
+   memset(source_map, 0, sizeof(struct rfile*) * block_length);
+   memset(offset_map, 0, sizeof(off_t) * block_length);
+
+   // A block is always sourced from its latest appearance,
+   // it could be in an incremental file, or a full file.
+   // Blocks included in the latest incremental backup can of course
+   // be sourced from there directly.
+   for (int i = 0; i < latest_source->num_blocks; i++)
+   {
+      // the block number of blocks inside latest incr file
+      b = latest_source->relative_block_numbers[i];
+      if (b >= block_length)
+      {
+         pgmoneta_log_error("find block number %d exceeding reconstructed file size %d at file path %s", b, block_length, input_file_path);
+         goto error;
+      }
+      source_map[b] = latest_source;
+      offset_map[b] = latest_source->header_length + (i * blocksz);
+
+      // some blocks have been modified,
+      // so cannot just copy the file from the prior full backup over
+      full_copy_possible = false;
+   }
+
+   // Go over all source files and try finding the source block for each block number,
+   // starting from the latest. Any block can date back to as far as the latest full file.
+   // There could be blocks that cannot be sourced. This is probably because the block gets truncated
+   // during the backup process before it gets backed up. In this case just zero fill the block later,
+   // the WAL replay will fix the inconsistency since it's getting truncated in the first place.
+   pgmoneta_deque_iterator_create(prior_backup_dirs, &bck_iter);
+   while (pgmoneta_deque_iterator_next(bck_iter))
+   {
+      struct rfile* rf = NULL;
+      char* dir = (char*)pgmoneta_value_data(bck_iter->value);
+      // try finding the full file
+      memset(path, 0, MAX_PATH);
+      // relative directory always ends with '/'
+      snprintf(path, MAX_PATH, "%s/%s%s", dir, relative_dir, bare_file_name);
+      if (rfile_create(path, &rf))
+      {
+         memset(path, 0, MAX_PATH);
+         snprintf(path, MAX_PATH, "%s/%s/INCREMENTAL.%s", dir, relative_dir, bare_file_name);
+         if (incremental_rfile_initialize(server, path, &rf))
+         {
+            goto error;
+         }
+      }
+      pgmoneta_deque_add_with_config(sources, NULL, (uintptr_t)rf, &rfile_config);
+
+      // If it's a full file, all blocks not sourced yet can be sourced from it.
+      // And then we are done, no need to go further back.
+      if (is_full_file(rf))
+      {
+         // would be nice if we could check if stat fails
+         file_size = pgmoneta_get_file_size(rf->filepath);
+         nblocks = file_size / blocksz;
+
+         // no need to check for blocks beyond truncation_block_length
+         // since those blocks should have been truncated away anyway,
+         // we just need to zero fill them later.
+         for (b = 0; b < latest_source->truncation_block_length; b++)
+         {
+            if (source_map[b] == NULL && b < nblocks)
+            {
+               source_map[b] = rf;
+               offset_map[b] = b * blocksz;
+            }
+         }
+
+         // full_copy_possible only remains true when there are no modified blocks in later incremental files,
+         // which means the file has probably never been modified since last full backup.
+         // But it still could've gotten truncated, so check the file size.
+         if (full_copy_possible && file_size == block_length * blocksz)
+         {
+            copy_source = rf;
+         }
+
+         break;
+      }
+      // as for an incremental file, source blocks we don't have yet from it
+      for (int i = 0; i < rf->num_blocks; i++)
+      {
+         b = rf->relative_block_numbers[i];
+         // only the latest source may contain blocks exceeding the latest truncation block length
+         // as for the rest...
+         if (b >= latest_source->truncation_block_length || source_map[b] != NULL)
+         {
+            continue;
+         }
+         source_map[b] = rf;
+         offset_map[b] = rf->header_length + (i * blocksz);
+         full_copy_possible = false;
+      }
+   }
+   // let's skip manifest for now
+   if (copy_source != NULL)
+   {
+      if (pgmoneta_copy_file(copy_source->filepath, output_file_path, NULL))
+      {
+         pgmoneta_log_error("reconstruct: fail to copy file from %s to %s", copy_source->filepath, output_file_path);
+         goto error;
+      }
+   }
+   else
+   {
+      if (write_reconstructed_file(output_file_path, block_length, source_map, offset_map, blocksz))
+      {
+         pgmoneta_log_error("reconstruct: fail to write reconstructed file at %s", output_file_path);
+         goto error;
+      }
+   }
+   pgmoneta_deque_destroy(sources);
+   pgmoneta_deque_iterator_destroy(bck_iter);
+   free(source_map);
+   free(offset_map);
+   return 0;
+error:
+   pgmoneta_deque_destroy(sources);
+   pgmoneta_deque_iterator_destroy(bck_iter);
+   free(source_map);
+   free(offset_map);
+   return 1;
+}
+
+static uint32_t
+find_reconstructed_block_length(struct rfile* s)
+{
+   uint32_t block_length = 0;
+   if (s == NULL)
+   {
+      return 0;
+   }
+   block_length = s->truncation_block_length;
+   for (int i = 0; i < s->num_blocks; i++)
+   {
+      if (s->relative_block_numbers[i] >= block_length)
+      {
+         block_length = s->relative_block_numbers[i] + 1;
+      }
+   }
+
+   return block_length;
+}
+
+static int
+rfile_create(char* file_path, struct rfile** rfile)
+{
+   struct rfile* rf = NULL;
+   FILE* fp = NULL;
+   fp = fopen(file_path, "r");
+
+   if (fp == NULL)
+   {
+      goto error;
+   }
+   rf = (struct rfile*) malloc(sizeof(struct rfile));
+   memset(rf, 0, sizeof(struct rfile));
+   rf->filepath = pgmoneta_append(NULL, file_path);
+   rf->fp = fp;
+   *rfile = rf;
+   return 0;
+
+error:
+   rfile_destroy(rf);
+   return 1;
+}
+
+static void
+rfile_destroy(struct rfile* rf)
+{
+   if (rf == NULL)
+   {
+      return;
+   }
+   if (rf->fp != NULL)
+   {
+      fclose(rf->fp);
+   }
+   free(rf->filepath);
+   free(rf->relative_block_numbers);
+   free(rf);
+}
+
+static void
+rfile_destroy_cb(uintptr_t data)
+{
+   rfile_destroy((struct rfile*) data);
+}
+
+static int
+incremental_rfile_initialize(int server, char* file_path, struct rfile** rfile)
+{
+   uint32_t magic = 0;
+   int nread = 0;
+   struct rfile* rf = NULL;
+   struct configuration* config;
+   size_t relsegsz = 0;
+   size_t blocksz = 0;
+
+   config = (struct configuration*)shmem;
+
+   relsegsz = config->servers[server].relseg_size;
+   blocksz = config->servers[server].block_size;
+
+   // create rfile after file is opened successfully
+   if (rfile_create(file_path, &rf))
+   {
+      pgmoneta_log_error("rfile initialize: failed to open incremental backup file at %s", file_path);
+      goto error;
+   }
+
+   // read magic number from header
+   nread = fread(&magic, 1, sizeof(uint32_t), rf->fp);
+   if (nread != sizeof(uint32_t))
+   {
+      pgmoneta_log_error("rfile initialize: incomplete file header at %s, cannot read magic number", file_path);
+      goto error;
+   }
+
+   if (magic != INCREMENTAL_MAGIC)
+   {
+      pgmoneta_log_error("rfile initialize: incorrect magic number, getting %X, expecting %X", magic, INCREMENTAL_MAGIC);
+      goto error;
+   }
+
+   // read number of blocks
+   nread = fread(&rf->num_blocks, 1, sizeof(uint32_t), rf->fp);
+   if (nread != sizeof(uint32_t))
+   {
+      pgmoneta_log_error("rfile initialize: incomplete file header at %s, cannot read block count", file_path);
+      goto error;
+   }
+   if (rf->num_blocks > relsegsz)
+   {
+      pgmoneta_log_error("rfile initialize: file has %d blocks which is more than server's segment size", rf->num_blocks);
+      goto error;
+   }
+
+   // read truncation block length
+   nread = fread(&rf->truncation_block_length, 1, sizeof(uint32_t), rf->fp);
+   if (nread != sizeof(uint32_t))
+   {
+      pgmoneta_log_error("rfile initialize: incomplete file header at %s, cannot read truncation block length", file_path);
+      goto error;
+   }
+   if (rf->truncation_block_length > relsegsz)
+   {
+      pgmoneta_log_error("rfile initialize: file has truncation block length of %d which is more than server's segment size", rf->truncation_block_length);
+      goto error;
+   }
+
+   if (rf->num_blocks > 0)
+   {
+      rf->relative_block_numbers = malloc(sizeof(uint32_t) * rf->num_blocks);
+      nread = fread(rf->relative_block_numbers, sizeof(uint32_t), rf->num_blocks, rf->fp);
+      if (nread != rf->num_blocks)
+      {
+         pgmoneta_log_error("rfile initialize: incomplete file header at %s, cannot read relative block numbers", file_path);
+         goto error;
+      }
+   }
+
+   // magic + block num + truncation block length + relative block numbers
+   rf->header_length = sizeof(uint32_t) * (1 + 1 + 1 + rf->num_blocks);
+   // round header length to multiple of block size, since the actual file data are aligned
+   // only needed when the file actually has data
+   if (rf->num_blocks > 0 && rf->header_length % blocksz != 0)
+   {
+      rf->header_length += (blocksz - (rf->header_length % blocksz));
+   }
+
+   *rfile = rf;
+
+   return 0;
+error:
+   // contains fp closing logic
+   rfile_destroy(rf);
+   return 1;
+}
+
+static bool
+is_full_file(struct rfile* rf)
+{
+   if (rf == NULL)
+   {
+      return false;
+   }
+   return rf->header_length == 0;
+}
+
+static int
+read_block(struct rfile* rf, off_t offset, uint32_t blocksz, uint8_t* buffer)
+{
+   int nread = 0;
+   if (fseek(rf->fp, offset, SEEK_SET))
+   {
+      pgmoneta_log_error("unable to locate file pointer to offset %llu in file %s", offset, rf->filepath);
+      goto error;
+   }
+
+   nread = fread(buffer, 1, blocksz, rf->fp);
+   if (nread != blocksz)
+   {
+      pgmoneta_log_error("unable to read block at offset %llu from file %s", offset, rf->filepath);
+      goto error;
+   }
+
+   return 0;
+error:
+   return 1;
+}
+
+static int
+write_reconstructed_file(char* output_file_path,
+                         uint32_t block_length,
+                         struct rfile** source_map,
+                         off_t* offset_map,
+                         uint32_t blocksz)
+{
+   FILE* wfp = NULL;
+   uint8_t buffer[blocksz];
+   struct rfile* s = NULL;
+
+   wfp = fopen(output_file_path, "wb+");
+   if (wfp == NULL)
+   {
+      pgmoneta_log_error("reconstruct: unable to open file for reconstruction at %s", output_file_path);
+      goto error;
+   }
+   for (int i = 0; i < block_length; i++)
+   {
+      memset(buffer, 0, blocksz);
+      s = source_map[i];
+      if (s == NULL)
+      {
+         // zero fill the block since source doesn't exist
+         memset(buffer, 0, blocksz);
+         if (fwrite(buffer, 1, blocksz, wfp) != blocksz)
+         {
+            pgmoneta_log_error("reconstruct: fail to write to file %s", output_file_path);
+            goto error;
+         }
+      }
+      else
+      {
+         // we might be able to use copy_file_range to have faster copy,
+         // but for now let's stay in user space
+         if (read_block(s, offset_map[i], blocksz, buffer))
+         {
+            goto error;
+         }
+         if (fwrite(buffer, 1, blocksz, wfp) != blocksz)
+         {
+            pgmoneta_log_error("reconstruct: fail to write to file %s", output_file_path);
+            goto error;
+         }
+      }
+   }
+   if (wfp != NULL)
+   {
+      fclose(wfp);
+   }
+   return 0;
+error:
+   if (wfp != NULL)
+   {
+      fclose(wfp);
+   }
+   return 1;
+}
+
+static int
+write_backup_label(char* from_dir, char* to_dir)
+{
+   char from_path[MAX_PATH];
+   char to_path[MAX_PATH];
+   char row[MISC_LENGTH];
+   FILE* from = NULL;
+   FILE* to = NULL;
+
+   memset(from_path, 0, MAX_PATH);
+   memset(to_path, 0, MAX_PATH);
+   memset(row, 0, MISC_LENGTH);
+
+   snprintf(from_path, MAX_PATH, "%s/backup_label", from_dir);
+   snprintf(to_path, MAX_PATH, "%s/backup_label", to_dir);
+
+   from = fopen(from_path, "r");
+   to = fopen(to_path, "w");
+
+   if (from == NULL)
+   {
+      pgmoneta_log_error("Write backup label, could not open %s", from_path);
+      goto error;
+   }
+
+   if (to == NULL)
+   {
+      pgmoneta_log_error("Write backup label, could not open %s", to_path);
+      goto error;
+   }
+
+   while (fgets(row, MISC_LENGTH, from) != NULL)
+   {
+      if (!pgmoneta_starts_with(row, "INCREMENTAL FROM LSN: ") &&
+          !pgmoneta_starts_with(row, "INCREMENTAL FROM TLI: "))
+      {
+         if (fputs(row, to) == EOF)
+         {
+            pgmoneta_log_error("Write backup label, could not write to file %s", to_path);
+            goto error;
+         }
+      }
+      memset(row, 0, MISC_LENGTH);
+   }
+
+   fclose(from);
+   fclose(to);
+   return 0;
+error:
+   if (from != NULL)
+   {
+      fclose(from);
+   }
+   if (to != NULL)
+   {
+      fclose(to);
+   }
+   return 1;
+}
+
+static uint32_t
+parse_oid(char* name)
+{
+   uint64_t oid = 0;
+   char* ep = NULL; //pointer to the ending char
+   errno = 0;
+   if (name == NULL)
+   {
+      goto error;
+   }
+   oid = strtoul(name, &ep, 10);
+   // check for overflow or premature return from parsing
+   if (errno != 0 || *ep != '\0' || oid == 0 || oid > UINT32_MAX)
+   {
+      pgmoneta_log_error("Unable to parse oid %s", name);
+      goto error;
+   }
+   return oid;
+error:
+   errno = 0;
+   return 0;
+}
+
+static void
+clear_manifest_incremental_entries(struct json* manifest)
+{
+   struct json* files = NULL;
+   struct json* f = NULL;
+   char* path = NULL;
+   struct json_iterator* iter = NULL;
+   struct deque_iterator* diter = NULL;
+   if (manifest == NULL)
+   {
+      return;
+   }
+   files = (struct json*)pgmoneta_json_get(files, MANIFEST_FILES);
+   if (files == NULL)
+   {
+      return;
+   }
+   pgmoneta_json_iterator_create(files, &iter);
+   // a tiny hack to get the internal deque iterator of the json iterator
+   diter = (struct deque_iterator*) iter->iter;
+   while (pgmoneta_deque_iterator_next(diter))
+   {
+      f = (struct json*)pgmoneta_value_data(diter->value);
+      path = (char*) pgmoneta_json_get(f, "Path");
+      if (pgmoneta_is_incremental_path(path))
+      {
+         pgmoneta_deque_iterator_remove(diter);
+      }
+   }
+   pgmoneta_json_iterator_destroy(iter);
+}
+
+static int
+get_file_manifest(char* path, char* manifest_path, int algorithm, struct json** file)
+{
+   struct json* f = NULL;
+   size_t size = 0;
+   time_t t;
+   struct tm* tinfo;
+   char now[MISC_LENGTH];
+   char* checksum = NULL;
+
+   *file = NULL;
+   pgmoneta_json_create(&f);
+
+   size = pgmoneta_get_file_size(path);
+
+   time(&t);
+   tinfo = gmtime(&t);
+   memset(now, 0, sizeof(now));
+   strftime(now, sizeof(now), "%Y-%m-%d %H:%M:%S GMT", tinfo);
+
+   if (pgmoneta_create_file_hash(algorithm, path, &checksum))
+   {
+      goto error;
+   }
+
+   switch (algorithm)
+   {
+      case HASH_ALGORITHM_SHA224:
+         pgmoneta_json_put(f, "Checksum-Algorithm", (uintptr_t)"SHA224", ValueString);
+         break;
+      case HASH_ALGORITHM_SHA256:
+         pgmoneta_json_put(f, "Checksum-Algorithm", (uintptr_t)"SHA256", ValueString);
+         break;
+      case HASH_ALGORITHM_SHA384:
+         pgmoneta_json_put(f, "Checksum-Algorithm", (uintptr_t)"SHA384", ValueString);
+         break;
+      case HASH_ALGORITHM_SHA512:
+         pgmoneta_json_put(f, "Checksum-Algorithm", (uintptr_t)"SHA512", ValueString);
+         break;
+      case HASH_ALGORITHM_CRC32C:
+         pgmoneta_json_put(f, "Checksum-Algorithm", (uintptr_t)"CRC32C", ValueString);
+         break;
+      default:
+         pgmoneta_json_put(f, "Checksum-Algorithm", (uintptr_t)"NONE", ValueString);
+         break;
+   }
+   pgmoneta_json_put(f, "Path", (uintptr_t)manifest_path, ValueString);
+   pgmoneta_json_put(f, "Size", size, ValueUInt64);
+   pgmoneta_json_put(f, "Last-Modified", (uintptr_t)now, ValueString);
+   pgmoneta_json_put(f, "Checksum", (uintptr_t)checksum, ValueString);
+   *file = f;
+
+   free(checksum);
+   return 0;
+
+error:
+   free(checksum);
+   pgmoneta_json_destroy(f);
+   return 1;
 }

--- a/src/libpgmoneta/retention.c
+++ b/src/libpgmoneta/retention.c
@@ -50,7 +50,7 @@ pgmoneta_retention(char** argv)
    if (atomic_load(&config->active_restores) == 0 &&
        atomic_load(&config->active_archives) == 0)
    {
-      workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_RETENTION, NULL);
+      workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_RETENTION, 0, NULL);
 
       pgmoneta_deque_create(false, &nodes);
 

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -3114,6 +3114,10 @@ error:
 bool
 pgmoneta_starts_with(char* str, char* prefix)
 {
+   if (str == NULL)
+   {
+      return false;
+   }
    return strncmp(prefix, str, strlen(prefix)) == 0;
 }
 
@@ -4374,6 +4378,30 @@ pgmoneta_lsn_to_string(uint64_t lsn)
    memset(result, 0, 64);
    snprintf(result, 64, "%X/%X", (uint32_t)(lsn >> 32), (uint32_t)lsn);
    return result;
+}
+
+bool
+pgmoneta_is_incremental_path(char* path)
+{
+   char* name;
+   int len = 0;
+   int seglen = 0;
+   if (path == NULL)
+   {
+      return false;
+   }
+   len = strlen(path);
+   // extract the last segment
+   for (int i = len - 1; i >= 0; i--)
+   {
+      if (path[i] == '/')
+      {
+         break;
+      }
+      seglen++;
+   }
+   name = path + (len - seglen);
+   return pgmoneta_starts_with(name, INCREMENTAL_PREFIX);
 }
 
 #ifdef DEBUG

--- a/src/libpgmoneta/verify.c
+++ b/src/libpgmoneta/verify.c
@@ -105,7 +105,7 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
       goto error;
    }
 
-   workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_VERIFY, backup);
+   workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_VERIFY, server, backup);
 
    current = workflow;
    while (current != NULL)

--- a/src/libpgmoneta/wf_cleanup.c
+++ b/src/libpgmoneta/wf_cleanup.c
@@ -89,8 +89,6 @@ cleanup_execute_restore(int server, char* identifier, struct deque* nodes)
 
    config = (struct configuration*)shmem;
 
-   pgmoneta_log_trace("Cleanup (execute): %s/%s", config->servers[server].name, identifier);
-
    label = (char*)pgmoneta_deque_get(nodes, NODE_LABEL);
 
    pgmoneta_log_debug("Cleanup (execute): %s/%s", config->servers[server].name, label);

--- a/src/libpgmoneta/wf_retention.c
+++ b/src/libpgmoneta/wf_retention.c
@@ -91,6 +91,7 @@ retention_execute(int server, char* identifier, struct deque* nodes)
    char* d;
    int number_of_backups = 0;
    struct backup** backups = NULL;
+   struct backup* child = NULL;
    bool* retention_keep = NULL;
    struct configuration* config;
 
@@ -142,7 +143,9 @@ retention_execute(int server, char* identifier, struct deque* nodes)
          {
             if (!retention_keep[j])
             {
-               if (!backups[j]->keep)
+               pgmoneta_get_backup_child(server, backups[j], &child);
+               // a backup can only be deleted if it has no child
+               if (!backups[j]->keep && child == NULL)
                {
                   pgmoneta_log_trace("Retention: %s/%s (%s)", config->servers[i].name, backups[j]->label, atomic_load(&config->servers[i].delete) ? "Active" : "Inactive");
 
@@ -153,6 +156,8 @@ retention_execute(int server, char* identifier, struct deque* nodes)
                      break;
                   }
                }
+               free(child);
+               child = NULL;
             }
          }
       }


### PR DESCRIPTION
This is the base of incremental backup support for Postgres17. It has full support for incremental backup and reconstruction, that works on both the base directory and tablespaces. 

Hotstandby will be temporarily disabled for incremental backups. Retention and deletion will only delete backups without a child for now. And retain will only keep full backup. These will be supported for incremental backups in later commits.