### PR TITLE
[#623] test suite: Development servers

### DIFF
--- a/test/testsuite.sh
+++ b/test/testsuite.sh
@@ -161,7 +161,7 @@ check_psql() {
 }
 
 check_postgres_version() {
-   version=$(psql --version | awk '{print $3}')
+   version=$(psql --version | awk '{print $3}' | sed -E 's/^([0-9]+(\.[0-9]+)?).*/\1/')
    major_version=$(echo "$version" | cut -d'.' -f1)
    required_major_version=$1
    if [ "$major_version" -ge "$required_major_version" ]; then


### PR DESCRIPTION
The recent postgres versions which are either the beta versions or the pre-release version have versioning something like `18devel` or `18beta1` . To parse the version and compare it with our requirement in testsuite, we read only the numeric part of the version string using regex.
`s/^([0-9]+(\.[0-9]+)?).*/\1/`.

Note: It will however drop the patch version.

@jesperpedersen PTAL