### PR TITLE
[#415] Implemented the translation and filtering

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -138,3 +138,24 @@ The configuration is loaded from either the path specified by the `-A` flag or `
 If pgmoneta has both Transport Layer Security (TLS) and `management` enabled then `pgmoneta-cli` can
 connect with TLS using the files `~/.pgmoneta/pgmoneta.key` (must be 0600 permission),
 `~/.pgmoneta/pgmoneta.crt` and `~/.pgmoneta/root.crt`.
+
+# pgmoneta_walinfo configuration
+The `pgmoneta_walinfo` configuration defines the info needed for `walinfo` to work.
+
+The configuration is loaded from either the path specified by the `-c` flag or `/etc/pgmoneta/pgmoneta_walinfo.conf` if -c wasn't provided.
+
+## [pgmoneta_walinfo]
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| log_type | console | String | No | The logging type (console, file, syslog) |
+| log_level | info | String | No | The logging level, any of the (case insensitive) strings `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG` (that can be more specific as `DEBUG1` thru `DEBUG5`). Debug level greater than 5 will be set to `DEBUG5`. Not recognized values will make the log_level be `INFO` |
+| log_path | pgmoneta.log | String | No | The log file location. Can be a strftime(3) compatible string. |
+
+## Server section
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| host | | String | Yes | The address of the PostgreSQL instance |
+| port | | Int | Yes | The port of the PostgreSQL instance |
+| user | | String | Yes | The replication user name |

--- a/doc/WALINFO.md
+++ b/doc/WALINFO.md
@@ -1,0 +1,20 @@
+# pgmoneta_walinfo configuration
+The `pgmoneta_walinfo` configuration defines the info needed for `walinfo` to work.
+
+The configuration is loaded from either the path specified by the `-c` flag or `/etc/pgmoneta/pgmoneta_walinfo.conf` if -c wasn't provided.
+
+## [pgmoneta_walinfo]
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| log_type | console | String | No | The logging type (console, file, syslog) |
+| log_level | info | String | No | The logging level, any of the (case insensitive) strings `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG` (that can be more specific as `DEBUG1` thru `DEBUG5`). Debug level greater than 5 will be set to `DEBUG5`. Not recognized values will make the log_level be `INFO` |
+| log_path | pgmoneta.log | String | No | The log file location. Can be a strftime(3) compatible string. |
+
+## Server section
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| host | | String | Yes | The address of the PostgreSQL instance |
+| port | | Int | Yes | The port of the PostgreSQL instance |
+| user | | String | Yes | The replication user name |

--- a/doc/etc/pgmoneta_walinfo.conf
+++ b/doc/etc/pgmoneta_walinfo.conf
@@ -1,0 +1,9 @@
+[pgmoneta-walinfo]
+log_type = file
+log_level = debug5
+log_path = /tmp/pgmoneta.log
+
+[primary]
+host = localhost
+port = 5432
+user = repl

--- a/doc/man/pgmoneta-walinfo.1.rst
+++ b/doc/man/pgmoneta-walinfo.1.rst
@@ -24,6 +24,9 @@ OPTIONS
 -c, --config CONFIG_FILE
   Set the path to the pgmoneta.conf file
 
+-u, --users USERS_FILE
+  Set the path to the pgmoneta_users.conf file
+
 -o, --output FILE
   Output file
 
@@ -45,6 +48,24 @@ OPTIONS
 -V, --version
   Display version information
 
+-t, --translate
+  Translate the OIDs in the XLOG records to the corresponding object (database/tablespace/relation) names
+
+-m, --mapping
+  The JSON file that contains the mapping of the OIDs to the corresponding object names
+
+-RT, --tablespaces  
+  Filter on tablspaces
+
+-RD, --databases    
+  Filter on databases
+
+-RT, --relations    
+  Filter on relations
+
+-R,   --filter      
+  Combination of -RT, -RD, -RR
+
 -?, --help
   Display help and usage information.
 
@@ -64,6 +85,12 @@ To display information about a WAL file in raw format:
 To display information in JSON format:
 
     pgmoneta-walinfo -F json /path/to/walfile
+  
+To display information and translate the OIDs to the corresponding object names:
+
+    pgmoneta-walinfo -c pgmoneta_walinfo.conf -t -m /path/to/mapping.json /path/to/walfile
+    or
+    pgmoneta-walinfo -c pgmoneta_walinfo.conf -t -u /path/to/pgmoneta_users.conf /path/to/walfile
 
 REPORTING BUGS
 ==============

--- a/doc/manual/user-02-configuration.md
+++ b/doc/manual/user-02-configuration.md
@@ -133,3 +133,24 @@ The `pgmoneta_admins` configuration defines the administrators known to the syst
 The configuration is loaded from either the path specified by the `-A` flag or `/etc/pgmoneta/pgmoneta_admins.conf`.
 
 If pgmoneta has both Transport Layer Security (TLS) and `management` enabled then `pgmoneta-cli` can connect with TLS using the files `~/.pgmoneta/pgmoneta.key` (must be 0600 permission), `~/.pgmoneta/pgmoneta.crt` and `~/.pgmoneta/root.crt`.
+
+# pgmoneta_walinfo configuration
+The `pgmoneta_walinfo` configuration defines the info needed for `walinfo` to work.
+
+The configuration is loaded from either the path specified by the `-c` flag or `/etc/pgmoneta/pgmoneta_walinfo.conf` if -c wasn't provided.
+
+## [pgmoneta_walinfo]
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| log_type | console | String | No | The logging type (console, file, syslog) |
+| log_level | info | String | No | The logging level, any of the (case insensitive) strings `FATAL`, `ERROR`, `WARN`, `INFO` and `DEBUG` (that can be more specific as `DEBUG1` thru `DEBUG5`). Debug level greater than 5 will be set to `DEBUG5`. Not recognized values will make the log_level be `INFO` |
+| log_path | pgmoneta.log | String | No | The log file location. Can be a strftime(3) compatible string. |
+
+## Server section
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| host | | String | Yes | The address of the PostgreSQL instance |
+| port | | Int | Yes | The port of the PostgreSQL instance |
+| user | | String | Yes | The replication user name |

--- a/src/cli.c
+++ b/src/cli.c
@@ -698,6 +698,7 @@ main(int argc, char** argv)
          config = (struct main_configuration*)shmem;
       }
    }
+
    if (!parse_command(argc, argv, optind, &parsed, command_table, command_count))
    {
       if (argc > optind)

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -37,8 +37,9 @@ extern "C" {
 
 #include <stdlib.h>
 
-/* The path of pgmoneta's main configuration file */
-#define PGMONETA_MAIN_CONFIG_FILE_PATH                "/etc/pgmoneta/pgmoneta.conf"
+#define PGMONETA_DEFAULT_CONFIG_FILE_PATH          "/etc/pgmoneta/pgmoneta.conf"
+#define PGMONETA_WALINFO_DEFAULT_CONFIG_FILE_PATH  "/etc/pgmoneta/pgmoneta_walinfo.conf"
+#define PGMONETA_DEFAULT_USERS_FILE_PATH           "/etc/pgmoneta/pgmoneta_users.conf"
 
 /* Main configuration fields */
 #define CONFIGURATION_ARGUMENT_HOST                   "host"
@@ -105,6 +106,9 @@ extern "C" {
 #define CONFIGURATION_ARGUMENT_USER_CONF_PATH          "users_configuration_path"
 #define CONFIGURATION_ARGUMENT_ADMIN_CONF_PATH         "admin_configuration_path"
 
+#define CONFIGURATION_TYPE_MAIN 0
+#define CONFIGURATION_TYPE_WALINFO 1
+
 /**
  * Initialize the configuration structure
  * @param shmem The shared memory segment
@@ -129,6 +133,31 @@ pgmoneta_read_main_configuration(void* shmem, char* filename);
  */
 int
 pgmoneta_validate_main_configuration(void* shmem);
+
+/**
+ * Initialize the WALINFO configuration structure
+ * @param shmem The shared memory segment
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_init_walinfo_configuration(void* shmem);
+
+/**
+ * Read the WALINFO configuration from a file
+ * @param shmem The shared memory segment
+ * @param filename The file name
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_read_walinfo_configuration(void* shmem, char* filename);
+
+/**
+ * Validate the WALINFO configuration
+ * @param shmem The shared memory segment
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_validate_walinfo_configuration(void* shmem);
 
 /**
  * Read the USERS configuration from a file

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -317,13 +317,23 @@ struct common_configuration
    char log_line_prefix[MISC_LENGTH];              /**< The logging prefix */
    atomic_schar log_lock;                          /**< The logging lock */
 
+   struct server servers[NUMBER_OF_SERVERS];       /**< The servers */
+   struct user users[NUMBER_OF_USERS];             /**< The users */
+   struct user admins[NUMBER_OF_ADMINS];           /**< The admins */
+
    int number_of_servers;                          /**< The number of servers */
    int number_of_users;                            /**< The number of users */
    int number_of_admins;                           /**< The number of admins */
 
-   struct server servers[NUMBER_OF_SERVERS];       /**< The servers */
-   struct user users[NUMBER_OF_USERS];             /**< The users */
-   struct user admins[NUMBER_OF_ADMINS];           /**< The admins */
+   char configuration_path[MAX_PATH];              /**< The configuration path */
+   char users_path[MAX_PATH];                      /**< The users path */
+   char admins_path[MAX_PATH];                     /**< The admins path */
+
+   bool keep_alive;                                /**< Use keep alive */
+   bool nodelay;                                   /**< Use NODELAY */
+   bool non_blocking;                              /**< Use non blocking */
+
+   struct prometheus prometheus;                   /**< The Prometheus metrics */
 } __attribute__ ((aligned (64)));
 
 /** @struct main_configuration
@@ -331,87 +341,78 @@ struct common_configuration
  */
 struct main_configuration
 {
-   struct common_configuration common; /**< Common configurations that are shared across multiple tools */
+   struct common_configuration common;          /**< Common configurations that are shared across multiple tools */
 
-   bool running; /**< Is pgmoneta running */
+   bool running;                                /**< Is pgmoneta running */
 
-   char configuration_path[MAX_PATH]; /**< The configuration path */
-   char users_path[MAX_PATH];         /**< The users path */
-   char admins_path[MAX_PATH];        /**< The admins path */
+   char host[MISC_LENGTH];                      /**< The host */
+   int metrics;                                 /**< The metrics port */
+   int metrics_cache_max_age;                   /**< Number of seconds to cache the Prometheus response */
+   int metrics_cache_max_size;                  /**< Number of bytes max to cache the Prometheus response */
+   int management;                              /**< The management port */
 
-   char host[MISC_LENGTH];     /**< The host */
-   int metrics;                /**< The metrics port */
-   int metrics_cache_max_age;  /**< Number of seconds to cache the Prometheus response */
-   int metrics_cache_max_size; /**< Number of bytes max to cache the Prometheus response */
-   int management;             /**< The management port */
+   char base_dir[MAX_PATH];                     /**< The base directory */
 
-   char base_dir[MAX_PATH];  /**< The base directory */
+   int compression_type;                        /**< The compression type */
+   int compression_level;                       /**< The compression level */
 
-   int compression_type;  /**< The compression type */
-   int compression_level; /**< The compression level */
+   int create_slot;                             /**< Create a slot */
 
-   int create_slot;                    /**< Create a slot */
+   int storage_engine;                          /**< The storage engine */
 
-   int storage_engine;  /**< The storage engine */
+   int encryption;                              /**< The AES encryption mode */
 
-   int encryption; /**< The AES encryption mode */
+   char ssh_hostname[MISC_LENGTH];              /**< The SSH hostname */
+   char ssh_username[MISC_LENGTH];              /**< The SSH username */
+   char ssh_base_dir[MAX_PATH];                 /**< The SSH base directory */
+   char ssh_ciphers[MISC_LENGTH];               /**< The SSH supported ciphers */
 
-   char ssh_hostname[MISC_LENGTH]; /**< The SSH hostname */
-   char ssh_username[MISC_LENGTH]; /**< The SSH username */
-   char ssh_base_dir[MAX_PATH];    /**< The SSH base directory */
-   char ssh_ciphers[MISC_LENGTH];  /**< The SSH supported ciphers */
+   char s3_aws_region[MISC_LENGTH];             /**< The AWS region */
+   char s3_access_key_id[MISC_LENGTH];          /**< The IAM Access Key ID */
+   char s3_secret_access_key[MISC_LENGTH];      /**< The IAM Secret Access Key */
+   char s3_bucket[MISC_LENGTH];                 /**< The S3 bucket */
+   char s3_base_dir[MAX_PATH];                  /**< The S3 base directory */
 
-   char s3_aws_region[MISC_LENGTH];         /**< The AWS region */
-   char s3_access_key_id[MISC_LENGTH];      /**< The IAM Access Key ID */
-   char s3_secret_access_key[MISC_LENGTH];  /**< The IAM Secret Access Key */
-   char s3_bucket[MISC_LENGTH];          /**< The S3 bucket */
-   char s3_base_dir[MAX_PATH];           /**< The S3 base directory */
+   char azure_storage_account[MISC_LENGTH];     /**< The Azure storage account name */
+   char azure_container[MISC_LENGTH];           /**< The Azure container name */
+   char azure_shared_key[MISC_LENGTH];          /**< The Azure storage account key */
+   char azure_base_dir[MAX_PATH];               /**< The Azure base directory */
 
-   char azure_storage_account[MISC_LENGTH];    /**< The Azure storage account name */
-   char azure_container[MISC_LENGTH];          /**< The Azure container name */
-   char azure_shared_key[MISC_LENGTH];         /**< The Azure storage account key */
-   char azure_base_dir[MAX_PATH];              /**< The Azure base directory */
+   int retention_days;                          /**< The retention days for the server */
+   int retention_weeks;                         /**< The retention weeks for the server */
+   int retention_months;                        /**< The retention months for the server */
+   int retention_years;                         /**< The retention years for the server */
+   int retention_interval;                      /**< The retention interval */
 
-   int retention_days;                  /**< The retention days for the server */
-   int retention_weeks;                 /**< The retention weeks for the server */
-   int retention_months;                /**< The retention months for the server */
-   int retention_years;                 /**< The retention years for the server */
-   int retention_interval;              /**< The retention interval */
+   char workspace[MAX_PATH];                    /**< A workspace for combining incremental backups */
 
-   char workspace[MAX_PATH]; /**< A workspace for combining incremental backups */
+   bool tls;                                    /**< Is TLS enabled */
+   char tls_cert_file[MISC_LENGTH];             /**< TLS certificate path */
+   char tls_key_file[MISC_LENGTH];              /**< TLS key path */
+   char tls_ca_file[MISC_LENGTH];               /**< TLS CA certificate path */
 
-   bool tls;                        /**< Is TLS enabled */
-   char tls_cert_file[MISC_LENGTH]; /**< TLS certificate path */
-   char tls_key_file[MISC_LENGTH];  /**< TLS key path */
-   char tls_ca_file[MISC_LENGTH];   /**< TLS CA certificate path */
+   int blocking_timeout;                        /**< The blocking timeout in seconds */
+   int authentication_timeout;                  /**< The authentication timeout in seconds */
+   char pidfile[MAX_PATH];                      /**< File containing the PID */
 
-   int blocking_timeout;       /**< The blocking timeout in seconds */
-   int authentication_timeout; /**< The authentication timeout in seconds */
-   char pidfile[MAX_PATH];     /**< File containing the PID */
+   int workers;                                 /**< The number of workers */
 
-   int workers;                /**< The number of workers */
+   unsigned int update_process_title;           /**< Behaviour for updating the process title */
 
-   unsigned int update_process_title;  /**< Behaviour for updating the process title */
+   char libev[MISC_LENGTH];                     /**< Name of libev mode */
+   int backlog;                                 /**< The backlog for listen */
+   unsigned char hugepage;                      /**< Huge page support */
 
-   char libev[MISC_LENGTH]; /**< Name of libev mode */
-   bool keep_alive;         /**< Use keep alive */
-   bool nodelay;            /**< Use NODELAY */
-   bool non_blocking;       /**< Use non blocking */
-   int backlog;             /**< The backlog for listen */
-   unsigned char hugepage;  /**< Huge page support */
+   char unix_socket_dir[MISC_LENGTH];           /**< The directory for the Unix Domain Socket */
 
-   char unix_socket_dir[MISC_LENGTH]; /**< The directory for the Unix Domain Socket */
+   int backup_max_rate;                         /**< Number of tokens added to the bucket with each replenishment for backup. */
+   int network_max_rate;                        /**< Number of bytes of tokens added every one second to limit the netowrk backup rate */
 
-   int backup_max_rate; /**< Number of tokens added to the bucket with each replenishment for backup. */
-   int network_max_rate;    /**< Number of bytes of tokens added every one second to limit the netowrk backup rate */
-
-   int manifest;  /**< The manifest hash algorithm */
+   int manifest;                                /**< The manifest hash algorithm */
 
 #ifdef DEBUG
-   bool link; /**< Do linking */
+   bool link;                                   /**< Do linking */
 #endif
-
-   struct prometheus prometheus;                   /**< The Prometheus metrics */
 } __attribute__ ((aligned (64)));
 
 /** @struct walinfo_configuration
@@ -419,7 +420,7 @@ struct main_configuration
  */
 struct walinfo_configuration
 {
-   struct common_configuration common; /**< Common configurations that are shared across multiple tools */
+   struct common_configuration common;          /**< Common configurations that are shared across multiple tools */
 } __attribute__ ((aligned (64)));
 
 #ifdef __cplusplus

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1321,6 +1321,38 @@ bool
 pgmoneta_is_incremental_path(char* path);
 
 /**
+ * Splits a string into an array of strings separated by a delimeter
+ *
+ * @param string The string to split
+ * @param results The array of strings to store the results
+ * @param count The number of strings the string splitted into
+ * @param delimeter The delimeter to split the string by
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_split(const char* string, char*** results, int* count, char delimiter);
+
+/**
+ * Merges an array of strings into a single string
+ *
+ * @param lists The arrays of strings to merge
+ * @param out_list The resulting merged array
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_merge_string_arrays(char** lists[], char*** out_list);
+
+/**
+ * Checks if string 'a' is a substring of 'b'.
+ *
+ * @param a The substring to search for
+ * @param b The string to search within
+ * @return 1 if found, 0 otherwise
+ */
+int
+pgmoneta_is_substring(char* a, char* b);
+
+/**
  * Generate a backtrace in the log
  * @return 0 if success, otherwise 1
  */

--- a/src/include/wal.h
+++ b/src/include/wal.h
@@ -49,6 +49,26 @@ struct timeline_history
 };
 
 /**
+ * @brief Enum representing types of PostgreSQL objects
+ */
+typedef enum
+{
+   OBJ_TABLESPACE,  /**< Tablespace object */
+   OBJ_DATABASE,    /**< Database object */
+   OBJ_RELATION     /**< Relation (table/view) object */
+} object_type;
+
+/**
+ * @brief Structure representing OID mapping for PostgreSQL objects
+ */
+typedef struct
+{
+   int oid;           /**< Object identifier (OID) */
+   object_type type;  /**< Type of object (tablespace/database/relation) */
+   char* name;        /**< Name of the object (read-only) */
+} oid_mapping;
+
+/**
  * Receive WAL
  * @param srv The server index
  * @param argv The argv
@@ -72,6 +92,110 @@ pgmoneta_get_timeline_history(int srv, uint32_t tli, struct timeline_history** h
  */
 void
 pgmoneta_free_timeline_history(struct timeline_history* history);
+
+/**
+ * @brief Read OID mappings from PostgreSQL server
+ *
+ * Executes SQL queries to retrieve OID mappings for tablespaces, databases,
+ * and relations. Populates global oidMappings array.
+ *
+ * @param server_index Index of the server
+ * @return 0 on success, 1 on failure
+ */
+int
+pgmoneta_read_mappings_from_server(int server_index);
+
+/**
+ * @brief Read OID mappings from JSON file
+ *
+ * @param mappings_path Path to JSON file with format:
+ * ```json
+ * {
+ *    "tablespaces": [
+ *       {"name1": "oid1"},
+ *       {"name2": "oid2"},
+ *        ...
+ *    ],
+ *    "databases": [
+ *       {"name1": "oid1"},
+ *       {"name2": "oid2"},
+ *       ...
+ *    ],
+ *    "relations": [
+ *       {"name1": "oid1"},
+ *       {"name2": "oid2"},
+ *       ...
+ *    ],
+ * }
+ * ```
+ * @endcode
+ * @return 0 on success, 1 on failure
+ */
+int
+pgmoneta_read_mappings_from_json(char* mappings_path);
+
+/**
+ * @brief Get tablespace name by OID
+ * @param oid Tablespace OID to lookup
+ * @param name [out] Tablespace name
+ * @return 0 on success, 1 on failure
+ * @note Name will be tablespace name or provided oid if not found
+ */
+int
+pgmoneta_get_tablespace_name(int oid, char** name);
+
+/**
+ * @brief Get database name by OID
+ * @param oid Database OID to lookup
+ * @param name [out] Database name
+ * @return 0 on success, 1 on failure
+ * @note Name will be database name or provided oid if not found
+ */
+int
+pgmoneta_get_database_name(int oid, char** name);
+
+/**
+ * @brief Get relation name by OID
+ * @param oid Relation OID to lookup
+ * @param name [out] Relation name
+ * @return 0 on success, 1 on failure
+ * @note Name will be relation name (schema-qualified) or provided oid if not found
+ */
+int
+pgmoneta_get_relation_name(int oid, char** name);
+
+/**
+ * @brief Get tablespace OID by name
+ *
+ * @param name Tablespace name to lookup
+ * @param oid [out] Tablespace OID
+ * @return 0 on success, 1 on failure
+ * @note OID will be tablespace OID or provided name if not found
+ */
+int
+pgmoneta_get_tablespace_oid(char* name, char** oid);
+
+/**
+ * @brief Get database OID by name
+ *
+ * @param name Database name to lookup
+ * @param oid [out] Database OID
+ * @return 0 on success, 1 on failure
+ * @note OID will be database OID or provided name if not found
+ */
+int
+pgmoneta_get_database_oid(char* name, char** oid);
+
+/**
+ * @brief Get relation OID by name
+ *
+ * @param name Relation name to lookup
+ * @param oid [out] Relation OID
+ * @return 0 on success, 1 on failure
+ * @note OID will be relation OID or provided name if not found
+ */
+int
+pgmoneta_get_relation_oid(char* name, char** oid);
 
 #ifdef __cplusplus
 }

--- a/src/include/walfile.h
+++ b/src/include/walfile.h
@@ -31,6 +31,7 @@
 
 #include <deque.h>
 #include <walfile/wal_reader.h>
+#include <wal.h>
 
 /* Return Codes */
 #define PGMONETA_WAL_SUCCESS      0   /**< WAL operation succeeded */
@@ -131,11 +132,12 @@ pgmoneta_destroy_walfile(struct walfile* wf);
  * @param end_lsn The end LSN
  * @param xids The XIDs
  * @param limit The limit
+ * @param included_objects The objects to include the wal records for, if NULL, all objects are included
  * @return 0 upon success, otherwise 1
  */
 int
 pgmoneta_describe_walfile(char* path, enum value_type type, char* output, bool quiet, bool color,
                           struct deque* rms, uint64_t start_lsn, uint64_t end_lsn, struct deque* xids,
-                          uint32_t limit);
+                          uint32_t limit, char** included_objects);
 
 #endif //PGMONETA_WALFILE_H

--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -397,10 +397,11 @@ pgmoneta_wal_array_desc(char* buf, void* array, size_t elem_size, int count);
  * @param end_lsn The end LSN
  * @param xids The XIDs
  * @param limit The limit
+ * @param included_objects Objects that will include wal records that reference them
  */
 void
 pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_value, enum value_type type, FILE* out, bool quiet, bool color,
-                            struct deque* rms, uint64_t start_lsn, uint64_t end_lsn, struct deque* xids, uint32_t limit);
+                            struct deque* rms, uint64_t start_lsn, uint64_t end_lsn, struct deque* xids, uint32_t limit, char** included_objects);
 
 /**
  * Encodes a WAL record into a buffer.

--- a/src/libpgmoneta/network.c
+++ b/src/libpgmoneta/network.c
@@ -27,6 +27,7 @@
  */
 
 /* pgmoneta */
+#include <configuration.h>
 #include <pgmoneta.h>
 #include <logging.h>
 #include <network.h>
@@ -223,9 +224,6 @@ pgmoneta_remove_unix_socket(char* directory, char* file)
    return 0;
 }
 
-/**
- *
- */
 int
 pgmoneta_connect(char* hostname, int port, int* fd)
 {
@@ -273,7 +271,7 @@ pgmoneta_connect(char* hostname, int port, int* fd)
 
       if (*fd != -1)
       {
-         if (config != NULL && config->keep_alive)
+         if (config != NULL && config->common.keep_alive)
          {
             if (setsockopt(*fd, SOL_SOCKET, SO_KEEPALIVE, &yes, optlen) == -1)
             {
@@ -285,7 +283,7 @@ pgmoneta_connect(char* hostname, int port, int* fd)
             }
          }
 
-         if (config != NULL && config->nodelay)
+         if (config != NULL && config->common.nodelay)
          {
             if (setsockopt(*fd, IPPROTO_TCP, TCP_NODELAY, &yes, optlen) == -1)
             {
@@ -337,7 +335,7 @@ pgmoneta_connect(char* hostname, int port, int* fd)
    freeaddrinfo(servinfo);
 
    /* Set O_NONBLOCK on the socket */
-   if (config != NULL && config->non_blocking)
+   if (config != NULL && config->common.non_blocking)
    {
       pgmoneta_socket_nonblocking(*fd, true);
    }
@@ -525,7 +523,7 @@ pgmoneta_tcp_nodelay(int fd)
 
    config = (struct main_configuration*)shmem;
 
-   if (config->nodelay)
+   if (config->common.nodelay)
    {
       if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &yes, optlen) == -1)
       {
@@ -636,7 +634,7 @@ bind_host(char* hostname, int port, int** fds, int* length)
          continue;
       }
 
-      if (config->non_blocking)
+      if (config->common.non_blocking)
       {
          if (pgmoneta_socket_nonblocking(sockfd, true))
          {

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <configuration.h>
 #include <info.h>
 #include <logging.h>
 #include <memory.h>
@@ -143,10 +144,10 @@ retry_cache_locking:
    {
       metrics_cache_invalidate();
 
-      atomic_store(&config->prometheus.logging_info, 0);
-      atomic_store(&config->prometheus.logging_warn, 0);
-      atomic_store(&config->prometheus.logging_error, 0);
-      atomic_store(&config->prometheus.logging_fatal, 0);
+      atomic_store(&config->common.prometheus.logging_info, 0);
+      atomic_store(&config->common.prometheus.logging_warn, 0);
+      atomic_store(&config->common.prometheus.logging_error, 0);
+      atomic_store(&config->common.prometheus.logging_fatal, 0);
 
       atomic_store(&cache->lock, STATE_FREE);
    }
@@ -167,16 +168,16 @@ pgmoneta_prometheus_logging(int type)
    switch (type)
    {
       case PGMONETA_LOGGING_LEVEL_INFO:
-         atomic_fetch_add(&config->prometheus.logging_info, 1);
+         atomic_fetch_add(&config->common.prometheus.logging_info, 1);
          break;
       case PGMONETA_LOGGING_LEVEL_WARN:
-         atomic_fetch_add(&config->prometheus.logging_warn, 1);
+         atomic_fetch_add(&config->common.prometheus.logging_warn, 1);
          break;
       case PGMONETA_LOGGING_LEVEL_ERROR:
-         atomic_fetch_add(&config->prometheus.logging_error, 1);
+         atomic_fetch_add(&config->common.prometheus.logging_error, 1);
          break;
       case PGMONETA_LOGGING_LEVEL_FATAL:
-         atomic_fetch_add(&config->prometheus.logging_fatal, 1);
+         atomic_fetch_add(&config->common.prometheus.logging_fatal, 1);
          break;
       default:
          break;
@@ -1389,22 +1390,22 @@ general_information(int client_fd)
    data = pgmoneta_append(data, "#HELP pgmoneta_logging_info The number of INFO logging statements\n");
    data = pgmoneta_append(data, "#TYPE pgmoneta_logging_info gauge\n");
    data = pgmoneta_append(data, "pgmoneta_logging_info ");
-   data = pgmoneta_append_ulong(data, atomic_load(&config->prometheus.logging_info));
+   data = pgmoneta_append_ulong(data, atomic_load(&config->common.prometheus.logging_info));
    data = pgmoneta_append(data, "\n\n");
    data = pgmoneta_append(data, "#HELP pgmoneta_logging_warn The number of WARN logging statements\n");
    data = pgmoneta_append(data, "#TYPE pgmoneta_logging_warn gauge\n");
    data = pgmoneta_append(data, "pgmoneta_logging_warn ");
-   data = pgmoneta_append_ulong(data, atomic_load(&config->prometheus.logging_warn));
+   data = pgmoneta_append_ulong(data, atomic_load(&config->common.prometheus.logging_warn));
    data = pgmoneta_append(data, "\n\n");
    data = pgmoneta_append(data, "#HELP pgmoneta_logging_error The number of ERROR logging statements\n");
    data = pgmoneta_append(data, "#TYPE pgmoneta_logging_error gauge\n");
    data = pgmoneta_append(data, "pgmoneta_logging_error ");
-   data = pgmoneta_append_ulong(data, atomic_load(&config->prometheus.logging_error));
+   data = pgmoneta_append_ulong(data, atomic_load(&config->common.prometheus.logging_error));
    data = pgmoneta_append(data, "\n\n");
    data = pgmoneta_append(data, "#HELP pgmoneta_logging_fatal The number of FATAL logging statements\n");
    data = pgmoneta_append(data, "#TYPE pgmoneta_logging_fatal gauge\n");
    data = pgmoneta_append(data, "pgmoneta_logging_fatal ");
-   data = pgmoneta_append_ulong(data, atomic_load(&config->prometheus.logging_fatal));
+   data = pgmoneta_append_ulong(data, atomic_load(&config->common.prometheus.logging_fatal));
    data = pgmoneta_append(data, "\n\n");
    data = pgmoneta_append(data, "#HELP pgmoneta_retention_days The retention days of pgmoneta\n");
    data = pgmoneta_append(data, "#TYPE pgmoneta_retention_days gauge\n");

--- a/src/libpgmoneta/walfile.c
+++ b/src/libpgmoneta/walfile.c
@@ -124,7 +124,6 @@ error:
    if (new_wf)
    {
       pgmoneta_destroy_walfile(new_wf);
-      free(new_wf);
    }
    return error_code;
 }
@@ -306,7 +305,7 @@ pgmoneta_destroy_walfile(struct walfile* wf)
 int
 pgmoneta_describe_walfile(char* path, enum value_type type, char* output, bool quiet, bool color,
                           struct deque* rms, uint64_t start_lsn, uint64_t end_lsn, struct deque* xids,
-                          uint32_t limit)
+                          uint32_t limit, char** included_objects)
 {
    FILE* out = NULL;
    char* tmp_wal = NULL;
@@ -415,7 +414,7 @@ pgmoneta_describe_walfile(char* path, enum value_type type, char* output, bool q
       {
          record = (struct decoded_xlog_record*) record_iterator->value->data;
          pgmoneta_wal_record_display(record, wf->long_phd->std.xlp_magic, type, out, quiet, color,
-                                     rms, start_lsn, end_lsn, xids, limit);
+                                     rms, start_lsn, end_lsn, xids, limit, included_objects);
       }
 
       if (!quiet)
@@ -429,7 +428,7 @@ pgmoneta_describe_walfile(char* path, enum value_type type, char* output, bool q
       {
          record = (struct decoded_xlog_record*) record_iterator->value->data;
          pgmoneta_wal_record_display(record, wf->long_phd->std.xlp_magic, type, out, quiet, color,
-                                     rms, start_lsn, end_lsn, xids, limit);
+                                     rms, start_lsn, end_lsn, xids, limit, included_objects);
       }
    }
 

--- a/src/libpgmoneta/wf_link.c
+++ b/src/libpgmoneta/wf_link.c
@@ -182,9 +182,9 @@ link_execute(char* name, struct art* nodes)
          }
 
 #ifdef HAVE_FREEBSD
-	 clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+         clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
 #else
-	 clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+         clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
 #endif
 
          linking_elapsed_time = pgmoneta_compute_duration(start_t, end_t);

--- a/src/main.c
+++ b/src/main.c
@@ -290,31 +290,31 @@ main(int argc, char** argv)
       {
          break;
       }
-      else if (strcmp(optname, "c") == 0 || strcmp(optname, "config") == 0)
+      else if (!strcmp(optname, "c") || !strcmp(optname, "config"))
       {
          configuration_path = optarg;
       }
-      else if (strcmp(optname, "u") == 0 || strcmp(optname, "users") == 0)
+      else if (!strcmp(optname, "u") || !strcmp(optname, "users"))
       {
          users_path = optarg;
       }
-      else if (strcmp(optname, "A") == 0 || strcmp(optname, "admins") == 0)
+      else if (!strcmp(optname, "A") || !strcmp(optname, "admins"))
       {
          admins_path = optarg;
       }
-      else if (strcmp(optname, "d") == 0 || strcmp(optname, "daemon") == 0)
+      else if (!strcmp(optname, "d") || !strcmp(optname, "daemon"))
       {
          daemon = true;
       }
-      else if (strcmp(optname, "offline") == 0)
+      else if (!strcmp(optname, "offline"))
       {
          offline = true;
       }
-      else if (strcmp(optname, "V") == 0 || strcmp(optname, "version") == 0)
+      else if (!strcmp(optname, "V") || !strcmp(optname, "version"))
       {
          version();
       }
-      else if (strcmp(optname, "?") == 0 || strcmp(optname, "help") == 0)
+      else if (!strcmp(optname, "?") || !strcmp(optname, "help"))
       {
          usage();
          exit(0);
@@ -366,7 +366,8 @@ main(int argc, char** argv)
       }
       configuration_path = "/etc/pgmoneta/pgmoneta.conf";
    }
-   memcpy(&config->configuration_path[0], configuration_path, MIN(strlen(configuration_path), MAX_PATH - 1));
+
+   memcpy(&config->common.configuration_path[0], configuration_path, MIN(strlen(configuration_path), MAX_PATH - 1));
 
    if (users_path != NULL)
    {
@@ -395,7 +396,7 @@ main(int argc, char** argv)
 #endif
          goto error;
       }
-      memcpy(&config->users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
+      memcpy(&config->common.users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
    }
    else
    {
@@ -403,7 +404,7 @@ main(int argc, char** argv)
       ret = pgmoneta_read_users_configuration(shmem, users_path);
       if (ret == 0)
       {
-         memcpy(&config->users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
+         memcpy(&config->common.users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
       }
    }
 
@@ -434,7 +435,7 @@ main(int argc, char** argv)
 #endif
          goto error;
       }
-      memcpy(&config->admins_path[0], admins_path, MIN(strlen(admins_path), MAX_PATH - 1));
+      memcpy(&config->common.admins_path[0], admins_path, MIN(strlen(admins_path), MAX_PATH - 1));
    }
    else
    {
@@ -442,7 +443,7 @@ main(int argc, char** argv)
       ret = pgmoneta_read_admins_configuration(shmem, admins_path);
       if (ret == 0)
       {
-         memcpy(&config->admins_path[0], admins_path, MIN(strlen(admins_path), MAX_PATH - 1));
+         memcpy(&config->common.admins_path[0], admins_path, MIN(strlen(admins_path), MAX_PATH - 1));
       }
    }
 
@@ -1125,15 +1126,15 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
    else if (id == MANAGEMENT_SHUTDOWN)
    {
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
 #endif
 
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
 #endif
 
       pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload);
@@ -1156,9 +1157,9 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       pgmoneta_management_create_response(payload, -1, &response);
 
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
 #endif
 
       pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload);
@@ -1166,17 +1167,17 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
    else if (id == MANAGEMENT_RESET)
    {
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
 #endif
 
       pgmoneta_prometheus_reset();
 
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
 #endif
 
       pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload);
@@ -1187,9 +1188,9 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       struct json* response = NULL;
 
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
 #endif
 
       restart = reload_configuration();
@@ -1199,9 +1200,9 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_RESTART, (uintptr_t)restart, ValueBool);
 
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
 #endif
 
       pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload);
@@ -1211,21 +1212,21 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       struct json* response = NULL;
 
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
 #endif
 
       pgmoneta_management_create_response(payload, -1, &response);
 
-      pgmoneta_json_put(response, CONFIGURATION_ARGUMENT_MAIN_CONF_PATH, (uintptr_t)config->configuration_path, ValueString);
-      pgmoneta_json_put(response, CONFIGURATION_ARGUMENT_USER_CONF_PATH, (uintptr_t)config->users_path, ValueString);
-      pgmoneta_json_put(response, CONFIGURATION_ARGUMENT_ADMIN_CONF_PATH, (uintptr_t)config->admins_path, ValueString);
+      pgmoneta_json_put(response, CONFIGURATION_ARGUMENT_MAIN_CONF_PATH, (uintptr_t)config->common.configuration_path, ValueString);
+      pgmoneta_json_put(response, CONFIGURATION_ARGUMENT_USER_CONF_PATH, (uintptr_t)config->common.users_path, ValueString);
+      pgmoneta_json_put(response, CONFIGURATION_ARGUMENT_ADMIN_CONF_PATH, (uintptr_t)config->common.admins_path, ValueString);
 
 #ifdef HAVE_FREEBSD
-     clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
 #else
-     clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
 #endif
 
       pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload);

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -26,17 +26,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <pgmoneta.h>
+/* pgmoneta */
 #include <cmd.h>
 #include <configuration.h>
 #include <deque.h>
 #include <logging.h>
+#include <management.h>
+#include <pgmoneta.h>
+#include <security.h>
 #include <shmem.h>
 #include <utils.h>
+#include <wal.h>
 #include <walfile.h>
 
-#include <inttypes.h>
+/* system */
 #include <err.h>
+#include <getopt.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -60,20 +66,27 @@ usage(void)
    printf("  pgmoneta-walinfo <file>\n");
    printf("\n");
    printf("Options:\n");
-   printf("  -c, --config CONFIG_FILE Set the path to the pgmoneta.conf file\n");
-   printf("  -o, --output FILE        Output file\n");
-   printf("  -F, --format             Output format (raw, json)\n");
-   printf("  -L, --logfile FILE       Set the log file\n");
-   printf("  -q, --quiet              No output only result\n");
-   printf("      --color              Use colors (on, off)\n");
-   printf("  -r, --rmgr               Filter on a resource manager\n");
-   printf("  -s, --start              Filter on a start LSN\n");
-   printf("  -e, --end                Filter on an end LSN\n");
-   printf("  -x, --xid                Filter on an XID\n");
-   printf("  -l, --limit              Limit number of outputs\n");
-   printf("  -v, --verbose            Output result\n");
-   printf("  -V, --version            Display version information\n");
-   printf("  -?, --help               Display help\n");
+   printf("  -c,   --config      Set the path to the pgmoneta_walinfo.conf file\n");
+   printf("  -u,   --users       Set the path to the pgmoneta_users.conf file \n");
+   printf("  -RT, --tablespaces  Filter on tablspaces\n");
+   printf("  -RD, --databases    Filter on databases\n");
+   printf("  -RT, --relations    Filter on relations\n");
+   printf("  -R,   --filter      Combination of -RT, -RD, -RR\n");
+   printf("  -o,   --output      Output file\n");
+   printf("  -F,   --format      Output format (raw, json)\n");
+   printf("  -L,   --logfile     Set the log file\n");
+   printf("  -q,   --quiet       No output only result\n");
+   printf("        --color       Use colors (on, off)\n");
+   printf("  -r,   --rmgr        Filter on a resource manager\n");
+   printf("  -s,   --start       Filter on a start LSN\n");
+   printf("  -e,   --end         Filter on an end LSN\n");
+   printf("  -x,   --xid         Filter on an XID\n");
+   printf("  -l,   --limit       Limit number of outputs\n");
+   printf("  -v,   --verbose     Output result\n");
+   printf("  -V,   --version     Display version information\n");
+   printf("  -m,   --mapping     Provide mappings file for OID translation\n");
+   printf("  -t,   --translate   Translate OIDs to object names in XLOG records\n");
+   printf("  -?,   --help        Display help\n");
    printf("\n");
    printf("pgmoneta: %s\n", PGMONETA_HOMEPAGE);
    printf("Report bugs: %s\n", PGMONETA_ISSUES);
@@ -84,6 +97,7 @@ main(int argc, char** argv)
 {
    int loaded = 1;
    char* configuration_path = NULL;
+   char* users_path = NULL;
    char* output = NULL;
    char* format = NULL;
    char* logfile = NULL;
@@ -102,6 +116,23 @@ main(int argc, char** argv)
    enum value_type type = ValueString;
    size_t size;
    struct walinfo_configuration* config = NULL;
+   bool enable_mapping = false;
+   char* mappings_path = NULL;
+   int ret;
+   char* tablespaces = NULL;
+   char* databases = NULL;
+   char* relations = NULL;
+   char* filters = NULL;
+   bool filtering_enabled = false;
+   char** included_objects = NULL;
+   char** databases_list = NULL;
+   char** tablespaces_list = NULL;
+   char** relations_list = NULL;
+   int databases_count = 0;
+   int tablespaces_count = 0;
+   int relations_count = 0;
+   char** temp_list = NULL;
+   int cnt = 0;
    int optind = 0;
    char* filepath;
    int num_results = 0;
@@ -111,6 +142,13 @@ main(int argc, char** argv)
       {"c", "config", true},
       {"o", "output", true},
       {"F", "format", true},
+      {"u", "users", true},
+      {"RT", "tablespaces", true},
+      {"RD", "databases", true},
+      {"RR", "relations", true},
+      {"R", "filter", true},
+      {"m", "mapping", true},
+      {"t", "translate", false},
       {"L", "logfile", true},
       {"q", "quiet", false},
       {"", "color", true},
@@ -150,15 +188,15 @@ main(int argc, char** argv)
       {
          break;
       }
-      else if (strcmp(optname, "c") == 0 || strcmp(optname, "config") == 0)
+      else if (!strcmp(optname, "c") || !strcmp(optname, "config"))
       {
          configuration_path = optarg;
       }
-      else if (strcmp(optname, "o") == 0 || strcmp(optname, "output") == 0)
+      else if (!strcmp(optname, "o") || !strcmp(optname, "output"))
       {
          output = optarg;
       }
-      else if (strcmp(optname, "F") == 0 || strcmp(optname, "format") == 0)
+      else if (!strcmp(optname, "F") || !strcmp(optname, "format"))
       {
          format = optarg;
 
@@ -171,15 +209,15 @@ main(int argc, char** argv)
             type = ValueString;
          }
       }
-      else if (strcmp(optname, "L") == 0 || strcmp(optname, "logfile") == 0)
+      else if (!strcmp(optname, "L") || !strcmp(optname, "logfile"))
       {
          logfile = optarg;
       }
-      else if (strcmp(optname, "q") == 0 || strcmp(optname, "quiet") == 0)
+      else if (!strcmp(optname, "q") || !strcmp(optname, "quiet"))
       {
          quiet = true;
       }
-      else if (strcmp(optname, "color") == 0)
+      else if (!strcmp(optname, "color"))
       {
          if (!strcmp(optarg, "off"))
          {
@@ -190,7 +228,7 @@ main(int argc, char** argv)
             color = true;
          }
       }
-      else if (strcmp(optname, "r") == 0 || strcmp(optname, "rmgr") == 0)
+      else if (!strcmp(optname, "r") || !strcmp(optname, "rmgr"))
       {
          if (rms == NULL)
          {
@@ -202,7 +240,7 @@ main(int argc, char** argv)
 
          pgmoneta_deque_add(rms, NULL, (uintptr_t)optarg, ValueString);
       }
-      else if (strcmp(optname, "s") == 0 || strcmp(optname, "start") == 0)
+      else if (!strcmp(optname, "s") || !strcmp(optname, "start"))
       {
          if (strchr(optarg, '/'))
          {
@@ -222,7 +260,7 @@ main(int argc, char** argv)
             start_lsn = strtoull(optarg, NULL, 10);    // Assuming optarg is a decimal number
          }
       }
-      else if (strcmp(optname, "e") == 0 || strcmp(optname, "end") == 0)
+      else if (!strcmp(optname, "e") || !strcmp(optname, "end"))
       {
          if (strchr(optarg, '/'))
          {
@@ -242,7 +280,7 @@ main(int argc, char** argv)
             end_lsn = strtoull(optarg, NULL, 10);    // Assuming optarg is a decimal number
          }
       }
-      else if (strcmp(optname, "x") == 0 || strcmp(optname, "xid") == 0)
+      else if (!strcmp(optname, "x") || !strcmp(optname, "xid"))
       {
          if (xids == NULL)
          {
@@ -254,20 +292,53 @@ main(int argc, char** argv)
 
          pgmoneta_deque_add(xids, NULL, (uintptr_t)pgmoneta_atoi(optarg), ValueUInt32);
       }
-      else if (strcmp(optname, "l") == 0 || strcmp(optname, "limit") == 0)
+      else if (!strcmp(optname, "l") || !strcmp(optname, "limit"))
       {
          limit = pgmoneta_atoi(optarg);
       }
-      else if (strcmp(optname, "v") == 0 || strcmp(optname, "verbose") == 0)
+      else if (!strcmp(optname, "m") || !strcmp(optname, "mapping"))
+      {
+         enable_mapping = true;
+         mappings_path = optarg;
+      }
+      else if (!strcmp(optname, "t") || !strcmp(optname, "translate"))
+      {
+         enable_mapping = true;
+      }
+      else if (!strcmp(optname, "RT") || !strcmp(optname, "tablespaces"))
+      {
+         tablespaces = optarg;
+         filtering_enabled = true;
+      }
+      else if (!strcmp(optname, "RD") || !strcmp(optname, "databases"))
+      {
+         databases = optarg;
+         filtering_enabled = true;
+      }
+      else if (!strcmp(optname, "RR") || !strcmp(optname, "relations"))
+      {
+         relations = optarg;
+         filtering_enabled = true;
+      }
+      else if (!strcmp(optname, "R") || !strcmp(optname, "filter"))
+      {
+         filters = optarg;
+         filtering_enabled = true;
+      }
+      else if (!strcmp(optname, "u") || !strcmp(optname, "users"))
+      {
+         users_path = optarg;
+      }
+      else if (!strcmp(optname, "v") || !strcmp(optname, "verbose"))
       {
          verbose = true;
       }
-      else if (strcmp(optname, "V") == 0 || strcmp(optname, "version") == 0)
+      else if (!strcmp(optname, "V") || !strcmp(optname, "version"))
       {
          version();
          exit(0);
       }
-      else if (strcmp(optname, "?") == 0 || strcmp(optname, "help") == 0)
+      else if (!strcmp(optname, "?") || !strcmp(optname, "help"))
       {
          usage();
          exit(0);
@@ -281,14 +352,14 @@ main(int argc, char** argv)
       goto error;
    }
 
-   pgmoneta_init_main_configuration(shmem);
+   pgmoneta_init_walinfo_configuration(shmem);
    config = (struct walinfo_configuration*)shmem;
 
    if (configuration_path != NULL)
    {
       if (pgmoneta_exists(configuration_path))
       {
-         loaded = pgmoneta_read_main_configuration(shmem, configuration_path);
+         loaded = pgmoneta_read_walinfo_configuration(shmem, configuration_path);
       }
 
       if (loaded)
@@ -297,9 +368,9 @@ main(int argc, char** argv)
       }
    }
 
-   if (loaded && pgmoneta_exists(PGMONETA_MAIN_CONFIG_FILE_PATH))
+   if (loaded && pgmoneta_exists(PGMONETA_WALINFO_DEFAULT_CONFIG_FILE_PATH))
    {
-      loaded = pgmoneta_read_main_configuration(shmem, PGMONETA_MAIN_CONFIG_FILE_PATH);
+      loaded = pgmoneta_read_walinfo_configuration(shmem, PGMONETA_WALINFO_DEFAULT_CONFIG_FILE_PATH);
    }
 
    if (loaded)
@@ -316,15 +387,205 @@ main(int argc, char** argv)
       }
    }
 
+   if (pgmoneta_validate_walinfo_configuration(shmem))
+   {
+      goto error;
+   }
+
    if (pgmoneta_start_logging())
    {
       exit(1);
    }
 
+   if (users_path != NULL)
+   {
+      ret = pgmoneta_read_users_configuration(shmem, users_path);
+      if (ret == 1)
+      {
+         warnx("pgmoneta: USERS configuration not found: %s", users_path);
+         goto error;
+      }
+      else if (ret == 2)
+      {
+         warnx("pgmoneta: Invalid master key file");
+         goto error;
+      }
+      else if (ret == 3)
+      {
+         warnx("pgmoneta: USERS: Too many users defined %d (max %d)", config->common.number_of_users, NUMBER_OF_USERS);
+         goto error;
+      }
+      memcpy(&config->common.users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
+   }
+   else
+   {
+      users_path = PGMONETA_DEFAULT_USERS_FILE_PATH;
+      ret = pgmoneta_read_users_configuration(shmem, users_path);
+      if (ret == 0)
+      {
+         memcpy(&config->common.users_path[0], users_path, MIN(strlen(users_path), MAX_PATH - 1));
+      }
+   }
+
+   if (enable_mapping)
+   {
+      if (mappings_path != NULL)
+      {
+         if (pgmoneta_read_mappings_from_json(mappings_path) != 0)
+         {
+            pgmoneta_log_error("Failed to read mappings file");
+            goto error;
+         }
+      }
+      else
+      {
+         if (config->common.number_of_servers == 0)
+         {
+            pgmoneta_log_error("No servers defined, user should provide exactly one server in the configuration file");
+            goto error;
+         }
+
+         if (pgmoneta_read_mappings_from_server(0) != 0)
+         {
+            pgmoneta_log_error("Failed to read mappings from server");
+            goto error;
+         }
+      }
+   }
+
+   if (filtering_enabled)
+   {
+      if (enable_mapping)
+      {
+         if (filters != NULL)
+         {
+            if (pgmoneta_split(filters, &temp_list, &cnt, '/'))
+            {
+               pgmoneta_log_error("Failed to parse filters");
+               goto error;
+            }
+            else
+            {
+               if (pgmoneta_split(temp_list[0], &tablespaces_list, &tablespaces_count, ','))
+               {
+                  pgmoneta_log_error("Failed to parse tablespaces to be included");
+                  goto error;
+               }
+
+               if (pgmoneta_split(temp_list[1], &databases_list, &databases_count, ','))
+               {
+                  pgmoneta_log_error("Failed to parse databases to be included");
+                  goto error;
+               }
+
+               if (pgmoneta_split(temp_list[2], &relations_list, &relations_count, ','))
+               {
+                  pgmoneta_log_error("Failed to parse relations to be included");
+                  goto error;
+               }
+
+               if (temp_list)
+               {
+                  for (int i = 0; temp_list[i] != NULL; i++)
+                  {
+                     free(temp_list[i]);
+                  }
+                  free(temp_list);
+               }
+            }
+         }
+
+         if (databases != NULL)
+         {
+            if (pgmoneta_split(databases, &databases_list, &databases_count, ','))
+            {
+               pgmoneta_log_error("Failed to parse databases to be included");
+               goto error;
+            }
+         }
+
+         if (tablespaces != NULL)
+         {
+            if (pgmoneta_split(tablespaces, &tablespaces_list, &tablespaces_count, ','))
+            {
+               pgmoneta_log_error("Failed to parse tablespaces to be included");
+               goto error;
+            }
+         }
+
+         if (relations != NULL)
+         {
+            if (pgmoneta_split(relations, &relations_list, &relations_count, ','))
+            {
+               pgmoneta_log_error("Failed to parse relations to be included");
+               goto error;
+            }
+         }
+
+         char** merged_lists[4] = {0};
+         int idx = 0;
+
+         if (databases_list != NULL)
+         {
+            merged_lists[idx++] = databases_list;
+         }
+
+         if (tablespaces_list != NULL)
+         {
+            merged_lists[idx++] = tablespaces_list;
+         }
+
+         if (relations_list != NULL)
+         {
+            merged_lists[idx++] = relations_list;
+         }
+
+         merged_lists[idx] = NULL;
+
+         if (pgmoneta_merge_string_arrays(merged_lists, &included_objects))
+         {
+            pgmoneta_log_error("Failed to merge include lists");
+            goto error;
+         }
+
+         if (databases_list)
+         {
+            for (int i = 0; i < databases_count; i++)
+            {
+               free(databases_list[i]);
+            }
+            free(databases_list);
+         }
+
+         if (tablespaces_list)
+         {
+            for (int i = 0; i < tablespaces_count; i++)
+            {
+               free(tablespaces_list[i]);
+            }
+            free(tablespaces_list);
+         }
+
+         if (relations_list)
+         {
+            for (int i = 0; i < relations_count; i++)
+            {
+               free(relations_list[i]);
+            }
+            free(relations_list);
+         }
+      }
+      else
+      {
+         pgmoneta_log_error("OID mappings are not loaded, please provide a mappings file or server credentials and enable translation (-t)");
+         goto error;
+      }
+   }
+
    if (filepath != NULL)
    {
       if (pgmoneta_describe_walfile(filepath, type, output, quiet, color,
-                                    rms, start_lsn, end_lsn, xids, limit))
+                                    rms, start_lsn, end_lsn, xids, limit, included_objects))
       {
          fprintf(stderr, "Error while reading/describing WAL file\n");
          goto error;
@@ -336,6 +597,16 @@ main(int argc, char** argv)
       usage();
       goto error;
    }
+
+   if (included_objects)
+   {
+      for (int i = 0; included_objects[i] != NULL; i++)
+      {
+         free(included_objects[i]);
+      }
+      free(included_objects);
+   }
+
    pgmoneta_destroy_shared_memory(shmem, size);
 
    if (logfile)
@@ -370,6 +641,51 @@ error:
    if (verbose)
    {
       printf("Failure\n");
+   }
+
+   if (databases_list)
+   {
+      for (int i = 0; i < databases_count; i++)
+      {
+         free(databases_list[i]);
+      }
+      free(databases_list);
+   }
+
+   if (tablespaces_list)
+   {
+      for (int i = 0; i < tablespaces_count; i++)
+      {
+         free(tablespaces_list[i]);
+      }
+      free(tablespaces_list);
+   }
+
+   if (relations_list)
+   {
+      for (int i = 0; i < relations_count; i++)
+      {
+         free(relations_list[i]);
+      }
+      free(relations_list);
+   }
+
+   if (included_objects)
+   {
+      for (int i = 0; included_objects[i] != NULL; i++)
+      {
+         free(included_objects[i]);
+      }
+      free(included_objects);
+   }
+
+   if (temp_list)
+   {
+      for (int i = 0; temp_list[i] != NULL; i++)
+      {
+         free(temp_list[i]);
+      }
+      free(temp_list);
    }
 
    return 1;

--- a/test/tsclient.c
+++ b/test/tsclient.c
@@ -253,7 +253,7 @@ get_connection()
     struct main_configuration* config;
 
     config = (struct main_configuration*)shmem;
-    if (!strlen(config->configuration_path))
+    if (!strlen(config->common.configuration_path))
     {
         if (pgmoneta_connect_unix_socket(config->unix_socket_dir, MAIN_UDS, &socket))
         {


### PR DESCRIPTION
Resolves #415

Now the user can type his OID mappings in json file and run this command to get the names of relations, databases, or tablespaces in the description of the XLOG records by running this command:
```
pgmoneta-walinfo --translate --mapping mapping.json walfile
```
and if `--mapping` was missing it will use `/etc/pgmoneta/pgmoneta_walinfo_conf.json` by default.