### PR TITLE
[#514] Print line numbers in pgmoneta_backtrace

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Sangkeun J.C. Kim <jchrys@me.com>
 Tejas Tyagi <tejastyagi.tt@gmail.com>
 Aryan Arora <aryanarora.w1@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
+Mingzhuo Yin <yinmingzhuo@gmail.com>

--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -38,6 +38,7 @@ Tejas Tyagi <tejastyagi.tt@gmail.com>
 Aryan Arora <aryanarora.w1@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
 Din Xin Chen <s990346@gmail.com>
+Mingzhuo Yin <yinmingzhuo@gmail.com>
 ```
 
 ## Committers

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -38,6 +38,7 @@ Tejas Tyagi <tejastyagi.tt@gmail.com>
 Aryan Arora <aryanarora.w1@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
 Din Xin Chen <s990346@gmail.com>
+Mingzhuo Yin <yinmingzhuo@gmail.com>
 ```
 
 ## Committers

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -41,8 +41,6 @@ extern "C" {
 #include <message.h>
 #include <workers.h>
 
-#include <stdlib.h>
-
 #define SHORT_TIME_LENGHT 8 + 1
 #define LONG_TIME_LENGHT  16 + 1
 #define UTC_TIME_LENGTH   29 + 1
@@ -1322,16 +1320,12 @@ pgmoneta_lsn_to_string(uint64_t lsn);
 bool
 pgmoneta_is_incremental_path(char* path);
 
-#ifdef DEBUG
-
 /**
  * Generate a backtrace in the log
  * @return 0 if success, otherwise 1
  */
 int
 pgmoneta_backtrace(void);
-
-#endif
 
 /**
  * Get the OS name and kernel version.

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -4590,31 +4590,163 @@ pgmoneta_is_incremental_path(char* path)
    return pgmoneta_starts_with(name, INCREMENTAL_PREFIX);
 }
 
-#ifdef DEBUG
+static bool
+calculate_offset(uint64_t addr, uint64_t* offset, char** filepath)
+{
+#ifdef HAVE_LINUX
+
+   char line[256];
+   char* start, * end, * base_offset, * filepath_ptr;
+   uint64_t start_addr, end_addr, base_offset_value;
+   FILE* fp;
+   bool success = false;
+
+   fp = fopen("/proc/self/maps", "r");
+   if (fp == NULL)
+   {
+      goto error;
+   }
+
+   while (fgets(line, sizeof(line), fp) != NULL)
+   {
+      // exmaple line:
+      // 7fb60d1ea000-7fb60d20c000 r--p 00000000 103:02 120327460 /usr/lib/libc.so.6
+      start = strtok(line, "-");
+      end = strtok(NULL, " ");
+      strtok(NULL, " "); // skip the next token
+      base_offset = strtok(NULL, " ");
+      strtok(NULL, " "); // skip the next token
+      strtok(NULL, " "); // skip the next token
+      filepath_ptr = strtok(NULL, " \n");
+      if (start != NULL && end != NULL && base_offset != NULL && filepath_ptr != NULL)
+      {
+         start_addr = strtoul(start, NULL, 16);
+         end_addr = strtoul(end, NULL, 16);
+         if (addr >= start_addr && addr < end_addr)
+         {
+            success = true;
+            break;
+         }
+      }
+   }
+   if (!success)
+   {
+      goto error;
+   }
+
+   base_offset_value = strtoul(base_offset, NULL, 16);
+   *offset = addr - start_addr + base_offset_value;
+   *filepath = pgmoneta_append(*filepath, filepath_ptr);
+   if (fp != NULL)
+   {
+      fclose(fp);
+   }
+   return 0;
+
+error:
+   if (fp != NULL)
+   {
+      fclose(fp);
+   }
+   return 1;
+
+#else
+   return 1;
+
+#endif
+}
 
 int
 pgmoneta_backtrace(void)
 {
 #ifdef HAVE_LINUX
-   void* array[100];
-   size_t size;
-   char** strings;
+   void* bt[1024];
+   char* log_str = NULL;
+   size_t bt_size;
 
-   size = backtrace(array, 100);
-   strings = backtrace_symbols(array, size);
-
-   for (size_t i = 0; i < size; i++)
+   bt_size = backtrace(bt, 1024);
+   if (bt_size == 0)
    {
-      printf("%s\n", strings[i]);
+      goto error;
    }
 
-   free(strings);
-#endif
+   log_str = pgmoneta_append(log_str, "Backtrace:\n");
 
+   // the first element is ___interceptor_backtrace, so we skip it
+   for (int i = 1; i < bt_size; i++)
+   {
+      uint64_t addr = (uint64_t)bt[i];
+      uint64_t offset;
+      char* filepath = NULL;
+      char cmd[256], buffer[256], log_buffer[64];
+      bool found_main = false;
+      FILE* pipe;
+
+      if (calculate_offset(addr, &offset, &filepath))
+      {
+         continue;
+      }
+
+      snprintf(cmd, sizeof(cmd), "addr2line -e %s -fC 0x%lx", filepath, offset);
+      free(filepath);
+      filepath = NULL;
+
+      pipe = popen(cmd, "r");
+      if (pipe == NULL)
+      {
+         pgmoneta_log_debug("Failed to run command: %s, reason: %s", cmd, strerror(errno));
+         continue;
+      }
+
+      if (fgets(buffer, sizeof(buffer), pipe) == NULL)
+      {
+         pgmoneta_log_debug("Failed to read from command output: %s", strerror(errno));
+         pclose(pipe);
+         continue;
+      }
+      buffer[strlen(buffer) - 1] = '\0'; // Remove trailing newline
+      if (strcmp(buffer, "main") == 0)
+      {
+         found_main = true;
+      }
+      snprintf(log_buffer, sizeof(log_buffer), "#%d  0x%lx in ", i - 1, addr);
+      log_str = pgmoneta_append(log_str, log_buffer);
+      log_str = pgmoneta_append(log_str, buffer);
+      log_str = pgmoneta_append(log_str, "\n");
+
+      if (fgets(buffer, sizeof(buffer), pipe) == NULL)
+      {
+         log_str = pgmoneta_append(log_str, "\tat ???:??\n");
+      }
+      else
+      {
+         buffer[strlen(buffer) - 1] = '\0'; // Remove trailing newline
+         log_str = pgmoneta_append(log_str, "\tat ");
+         log_str = pgmoneta_append(log_str, buffer);
+         log_str = pgmoneta_append(log_str, "\n");
+      }
+
+      pclose(pipe);
+      if (found_main)
+      {
+         break;
+      }
+   }
+
+   pgmoneta_log_debug("%s", log_str);
+   free(log_str);
    return 0;
-}
 
+error:
+   if (log_str != NULL)
+   {
+      free(log_str);
+   }
+   return 1;
+#else
+   return 1;
 #endif
+}
 
 int
 pgmoneta_os_kernel_version(char** os, int* kernel_major, int* kernel_minor, int* kernel_patch)


### PR DESCRIPTION
implement #514

This PR introduces an enhanced stack backtrace feature that provides detailed debugging information, including function names, filenames, and line numbers. When `pgmoneta_backtrace` is called, it generates a formatted stack trace that is particularly useful for debugging and troubleshooting.

## Example Output

The following example demonstrates the output when `pgmoneta_backtrace` is invoked from the `version` function in `src/main.c:206`:
```
#0  0x7c00d33dff2a in pgmoneta_backtrace
	at /home/silver/code/pgmoneta/src/libpgmoneta/utils.c:4543
#1  0x5dc62da7fe25 in version
	at /home/silver/code/pgmoneta/src/main.c:206
#2  0x5dc62da7c1e0 in main
	at /home/silver/code/pgmoneta/src/main.c:301
```

## Details

- The implementation leverages the [`libbacktrace`](https://github.com/ianlancetaylor/libbacktrace) to capture stack trace information.
- When symbolic information is unavailable, the backtrace will fallback to displaying only the memory addresses.
