### PR TITLE
[#525] Fixed a bug in `zstd_decompress`

### DIFF
--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -1544,7 +1544,7 @@ restore_backup_incremental(struct art* nodes)
    char target_root_combine[MAX_PATH];
    char target_base_combine[MAX_PATH_CONCAT];
    char excluded_file_path[MAX_PATH_CONCAT];
-   char tmp_excluded_file_path[MAX_PATH_CONCAT+sizeof(TMP_SUFFIX)];
+   char tmp_excluded_file_path[MAX_PATH_CONCAT + sizeof(TMP_SUFFIX)];
    int excluded_files = 0;
    char label[MISC_LENGTH];
    char* manifest_path = NULL;


### PR DESCRIPTION
This solves the infinite loop that occurs on my machine. However, the file's compression appears to be somewhat broken since the `input.pos` is not changing in the inner while loop.

```
pgmoneta@apollo:~$ pgmoneta-walinfo 000000010000000000000004.zstd.aes
Error while reading/describing WAL file
pgmoneta@apollo:~$ cat /tmp/pgmoneta.log
2025-03-28 14:18:06 TRACE utils.c:2548 FILETRACKER | Copy | 000000010000000000000004.zstd.aes | /tmp |
2025-03-28 14:18:06 ERROR aes.c:932 EVP_CipherFinal_ex: failed to process final cipher block
2025-03-28 14:18:06 ERROR zstandard_compression.c:471 ZSTD: Could not decompress /tmp/000000010000000000000004.zstd
2025-03-28 14:18:06 FATAL walfile.c:380 Failed to decompress WAL file at 000000010000000000000004.zstd.aes
pgmoneta@apollo:~$
```

Please test on your machine and tell me whether this strange output is still there. @jesperpedersen 