### PR TITLE
[#600] Build: cmake 3.31+

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,6 +1,7 @@
 # man target
 add_custom_target(man ALL)
 
+
 # man page definitions
 set(PGMONETA_SRC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/man/pgmoneta.1.rst")
 set(PGMONETA_DST_FILE "${CMAKE_CURRENT_BINARY_DIR}/pgmoneta.1")
@@ -11,39 +12,43 @@ set(PGMONETA_ADMIN_DST_FILE "${CMAKE_CURRENT_BINARY_DIR}/pgmoneta-admin.1")
 set(PGMONETA_CONF_SRC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/man/pgmoneta.conf.5.rst")
 set(PGMONETA_CONF_DST_FILE "${CMAKE_CURRENT_BINARY_DIR}/pgmoneta.conf.5")
 
+
 # pgmoneta.1
 add_custom_command(
-  TARGET man
+  OUTPUT ${PGMONETA_DST_FILE}
   COMMAND ${RST2MAN_EXECUTABLE} ${PGMONETA_SRC_FILE} ${PGMONETA_DST_FILE}
-  OUTPUTS ${PGMONETA_DST_FILE}
+  DEPENDS ${PGMONETA_SRC_FILE}
+  COMMENT "Generating man page: pgmoneta.1"
 )
-
 # pgmoneta-cli.1
 add_custom_command(
-  TARGET man
+  OUTPUT ${PGMONETA_CLI_DST_FILE}
   COMMAND ${RST2MAN_EXECUTABLE} ${PGMONETA_CLI_SRC_FILE} ${PGMONETA_CLI_DST_FILE}
-  OUTPUTS ${PGMONETA_CLI_DST_FILE}
+  DEPENDS ${PGMONETA_CLI_SRC_FILE}
+  COMMENT "Generating man page: pgmoneta-cli.1"
 )
-
 # pgmoneta-admin.1
 add_custom_command(
-  TARGET man
+  OUTPUT ${PGMONETA_ADMIN_DST_FILE}
   COMMAND ${RST2MAN_EXECUTABLE} ${PGMONETA_ADMIN_SRC_FILE} ${PGMONETA_ADMIN_DST_FILE}
-  OUTPUTS ${PGMONETA_ADMIN_DST_FILE}
+  DEPENDS ${PGMONETA_ADMIN_SRC_FILE}
+  COMMENT "Generating man page: pgmoneta-admin.1"
 )
-
 # pgmoneta.conf.5
 add_custom_command(
-  TARGET man
+  OUTPUT ${PGMONETA_CONF_DST_FILE}
   COMMAND ${RST2MAN_EXECUTABLE} ${PGMONETA_CONF_SRC_FILE} ${PGMONETA_CONF_DST_FILE}
-  OUTPUTS ${PGMONETA_CONF_DST_FILE}
+  DEPENDS ${PGMONETA_CONF_SRC_FILE}
+  COMMENT "Generating man page: pgmoneta.conf.5"
 )
 
-# man pages
-add_custom_command(
-  TARGET man
+# Group man page outputs into a target
+add_custom_target(manpages ALL
   DEPENDS ${PGMONETA_DST_FILE} ${PGMONETA_CLI_DST_FILE} ${PGMONETA_ADMIN_DST_FILE} ${PGMONETA_CONF_DST_FILE}
 )
+
+# Make 'man' depend on 'manpages'
+add_dependencies(man manpages)
 
 #
 # Install configuration and documentation
@@ -153,12 +158,14 @@ if (DOXYGEN_FOUND)
       TARGET api
       COMMAND ${DOXYGEN_EXECUTABLE} -q ${DOXYFILE_OUT}
       COMMENT "Generating API documentation"
+      POST_BUILD
     )
   else()
     add_custom_command(
       TARGET api
       COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
       COMMENT "Generating API documentation"
+        POST_BUILD
     )
   endif()
 endif()


### PR DESCRIPTION
New policy rules
https://cmake.org/cmake/help/latest/policy/CMP0175.html#policy:CMP0175

As per the new CMake policy CMP0175, I've updated the project to comply with the latest standards. The old policy is being deprecated and will soon be retired, so it’s important to transition to the new one