### PR TITLE
[#538] add --sort asc|desc option to list-backup command

### DIFF
--- a/doc/manual/97-acknowledgement.md
+++ b/doc/manual/97-acknowledgement.md
@@ -37,6 +37,7 @@ Sangkeun J.C. Kim <jchrys@me.com>
 Tejas Tyagi <tejastyagi.tt@gmail.com>
 Aryan Arora <aryanarora.w1@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
+Din Xin Chen <s990346@gmail.com>
 ```
 
 ## Committers

--- a/doc/manual/advanced/05-backup.md
+++ b/doc/manual/advanced/05-backup.md
@@ -75,6 +75,22 @@ Response:
   ServerVersion: 0.16.0
 ```
 
+## Sorting backups
+
+You can sort the backup list by timestamp using the `--sort` option:
+
+```
+pgmoneta-cli list-backup primary --sort asc
+```
+
+for ascending order (oldest first), or 
+
+```
+pgmoneta-cli list-backup primary --sort desc
+```
+
+for descending order (newest first).
+
 ## Create an incremental backup
 
 We can take an incremental backup from the primary with the following command

--- a/doc/manual/advanced/97-acknowledgement.md
+++ b/doc/manual/advanced/97-acknowledgement.md
@@ -37,6 +37,7 @@ Sangkeun J.C. Kim <jchrys@me.com>
 Tejas Tyagi <tejastyagi.tt@gmail.com>
 Aryan Arora <aryanarora.w1@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
+Din Xin Chen <s990346@gmail.com>
 ```
 
 ## Committers

--- a/doc/manual/user-10-cli.md
+++ b/doc/manual/user-10-cli.md
@@ -98,13 +98,23 @@ List the backups for a server
 Command
 
 ``` sh
-pgmoneta-cli list-backup <server>
+pgmoneta-cli list-backup <server> [--sort asc|desc]
 ```
+
+The `--sort` option allows sorting backups by timestamp:
+- `asc` for ascending order (oldest first)
+- `desc` for descending order (newest first)
 
 Example
 
 ``` sh
 pgmoneta-cli list-backup primary
+```
+
+Example with sorting
+
+``` sh
+pgmoneta-cli list-backup primary --sort desc
 ```
 
 ## restore

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -158,6 +158,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_SERVERS               "Servers"
 #define MANAGEMENT_ARGUMENT_SERVER_SIZE           "ServerSize"
 #define MANAGEMENT_ARGUMENT_SERVER_VERSION        "ServerVersion"
+#define MANAGEMENT_ARGUMENT_SORT                  "Sort"
 #define MANAGEMENT_ARGUMENT_SOURCE_FILE           "SourceFile"
 #define MANAGEMENT_ARGUMENT_START_HILSN           "StartHiLSN"
 #define MANAGEMENT_ARGUMENT_START_LOLSN           "StartLoLSN"
@@ -208,6 +209,7 @@ extern "C" {
 #define MANAGEMENT_ERROR_LIST_BACKUP_NETWORK      303
 #define MANAGEMENT_ERROR_LIST_BACKUP_NOSERVER     304
 #define MANAGEMENT_ERROR_LIST_BACKUP_NOFORK       305
+#define MANAGEMENT_ERROR_LIST_BACKUP_INVALID_SORT 306
 
 #define MANAGEMENT_ERROR_DELETE_SETUP    400
 #define MANAGEMENT_ERROR_DELETE_EXECUTE  401
@@ -411,13 +413,14 @@ pgmoneta_management_request_backup(SSL* ssl, int socket, char* server, uint8_t c
  * @param ssl The SSL connection
  * @param socket The socket descriptor
  * @param server The server
+ * @param sort_order The sort order (asc, desc, or NULL)
  * @param compression The compress method for wire protocol
  * @param encryption The encrypt method for wire protocol
  * @param output_format The output format
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_management_request_list_backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
+pgmoneta_management_request_list_backup(SSL* ssl, int socket, char* server, char* sort_order, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Create a restore request

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -773,6 +773,15 @@ int
 pgmoneta_strip_extension(char* s, char** name);
 
 /**
+ * Get basename from a file path
+ * @param path The file path
+ * @param basename The resulting basename
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_file_basename(char* path, char** basename);
+
+/**
  * Get the translated size of a file
  * @param size The size
  * @return The result

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -90,7 +90,7 @@ error:
 }
 
 int
-pgmoneta_management_request_list_backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format)
+pgmoneta_management_request_list_backup(SSL* ssl, int socket, char* server, char* sort_order, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    struct json* j = NULL;
    struct json* request = NULL;
@@ -106,6 +106,8 @@ pgmoneta_management_request_list_backup(SSL* ssl, int socket, char* server, uint
    }
 
    pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SORT, (uintptr_t)(sort_order != NULL ? sort_order : "asc"), ValueString);
 
    if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
    {


### PR DESCRIPTION
implement [#538](https://github.com/pgmoneta/pgmoneta/issues/538)

This PR adds a `--sort` option to the `list-backup` CLI command, allowing users to sort backups by time in either ascending (`asc`) or descending (`desc`) order. This enhancement improves usability by enabling easier inspection of backup history in the desired order.

## Example Output
### Input: `pgmoneta-cli list-backup primary --sort desc`
Output:
```Header:
  ClientVersion: 0.16.0
  Command: list-backup
  ...
Response:
  Backups:
    - Backup: 20250330135708
      BackupSize: 3.98MB
      ...
    - Backup: 20250330105024
      BackupSize: 3.98MB
      ...
    - Backup: 20250330102835
      BackupSize: 6.44MB
      ...
  NumberOfBackups: 3
```
### Input: `pgmoneta-cli list-backup primary --sort asc`
Output:
```
Header:
  ClientVersion: 0.16.0
  Command: list-backup
  ...
Response:
  Backups:
    - Backup: 20250330102835
      BackupSize: 6.44MB
      ...
    - Backup: 20250330105024
      BackupSize: 3.98MB
      ...
    - Backup: 20250330135708
      BackupSize: 3.98MB
      ...
  NumberOfBackups: 3
```


## Details
- Updated the list_backup function to accept a sort_order parameter
- Modified pgmoneta_management_request_list_backup to pass sort_order to the server
- Implemented sorting logic in the server's pgmoneta_list_backup function
- Updated help and usage documentation to include the new option
- Updated user guide and manual documenting the new feature