### PR TITLE
admin: support password through environment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Ashutosh Sharma <ash2003sharma@gmail.com>
 Mario Rodas
 Annupamaa <annu242005@gmail.com>
 Mohab Yaser <mohabyaserofficial2003@gmail.com>
+Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -240,13 +240,17 @@ In order to set the master key for all users you can use
 pgmoneta-admin -g master-key
 ```
 
-The master key must be at least 8 characters.
+The master key must be at least 8 characters if provided interactively.
+
+For scripted use, the master key can be provided using the `PGMONETA_PASSWORD` environment variable.
 
 Then use the other commands to add, update, remove or list the current user names, f.ex.
 
 ```
 pgmoneta-admin -f pgmoneta_users.conf user add
 ```
+
+For scripted use, the user password can be provided using the `PGMONETA_PASSWORD` environment variable.
 
 ## Next Steps
 

--- a/doc/man/pgmoneta-admin.1.rst
+++ b/doc/man/pgmoneta-admin.1.rst
@@ -60,6 +60,15 @@ user del
 user ls
   List all users
 
+ENVIRONMENT VARIABLES
+=====================
+
+PGMONETA_PASSWORD
+  Provide either a key for use with the `master-key` command, or a user password for use with the `user add` or `user edit` commands.
+  If provided, `pgmoneta-admin` will not ask for the key/password interactively.
+  Note that a password provided using the `--password` command line argument will have precedence over this variable.
+
+
 REPORTING BUGS
 ==============
 

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -31,6 +31,7 @@ Mario Rodas
 Annupamaa <annu242005@gmail.com>
 Ashutosh Sharma <ash2003sharma@gmail.com>
 Mohab Yaser <mohabyaserofficial2003@gmail.com>
+Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
 ```
 
 ## Committers

--- a/doc/manual/advanced/03-installation.md
+++ b/doc/manual/advanced/03-installation.md
@@ -157,6 +157,10 @@ First, we will need to create a master security key for the [**pgmoneta**][pgmon
 pgmoneta-admin -g master-key
 ```
 
+By default, this will ask for a key interactively. Alternatively, a key can be provided using either the
+`--password` command line argument, or the `PGMONETA_PASSWORD` environment variable. Note that passing the
+key using the command line might not be secure.
+
 Then we will create the configuration for [**pgmoneta**][pgmoneta],
 
 ```

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -31,6 +31,7 @@ Mario Rodas
 Annupamaa <annu242005@gmail.com>
 Ashutosh Sharma <ash2003sharma@gmail.com>
 Mohab Yaser <mohabyaserofficial2003@gmail.com>
+Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>
 ```
 
 ## Committers

--- a/doc/manual/user-01-quickstart.md
+++ b/doc/manual/user-01-quickstart.md
@@ -94,6 +94,8 @@ pgmoneta-admin master-key
 pgmoneta-admin -f pgmoneta_users.conf user add
 ```
 
+For scripted use, the master key and user password can be provided using the `PGMONETA_PASSWORD` environment variable.
+
 We are now ready to run [**pgmoneta**][pgmoneta].
 
 See the **Configuration** charpter for all configuration options.

--- a/doc/tutorial/01_install.md
+++ b/doc/tutorial/01_install.md
@@ -154,9 +154,12 @@ Add the master key and create vault
 
 ```
 pgmoneta-admin master-key
-pgmoneta-admin -f pgmoneta_users.conf -U repl -P secretpassword user add
+pgmoneta-admin -f pgmoneta_users.conf -U repl user add
 ```
+
 You have to choose a password for the master key - remember it !
+
+For scripted use, the master key and user password can be provided using the `PGMONETA_PASSWORD` environment variable.
 
 If you see an error saying `error while loading shared libraries: libpgmoneta.so.0: cannot open shared object` running 
 the above command. you may need to locate where your `libpgmoneta.so.0` is. It could be in `/usr/local/lib` or `/usr/local/lib64`

--- a/src/admin.c
+++ b/src/admin.c
@@ -396,25 +396,34 @@ master_key(char* password, bool generate_pwd, int pwd_length, int32_t output_for
 
    if (password == NULL)
    {
-      if (!generate_pwd)
-      {
-         while (!is_valid_key(password))
-         {
-            if (password != NULL)
-            {
-               free(password);
-               password = NULL;
-            }
-
-            printf("Master key: ");
-            password = pgmoneta_get_password();
-            printf("\n");
-         }
-      }
-      else
+      if (generate_pwd)
       {
          password = generate_password(pwd_length);
          do_free = false;
+      }
+      else
+      {
+         password = secure_getenv("PGMONETA_PASSWORD");
+
+         if (password == NULL)
+         {
+            while (!is_valid_key(password))
+            {
+               if (password != NULL)
+               {
+                  free(password);
+                  password = NULL;
+               }
+
+               printf("Master key: ");
+               password = pgmoneta_get_password();
+               printf("\n");
+            }
+         }
+         else
+         {
+            do_free = false;
+         }
       }
    }
    else
@@ -623,15 +632,25 @@ password:
       }
       else
       {
-         printf("Password : ");
+         password = secure_getenv("PGMONETA_PASSWORD");
 
-         if (password != NULL)
+         if (password == NULL)
          {
-            free(password);
-            password = NULL;
-         }
+            printf("Password : ");
 
-         password = pgmoneta_get_password();
+            if (password != NULL)
+            {
+               free(password);
+               password = NULL;
+            }
+
+            password = pgmoneta_get_password();
+         }
+         else
+         {
+            do_free = false;
+            do_verify = false;
+         }
       }
       printf("\n");
    }
@@ -848,15 +867,25 @@ password:
             }
             else
             {
-               printf("Password : ");
+               password = secure_getenv("PGMONETA_PASSWORD");
 
-               if (password != NULL)
+               if (password == NULL)
                {
-                  free(password);
-                  password = NULL;
-               }
+                  printf("Password : ");
 
-               password = pgmoneta_get_password();
+                  if (password != NULL)
+                  {
+                     free(password);
+                     password = NULL;
+                  }
+
+                  password = pgmoneta_get_password();
+               }
+               else
+               {
+                  do_free = false;
+                  do_verify = false;
+               }
             }
             printf("\n");
          }


### PR DESCRIPTION
Passing the password through the "--password" command line argument is potentially insecure, as the value would be exposed in a process listing or shell history. Read an environment variable as an alternative.