### PR TITLE
[#557] Workers: Use Deque

### DIFF
--- a/src/include/workers.h
+++ b/src/include/workers.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 #include <pgmoneta.h>
+#include <deque.h>
 
 #include <pthread.h>
 #include <stdio.h>
@@ -49,28 +50,6 @@ struct semaphore
    pthread_mutex_t mutex; /**< The mutex of the semaphore */
    pthread_cond_t cond;   /**< The condition of the semaphore */
    int value;             /**< The current value */
-};
-
-/** @struct task
- * Defines a task
- */
-struct task
-{
-   struct task* previous;                  /**< The previous task */
-   void (*function)(struct worker_common*); /**< The task */
-   struct worker_common* wc;                /**< The common base */
-};
-
-/** @struct queue
- * Defines a queue
- */
-struct queue
-{
-   pthread_mutex_t rwmutex;     /**< The read/write mutex */
-   struct task* front;          /**< The first task */
-   struct task* rear;           /**< The last task */
-   struct semaphore* has_tasks; /**< Are there any tasks ? */
-   int number_of_tasks;         /**< The number of tasks */
 };
 
 /** @struct worker
@@ -93,7 +72,8 @@ struct workers
    pthread_mutex_t worker_lock;    /**< The worker lock */
    pthread_cond_t worker_all_idle; /**< Are workers idle */
    bool outcome;                   /**< Outcome of the workers */
-   struct queue queue;             /**< The queue */
+   struct deque* queue;       /**< The task queue using deque */
+   struct semaphore* has_tasks;    /**< Are there any tasks ? */
 };
 
 /** @struct worker_common
@@ -102,6 +82,7 @@ struct workers
 struct worker_common
 {
    struct workers* workers;  /**< The root structure */
+   void (*function)(struct worker_common*); /**< The task function */
 };
 
 /** @struct worker_input

--- a/src/libpgmoneta/workers.c
+++ b/src/libpgmoneta/workers.c
@@ -27,8 +27,10 @@
  */
 
 #include <pgmoneta.h>
+#include <deque.h>
 #include <logging.h>
 #include <workers.h>
+#include <value.h>
 
 #include <errno.h>
 #include <signal.h>
@@ -44,17 +46,11 @@ static int worker_init(struct workers* workers, struct worker** worker);
 static void* worker_do(struct worker* worker);
 static void worker_destroy(struct worker* worker);
 
-static int queue_init(struct queue* queue);
-static void queue_clear(struct queue* queue);
-static void queue_push(struct queue* queue, struct task* task);
-static struct task* queue_pull(struct queue* queue);
-static void queue_destroy(struct queue* queue);
-
 static int semaphore_init(struct semaphore* semaphore, int value);
-static void semaphore_reset(struct semaphore* semaphore);
 static void semaphore_post(struct semaphore* semaphore);
 static void semaphore_post_all(struct semaphore* semaphore);
 static void semaphore_wait(struct semaphore* semaphore);
+static void destroy_data_wrapper(uintptr_t data);
 
 int
 pgmoneta_workers_initialize(int num, struct workers** workers)
@@ -81,9 +77,21 @@ pgmoneta_workers_initialize(int num, struct workers** workers)
    w->number_of_working = 0;
    w->outcome = true;
 
-   if (queue_init(&w->queue))
+   if (pgmoneta_deque_create(true, &w->queue)) {
+      pgmoneta_log_error("Could not allocate memory for deque");
+      goto error;
+   }
+
+   w->has_tasks = (struct semaphore*)malloc(sizeof(struct semaphore));
+   if (w->has_tasks == NULL)
    {
-      pgmoneta_log_error("Could not allocate memory for queue");
+      pgmoneta_log_error("Could not allocate memory for task semaphore");
+      goto error;
+   }
+
+   if (semaphore_init(w->has_tasks, 0))
+   {  
+      pgmoneta_log_error("Could not initialize task semaphore");
       goto error;
    }
 
@@ -115,7 +123,8 @@ error:
 
    if (w != NULL)
    {
-      queue_destroy(&w->queue);
+      pgmoneta_deque_destroy(w->queue);
+      free(w->has_tasks);
       free(w);
    }
 
