### PR TITLE
[#557] Workers: Use Deque

### DIFF
--- a/src/include/workers.h
+++ b/src/include/workers.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 #include <pgmoneta.h>
+#include <deque.h>
 
 #include <pthread.h>
 #include <stdio.h>
@@ -48,29 +49,17 @@ struct semaphore
 {
    pthread_mutex_t mutex; /**< The mutex of the semaphore */
    pthread_cond_t cond;   /**< The condition of the semaphore */
-   int value;             /**< The current value */
+   int count;             /**< The current count */
 };
 
-/** @struct task
- * Defines a task
+/** @struct worker_task
+ * Defines a worker task
  */
-struct task
+struct worker_task
 {
-   struct task* previous;                  /**< The previous task */
-   void (*function)(struct worker_common*); /**< The task */
-   struct worker_common* wc;                /**< The common base */
-};
-
-/** @struct queue
- * Defines a queue
- */
-struct queue
-{
-   pthread_mutex_t rwmutex;     /**< The read/write mutex */
-   struct task* front;          /**< The first task */
-   struct task* rear;           /**< The last task */
-   struct semaphore* has_tasks; /**< Are there any tasks ? */
-   int number_of_tasks;         /**< The number of tasks */
+   void (*function)(struct worker_common*); /**< The task function */
+   struct worker_common* wc;                /**< Pointer to the common data */
+   char* name;                              /**< The name of the function */
 };
 
 /** @struct worker
@@ -93,7 +82,8 @@ struct workers
    pthread_mutex_t worker_lock;    /**< The worker lock */
    pthread_cond_t worker_all_idle; /**< Are workers idle */
    bool outcome;                   /**< Outcome of the workers */
-   struct queue queue;             /**< The queue */
+   struct deque* queue;            /**< The task queue using deque */
+   struct semaphore* has_tasks;    /**< Semaphore for tasks dispatching*/
 };
 
 /** @struct worker_common
@@ -132,11 +122,11 @@ pgmoneta_workers_initialize(int num, struct workers** workers);
  * Add work to the queue
  * @param workers The workers
  * @param function The function pointer
- * @param wi The argument
+ * @param wc The argument
  * @return 0 upon success, otherwise 1.
  */
 int
-pgmoneta_workers_add(struct workers* workers, void (*function)(struct worker_common*), struct worker_common* wi);
+pgmoneta_workers_add(struct workers* workers, void (*function)(struct worker_common*), struct worker_common* wc);
 
 /**
  * Wait for all queued work units to finish

--- a/src/libpgmoneta/wf_hot_standby.c
+++ b/src/libpgmoneta/wf_hot_standby.c
@@ -387,6 +387,8 @@ error:
    free(old_manifest);
    free(new_manifest);
 
+   pgmoneta_workers_destroy(workers);
+
    if (source_root != NULL)
    {
       pgmoneta_delete_directory(source_root);

--- a/src/libpgmoneta/workers.c
+++ b/src/libpgmoneta/workers.c
@@ -27,8 +27,10 @@
  */
 
 #include <pgmoneta.h>
+#include <deque.h>
 #include <logging.h>
 #include <workers.h>
+#include <value.h>
 
 #include <errno.h>
 #include <signal.h>
@@ -44,17 +46,11 @@ static int worker_init(struct workers* workers, struct worker** worker);
 static void* worker_do(struct worker* worker);
 static void worker_destroy(struct worker* worker);
 
-static int queue_init(struct queue* queue);
-static void queue_clear(struct queue* queue);
-static void queue_push(struct queue* queue, struct task* task);
-static struct task* queue_pull(struct queue* queue);
-static void queue_destroy(struct queue* queue);
-
-static int semaphore_init(struct semaphore* semaphore, int value);
-static void semaphore_reset(struct semaphore* semaphore);
+static int semaphore_init(struct semaphore* semaphore);
 static void semaphore_post(struct semaphore* semaphore);
 static void semaphore_post_all(struct semaphore* semaphore);
 static void semaphore_wait(struct semaphore* semaphore);
+static void destroy_task_wrapper(uintptr_t data);
 
 int
 pgmoneta_workers_initialize(int num, struct workers** workers)
@@ -81,9 +77,22 @@ pgmoneta_workers_initialize(int num, struct workers** workers)
    w->number_of_working = 0;
    w->outcome = true;
 
