### PR TITLE
File-by-file incremental backup combine

### DIFF
--- a/src/include/backup.h
+++ b/src/include/backup.h
@@ -84,13 +84,23 @@ pgmoneta_get_backup_max_rate(int server);
  * Extract a file from a backup
  * @param server The server
  * @param label The label
- * @param file The file path
+ * @param relative_file_path The file path relative to the backup data directory
  * @param target_directory The target root directory
  * @param target_file The target file
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_extract_backup_file(int server, char* label, char* file, char* target_directory, char** target_file);
+pgmoneta_extract_backup_file(int server, char* label, char* relative_file_path, char* target_directory, char** target_file);
+
+/**
+ * Strip the compression/encryption suffix from a file path
+ * @param file The file path
+ * @param basename [out] The base file path with its compression/encryption suffix stripped,
+ * or a copy of the original path if it has none of the suffix
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_file_basename(char* file, char** basename);
 
 #ifdef __cplusplus
 }

--- a/src/include/restore.h
+++ b/src/include/restore.h
@@ -80,17 +80,18 @@ pgmoneta_restore_backup(struct art* nodes);
 /**
  * Combine the provided backups
  * @param server The server
+ * @param label The label of the current backup to combine
  * @param base The base directory that contains data and tablespaces
  * @param input_dir The base directory of the current input incremental backup
  * @param output_dir The base directory of the output incremental backup
  * (the last level of directory should not be followed by back slash)
- * @param prior_backup_dirs The root directory of prior incremental/full backups, from newest to oldest
+ * @param prior_labels The labels of prior incremental/full backups, from newest to oldest
  * @param bck The backup to be restored
  * @param manifest The manifest of the incremental backup to be combined
  * @return 0 on success, 1 if otherwise
  */
 int
-pgmoneta_combine_backups(int server, char* base, char* input_dir, char* output_dir, struct deque* prior_backup_dirs,
+pgmoneta_combine_backups(int server, char* label, char* base, char* input_dir, char* output_dir, struct deque* prior_labels,
                          struct backup* bck, struct json* manifest);
 
 #ifdef __cplusplus

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -57,13 +57,14 @@ extern "C" {
 
 #define NODE_ALL               "all"               /* All the files in a manifest */
 #define NODE_BACKUP            "backup"            /* The backup structure */
-#define NODE_BACKUPS           "backups"           /* A list of backups */
+#define NODE_COPY_WAL          "copy_wal"          /* Whether to copy WAL */
 #define NODE_BACKUP_BASE       "backup_base"       /* The base directory of the backup */
 #define NODE_BACKUP_DATA       "backup_data"       /* The data directory of the backup */
 #define NODE_FAILED            "failed"            /* The failed files in a manifest */
 #define NODE_INCREMENTAL_BASE  "incremental_base"  /* The base directory of incremental */
 #define NODE_INCREMENTAL_LABEL "incremental_label" /* The label of the incremental backup */
 #define NODE_LABEL             "label"             /* The backup label */
+#define NODE_LABELS            "labels"            /* A list of backup labels */
 #define NODE_MANIFEST          "manifest"          /* The manifest */
 #define NODE_PRIMARY           "primary"           /* Is the server a primary */
 #define NODE_RECOVERY_INFO     "recovery_info"     /* The recovery information */

--- a/src/include/workflow_funcs.h
+++ b/src/include/workflow_funcs.h
@@ -133,6 +133,9 @@ pgmoneta_create_bzip2(bool compress);
 struct workflow*
 pgmoneta_create_link(void);
 
+struct workflow*
+pgmoneta_create_copy_wal(void);
+
 /**
  * Create a workflow for recovery info
  * @return The workflow

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -536,6 +536,9 @@ wf_restore(struct backup* backup)
       current = current->next;
    }
 
+   current->next = pgmoneta_create_copy_wal();
+   current = current->next;
+
    current->next = pgmoneta_create_recovery_info();
    current = current->next;
 
@@ -572,10 +575,10 @@ wf_combine(int server, struct backup* backup)
    head = pgmoneta_create_combine_incremental();
    current = head;
 
-   current->next = pgmoneta_create_recovery_info();
+   current->next = pgmoneta_create_copy_wal();
    current = current->next;
 
-   current->next = pgmoneta_restore_excluded_files();
+   current->next = pgmoneta_create_recovery_info();
    current = current->next;
 
    current->next = pgmoneta_create_permissions(PERMISSION_TYPE_RESTORE);


### PR DESCRIPTION
This should decrease our disk requirement for incremental backup combine drastically, now the overhead is only a chain of one file, instead of a chain of backups.