@@ -125,21 +134,26 @@ error:
 int
 pgmoneta_workers_add(struct workers* workers, void (*function)(struct worker_common*), struct worker_common* wc)
 {
-   struct task* t = NULL;
+   struct worker_common* task_wc = NULL;
 
    if (workers != NULL)
    {
-      t = (struct task*)malloc(sizeof(struct task));
-      if (t == NULL)
+      task_wc = (struct worker_common*)malloc(sizeof(struct worker_common));
+      if (task_wc == NULL)
       {
          pgmoneta_log_error("Could not allocate memory for task");
          goto error;
       }
 
-      t->function = function;
-      t->wc = wc;
+      memcpy(task_wc, wc, sizeof(struct worker_common));
+      task_wc->function = function;
 
-      queue_push(&workers->queue, t);
+      struct value_config config = {0};
+      config.destroy_data = destroy_data_wrapper;
+      
+      pgmoneta_deque_add_with_config(workers->queue, NULL, (uintptr_t)task_wc, &config);
+      
+      semaphore_post(workers->has_tasks);
 
       return 0;
    }
@@ -156,7 +170,7 @@ pgmoneta_workers_wait(struct workers* workers)
    {
       pthread_mutex_lock(&workers->worker_lock);
 
-      while (workers->queue.number_of_tasks || workers->number_of_working)
+      while (pgmoneta_deque_size(workers->queue) || workers->number_of_working)
       {
          pthread_cond_wait(&workers->worker_all_idle, &workers->worker_lock);
       }
@@ -182,18 +196,19 @@ pgmoneta_workers_destroy(struct workers* workers)
       time (&start);
       while (tpassed < timeout && workers->number_of_alive)
       {
-         semaphore_post_all(workers->queue.has_tasks);
+         semaphore_post_all(workers->has_tasks);
          time(&end);
          tpassed = difftime(end, start);
       }
 
       while (workers->number_of_alive)
       {
-         semaphore_post_all(workers->queue.has_tasks);
+         semaphore_post_all(workers->has_tasks);
          SLEEP(1000000000L);
       }
 
-      queue_destroy(&workers->queue);
+      pgmoneta_deque_destroy(workers->queue);
+      free(workers->has_tasks);
 
       for (int n = 0; n < worker_total; n++)
       {
@@ -309,8 +324,7 @@ error:
 static void*
 worker_do(struct worker* worker)
 {
-   void (*func_ref)(struct worker_common*);
-   struct task* t;
+   struct worker_common* task_wc;
    struct workers* workers = worker->workers;
 
    pthread_mutex_lock(&workers->worker_lock);
@@ -319,7 +333,7 @@ worker_do(struct worker* worker)
 
    while (worker_keepalive)
    {
-      semaphore_wait(workers->queue.has_tasks);
+      semaphore_wait(workers->has_tasks);
 
       if (worker_keepalive)
       {
@@ -327,13 +341,11 @@ worker_do(struct worker* worker)
          workers->number_of_working++;
          pthread_mutex_unlock(&workers->worker_lock);
 
-         t = queue_pull(&workers->queue);
-         if (t)
+         task_wc = (struct worker_common*)pgmoneta_deque_poll(workers->queue, NULL);
+         
+         if (task_wc)
          {
-            func_ref = t->function;
-            func_ref(t->wc);
-
-            free(t);
+            task_wc->function(task_wc);
          }
 
          pthread_mutex_lock(&workers->worker_lock);
@@ -360,108 +372,6 @@ worker_destroy(struct worker* w)
 }
 
 static int
-queue_init(struct queue* queue)
-{
-   queue->number_of_tasks = 0;
-   queue->front = NULL;
-   queue->rear = NULL;
-
-   queue->has_tasks = (struct semaphore*)malloc(sizeof(struct semaphore));
-   if (queue->has_tasks == NULL)
-   {
-      return 1;
-   }
-
-   pthread_mutex_init(&(queue->rwmutex), NULL);
-   if (semaphore_init(queue->has_tasks, 0))
-   {
-      goto error;
-   }
-
-   return 0;
-
-error:
-
-   return 1;
-}
-
-static void
-queue_clear(struct queue* queue)
-{
-   while (queue->number_of_tasks)
-   {
-      free(queue_pull(queue));
-   }
-
-   queue->front = NULL;
-   queue->rear = NULL;
-   semaphore_reset(queue->has_tasks);
-   queue->number_of_tasks = 0;
-
-}
-
-static void
-queue_push(struct queue* queue, struct task* task)
-{
-
-   pthread_mutex_lock(&queue->rwmutex);
-   task->previous = NULL;
-
-   switch (queue->number_of_tasks)
-   {
-      case 0:
-         queue->front = task;
-         queue->rear = task;
-         break;
-
-      default:
-         queue->rear->previous = task;
-         queue->rear = task;
-
-   }
-   queue->number_of_tasks++;
-
-   semaphore_post(queue->has_tasks);
-   pthread_mutex_unlock(&queue->rwmutex);
-}
-
-static struct task*
-queue_pull(struct queue* queue)
-{
-   struct task* task = NULL;
-
-   pthread_mutex_lock(&queue->rwmutex);
-   task = queue->front;
-
-   switch (queue->number_of_tasks)
-   {
-      case 0:
-         break;
-
-      case 1:
-         queue->front = NULL;
-         queue->rear = NULL;
-         queue->number_of_tasks = 0;
-         break;
-
-      default:
-         queue->front = task->previous;
-         queue->number_of_tasks--;
-         semaphore_post(queue->has_tasks);
-   }
-
-   pthread_mutex_unlock(&queue->rwmutex);
-   return task;
-}
-
-static void
-queue_destroy(struct queue* queue)
-{
-   queue_clear(queue);
-   free(queue->has_tasks);
-}
-
-static int
 semaphore_init(struct semaphore* semaphore, int value)
 {
    if (value < 0 || value > 1 || semaphore == NULL)
@@ -479,14 +389,6 @@ semaphore_init(struct semaphore* semaphore, int value)
 error:
 
    return 1;
-}
-
-static void
-semaphore_reset(struct semaphore* semaphore)
-{
-   pthread_mutex_destroy(&(semaphore->mutex));
-   pthread_cond_destroy(&(semaphore->cond));
-   semaphore_init(semaphore, 0);
 }
 
 static void
@@ -517,4 +419,10 @@ semaphore_wait(struct semaphore* semaphore)
    }
    semaphore->value = 0;
    pthread_mutex_unlock(&semaphore->mutex);
+}
+
+static void
+destroy_data_wrapper(uintptr_t data)
+{
+   free((void*)data);
 }


### PR DESCRIPTION
implement #557 

This PR replace the custom queue in `workers.c` with the existing deque in `deque.c` implementation.

## Details
1. The task is now included into `worker_common`, instead of being wrapped in a separate `struct task`. Since the deque is designed to hold generic values (with cleanup via value_config), storing the complete task in a single structure simplifies both insertion and memory management.
2. Move `struct semaphore* has_tasks;` from original queue to workers since deque doesn't have semaphore logic.