-   if (queue_init(&w->queue))
+   if (pgmoneta_deque_create(true, &w->queue))
    {
-      pgmoneta_log_error("Could not allocate memory for queue");
+      pgmoneta_log_error("Could not allocate memory for deque");
+      goto error;
+   }
+
+   w->has_tasks = (struct semaphore*)malloc(sizeof(struct semaphore));
+   if (w->has_tasks == NULL)
+   {
+      pgmoneta_log_error("Could not allocate memory for workers semaphore");
+      goto error;
+   }
+
+   if (semaphore_init(w->has_tasks))
+   {
+      pgmoneta_log_error("Could not initialize workers semaphore");
       goto error;
    }
 
@@ -115,7 +124,8 @@ error:
 
    if (w != NULL)
    {
-      queue_destroy(&w->queue);
+      pgmoneta_deque_destroy(w->queue);
+      free(w->has_tasks);
       free(w);
    }
 
@@ -125,21 +135,27 @@ error:
 int
 pgmoneta_workers_add(struct workers* workers, void (*function)(struct worker_common*), struct worker_common* wc)
 {
-   struct task* t = NULL;
+   struct worker_task* task = NULL;
+   struct value_config config = {0};
 
    if (workers != NULL)
    {
-      t = (struct task*)malloc(sizeof(struct task));
-      if (t == NULL)
+      task = (struct worker_task*)malloc(sizeof(struct worker_task));
+      if (task == NULL)
       {
          pgmoneta_log_error("Could not allocate memory for task");
          goto error;
       }
 
-      t->function = function;
-      t->wc = wc;
+      task->function = function;
+      task->wc = wc;
+      task->name = NULL;
 
-      queue_push(&workers->queue, t);
+      config.destroy_data = destroy_task_wrapper;
+
+      pgmoneta_deque_add_with_config(workers->queue, NULL, (uintptr_t)task, &config);
+
+      semaphore_post(workers->has_tasks);
 
       return 0;
    }
@@ -156,7 +172,7 @@ pgmoneta_workers_wait(struct workers* workers)
    {
       pthread_mutex_lock(&workers->worker_lock);
 
-      while (workers->queue.number_of_tasks || workers->number_of_working)
+      while (pgmoneta_deque_size(workers->queue) > 0 || workers->number_of_working > 0)
       {
          pthread_cond_wait(&workers->worker_all_idle, &workers->worker_lock);
       }
@@ -182,18 +198,19 @@ pgmoneta_workers_destroy(struct workers* workers)
       time (&start);
       while (tpassed < timeout && workers->number_of_alive)
       {
-         semaphore_post_all(workers->queue.has_tasks);
+         semaphore_post_all(workers->has_tasks);
          time(&end);
          tpassed = difftime(end, start);
       }
 
       while (workers->number_of_alive)
       {
-         semaphore_post_all(workers->queue.has_tasks);
+         semaphore_post_all(workers->has_tasks);
          SLEEP(1000000000L);
       }
 
-      queue_destroy(&workers->queue);
+      pgmoneta_deque_destroy(workers->queue);
+      free(workers->has_tasks);
 
       for (int n = 0; n < worker_total; n++)
       {
@@ -309,8 +326,7 @@ error:
 static void*
 worker_do(struct worker* worker)
 {
-   void (*func_ref)(struct worker_common*);
-   struct task* t;
+   struct worker_task* task;
    struct workers* workers = worker->workers;
 
    pthread_mutex_lock(&workers->worker_lock);
@@ -319,7 +335,7 @@ worker_do(struct worker* worker)
 
    while (worker_keepalive)
    {
-      semaphore_wait(workers->queue.has_tasks);
+      semaphore_wait(workers->has_tasks);
 
       if (worker_keepalive)
       {
@@ -327,13 +343,12 @@ worker_do(struct worker* worker)
          workers->number_of_working++;
          pthread_mutex_unlock(&workers->worker_lock);
 
-         t = queue_pull(&workers->queue);
-         if (t)
-         {
-            func_ref = t->function;
-            func_ref(t->wc);
+         task = (struct worker_task*)pgmoneta_deque_poll(workers->queue, NULL);
 
-            free(t);
+         if (task)
+         {
+            task->function(task->wc);
+            free(task);
          }
 
          pthread_mutex_lock(&workers->worker_lock);
@@ -360,140 +375,30 @@ worker_destroy(struct worker* w)
 }
 
 static int
-queue_init(struct queue* queue)
+semaphore_init(struct semaphore* semaphore)
 {
-   queue->number_of_tasks = 0;
-   queue->front = NULL;
-   queue->rear = NULL;
-
-   queue->has_tasks = (struct semaphore*)malloc(sizeof(struct semaphore));
-   if (queue->has_tasks == NULL)
+   if (semaphore == NULL)
    {
-      return 1;
-   }
-
-   pthread_mutex_init(&(queue->rwmutex), NULL);
-   if (semaphore_init(queue->has_tasks, 0))
-   {
-      goto error;
-   }
-
-   return 0;
-
-error:
-
-   return 1;
-}
-
-static void
-queue_clear(struct queue* queue)
-{
-   while (queue->number_of_tasks)
-   {
-      free(queue_pull(queue));
-   }
-
-   queue->front = NULL;
-   queue->rear = NULL;
-   semaphore_reset(queue->has_tasks);
-   queue->number_of_tasks = 0;
-
-}
-
-static void
-queue_push(struct queue* queue, struct task* task)
-{
-
-   pthread_mutex_lock(&queue->rwmutex);
-   task->previous = NULL;
-
-   switch (queue->number_of_tasks)
-   {
-      case 0:
-         queue->front = task;
-         queue->rear = task;
-         break;
-
-      default:
-         queue->rear->previous = task;
-         queue->rear = task;
-
-   }
-   queue->number_of_tasks++;
-
-   semaphore_post(queue->has_tasks);
-   pthread_mutex_unlock(&queue->rwmutex);
-}
-
-static struct task*
-queue_pull(struct queue* queue)
-{
-   struct task* task = NULL;
-
-   pthread_mutex_lock(&queue->rwmutex);
-   task = queue->front;
-
-   switch (queue->number_of_tasks)
-   {
-      case 0:
-         break;
-
-      case 1:
-         queue->front = NULL;
-         queue->rear = NULL;
-         queue->number_of_tasks = 0;
-         break;
-
-      default:
-         queue->front = task->previous;
-         queue->number_of_tasks--;
-         semaphore_post(queue->has_tasks);
-   }
-
-   pthread_mutex_unlock(&queue->rwmutex);
-   return task;
-}
-
-static void
-queue_destroy(struct queue* queue)
-{
-   queue_clear(queue);
-   free(queue->has_tasks);
-}
-
-static int
-semaphore_init(struct semaphore* semaphore, int value)
-{
-   if (value < 0 || value > 1 || semaphore == NULL)
-   {
-      pgmoneta_log_error("Invalid semaphore value: %d", value);
+      pgmoneta_log_error("Invalid semaphore");
       goto error;
    }
 
    pthread_mutex_init(&(semaphore->mutex), NULL);
    pthread_cond_init(&(semaphore->cond), NULL);
-   semaphore->value = value;
+   semaphore->count = 0;
 
    return 0;
 
 error:
 
    return 1;
-}
-
-static void
-semaphore_reset(struct semaphore* semaphore)
-{
-   pthread_mutex_destroy(&(semaphore->mutex));
-   pthread_cond_destroy(&(semaphore->cond));
-   semaphore_init(semaphore, 0);
 }
 
 static void
 semaphore_post(struct semaphore* semaphore)
 {
    pthread_mutex_lock(&semaphore->mutex);
-   semaphore->value = 1;
+   semaphore->count++;
    pthread_cond_signal(&semaphore->cond);
    pthread_mutex_unlock(&semaphore->mutex);
 }
@@ -502,7 +407,7 @@ static void
 semaphore_post_all(struct semaphore* semaphore)
 {
    pthread_mutex_lock(&semaphore->mutex);
-   semaphore->value = 1;
+   semaphore->count++;
    pthread_cond_broadcast(&semaphore->cond);
    pthread_mutex_unlock(&semaphore->mutex);
 }
@@ -511,10 +416,17 @@ static void
 semaphore_wait(struct semaphore* semaphore)
 {
    pthread_mutex_lock(&semaphore->mutex);
-   while (semaphore->value != 1)
+   while (semaphore->count == 0)
    {
       pthread_cond_wait(&semaphore->cond, &semaphore->mutex);
    }
-   semaphore->value = 0;
+   semaphore->count--;
    pthread_mutex_unlock(&semaphore->mutex);
+}
+
+static void
+destroy_task_wrapper(uintptr_t data)
+{
+   struct worker_task* task = (struct worker_task*)data;
+   free(task);
 }


### PR DESCRIPTION
implement  https://github.com/pgmoneta/pgmoneta/issues/557
fix PR https://github.com/pgmoneta/pgmoneta/pull/565

This PR replace the custom queue in workers.c with the existing deque in deque.c implementation. Backup successfully with workers = 8

## Updates
Comparing to the original code, I’ve made several updates
1. **change semaphore value from binary to counting** -> This prevents a situation where worker threads go to sleep even though tasks are still available, which can happen if tasks are added faster than they’re polled from the deque.
2. **seperate the `worker_task` and `worker_common`** to avoid freeing them both when we want to free the task
3. **add `pgmoneta_workers_wait` to `pgmoneta_workers_destroy`**