### PR TITLE
[#587] pgmoneta format to PostgreSQL manifest conversion 

### DIFF
--- a/src/include/manifest.h
+++ b/src/include/manifest.h
@@ -81,6 +81,8 @@ pgmoneta_manifest_checksum_verify(char* root);
 int
 pgmoneta_compare_manifests(char* old_manifest, char* new_manifest, struct art** deleted_files, struct art** changed_files, struct art** added_files);
 
+char* pgmoneta_convert_manifest_to_pg_format(char* manifest_path);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Implements #587
### Description
This PR implements the `pgmoneta_convert_manifest_to_pg_format` function to address issue #587, which requires converting a pgmoneta manifest (JSON format) into PostgreSQL's manifest format (CSV-like format).

### Changes
- Added `pgmoneta_convert_manifest_to_pg_format` in `manifest.c` and its declaration in `manifest.h`.
- The function reads a pgmoneta manifest JSON file, extracts the "Files" array, and converts each entry into the format `path,size,checksum\n` (e.g., `base/16384/12345,8192,abc123`).
- Includes error handling for:
  - Missing or invalid manifest file.
  - Missing "Files" array in the JSON.
  - Missing required fields (`Path`, `Size`, `Checksum`) in file entries.
- Manages memory safely, with dynamic resizing of the output buffer and proper cleanup.

### Testing
- Tested with a valid manifest:
  - Input: `{"Files": [{"Path": "base/16384/12345", "Size": "8192", "Checksum": "abc123"}, {"Path": "base/16384/12346", "Size": "8192", "Checksum": "def456"}]}`
  - Output: `base/16384/12345,8192,abc123\nbase/16384/12346,8192,def456`
- Error cases:
  - Missing file: Logs error and returns `NULL`.
  - Missing "Files" array: Logs error and returns `NULL`.
  - Missing fields: Skips invalid entries and logs errors.