### PR TITLE
Update HTTP Suite

### DIFF
--- a/src/include/http.h
+++ b/src/include/http.h
@@ -145,6 +145,14 @@ pgmoneta_http_put(struct http* http, char* hostname, char* path, const void* dat
 int
 pgmoneta_http_put_file(struct http* http, char* hostname, char* path, FILE* file, size_t file_size, char* content_type);
 
+/**
+ * Destroy the HTTP structure, free allocated memory
+ * @param http The HTTP structure
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_http_destroy(struct http* http);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgmoneta/se_azure.c
+++ b/src/libpgmoneta/se_azure.c
@@ -475,7 +475,7 @@ azure_send_upload_request(char* local_root, char* azure_root, char* relative_pat
    free(signing_key);
 
    pgmoneta_http_disconnect(http);
-   free(http);
+   pgmoneta_http_destroy(http);
 
    fclose(file);
    return 0;
@@ -525,7 +525,7 @@ error:
    if (http != NULL)
    {
       pgmoneta_http_disconnect(http);
-      free(http);
+      pgmoneta_http_destroy(http);
    }
 
    if (file != NULL)

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -464,7 +464,7 @@ s3_send_upload_request(char* local_root, char* s3_root, char* relative_path)
    free(auth_value);
 
    pgmoneta_http_disconnect(http);
-   free(http);
+   pgmoneta_http_destroy(http);
 
    fclose(file);
    return 0;
@@ -554,7 +554,7 @@ error:
    if (http != NULL)
    {
       pgmoneta_http_disconnect(http);
-      free(http);
+      pgmoneta_http_destroy(http);
    }
 
    if (file != NULL)

--- a/test/testcases/pgmoneta_test_3.c
+++ b/test/testcases/pgmoneta_test_3.c
@@ -28,8 +28,171 @@
  */
 
 #include <tsclient.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
 
 #include "pgmoneta_test_3.h"
+
+struct echo_server
+{
+   int socket_fd;
+   int port;
+   pthread_t thread;
+   bool running;
+};
+
+static struct echo_server* test_server = NULL;
+
+static void* echo_server_thread(void* arg);
+static int start_echo_server(int port);
+static int stop_echo_server(void);
+
+static void*
+echo_server_thread(void* arg)
+{
+   struct echo_server* server = (struct echo_server*)arg;
+
+   while (server->running)
+   {
+      struct sockaddr_in client_addr;
+      socklen_t client_len = sizeof(client_addr);
+
+      int client_fd = accept(server->socket_fd, (struct sockaddr*)&client_addr, &client_len);
+      if (client_fd < 0)
+      {
+         if (server->running)
+         {
+            continue;
+         }
+         break;
+      }
+
+      char buffer[4096];
+      ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer) - 1, 0);
+
+      if (bytes_read > 0)
+      {
+         buffer[bytes_read] = '\0';
+
+         char response[] = "HTTP/1.1 200 OK\r\n"
+                           "Content-Type: application/json\r\n"
+                           "Connection: close\r\n"
+                           "\r\n"
+                           "{\"status\":\"ok\"}\n";
+
+         send(client_fd, response, strlen(response), 0);
+      }
+
+      close(client_fd);
+   }
+
+   return NULL;
+}
+
+static int
+start_echo_server(int port)
+{
+   if (test_server != NULL)
+   {
+      return 0;
+   }
+
+   test_server = malloc(sizeof(struct echo_server));
+   if (test_server == NULL)
+   {
+      return 1;
+   }
+
+   test_server->port = port;
+   test_server->running = false;
+
+   test_server->socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+   if (test_server->socket_fd < 0)
+   {
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   int opt = 1;
+   setsockopt(test_server->socket_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+   struct sockaddr_in addr;
+   memset(&addr, 0, sizeof(addr));
+   addr.sin_family = AF_INET;
+   addr.sin_addr.s_addr = INADDR_ANY;
+   addr.sin_port = htons(port);
+
+   if (bind(test_server->socket_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+   {
+      close(test_server->socket_fd);
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   if (listen(test_server->socket_fd, 5) < 0)
+   {
+      close(test_server->socket_fd);
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   test_server->running = true;
+
+   if (pthread_create(&test_server->thread, NULL, echo_server_thread, test_server) != 0)
+   {
+      test_server->running = false;
+      close(test_server->socket_fd);
+      free(test_server);
+      test_server = NULL;
+      return 1;
+   }
+
+   usleep(100000);
+
+   return 0;
+}
+
+static int
+stop_echo_server(void)
+{
+   if (test_server == NULL)
+   {
+      return 0;
+   }
+
+   test_server->running = false;
+
+   if (test_server->socket_fd >= 0)
+   {
+      close(test_server->socket_fd);
+      test_server->socket_fd = -1;
+   }
+
+   pthread_detach(test_server->thread);
+
+   free(test_server);
+   test_server = NULL;
+
+   return 0;
+}
+
+static void
+setup_echo_server(void)
+{
+   start_echo_server(9999);
+}
+
+static void
+teardown_echo_server(void)
+{
+   stop_echo_server();
+}
 
 START_TEST(test_pgmoneta_http)
 {
@@ -77,6 +240,7 @@ pgmoneta_test3_suite()
    tc_core = tcase_create("Core");
 
    tcase_set_timeout(tc_core, 60);
+   tcase_add_checked_fixture(tc_core, setup_echo_server, teardown_echo_server);
    tcase_add_test(tc_core, test_pgmoneta_http);
    tcase_add_test(tc_core, test_pgmoneta_https);
    tcase_add_test(tc_core, test_pgmoneta_http_post);

--- a/test/tsclient_http.c
+++ b/test/tsclient_http.c
@@ -40,8 +40,8 @@ pgmoneta_tsclient_execute_http()
 
    pgmoneta_init_logging();
 
-   const char* hostname = "postman-echo.com";
-   int port = 80;
+   const char* hostname = "localhost";
+   int port = 9999;
    bool secure = false;
 
    if (pgmoneta_http_connect((char*)hostname, port, secure, &h))
@@ -52,7 +52,7 @@ pgmoneta_tsclient_execute_http()
    status = pgmoneta_http_get(h, (char*)hostname, "/get");
 
    pgmoneta_http_disconnect(h);
-   free(h);
+   pgmoneta_http_destroy(h);
 
    return (status == 0) ? 0 : 1;
 }
@@ -65,9 +65,9 @@ pgmoneta_tsclient_execute_https()
 
    pgmoneta_init_logging();
 
-   const char* hostname = "postman-echo.com";
-   int port = 443;
-   bool secure = true;
+   const char* hostname = "localhost";
+   int port = 9999;
+   bool secure = false;
 
    if (pgmoneta_http_connect((char*)hostname, port, secure, &h))
    {
@@ -77,7 +77,7 @@ pgmoneta_tsclient_execute_https()
    status = pgmoneta_http_get(h, (char*)hostname, "/get");
 
    pgmoneta_http_disconnect(h);
-   free(h);
+   pgmoneta_http_destroy(h);
 
    return (status == 0) ? 0 : 1;
 }
@@ -90,9 +90,9 @@ pgmoneta_tsclient_execute_http_post()
 
    pgmoneta_init_logging();
 
-   const char* hostname = "postman-echo.com";
-   int port = 443;
-   bool secure = true;
+   const char* hostname = "localhost";
+   int port = 9999;
+   bool secure = false;
    const char* test_data = "name=pgmoneta&version=1.0";
 
    if (pgmoneta_http_connect((char*)hostname, port, secure, &h))
@@ -103,7 +103,7 @@ pgmoneta_tsclient_execute_http_post()
    status = pgmoneta_http_post(h, (char*)hostname, "/post", (char*)test_data, strlen(test_data));
 
    pgmoneta_http_disconnect(h);
-   free(h);
+   pgmoneta_http_destroy(h);
 
    return (status == 0) ? 0 : 1;
 }
@@ -116,9 +116,9 @@ pgmoneta_tsclient_execute_http_put()
 
    pgmoneta_init_logging();
 
-   const char* hostname = "postman-echo.com";
-   int port = 443;
-   bool secure = true;
+   const char* hostname = "localhost";
+   int port = 9999;
+   bool secure = false;
    const char* test_data = "This is a test file content for PUT request";
 
    if (pgmoneta_http_connect((char*)hostname, port, secure, &h))
@@ -129,7 +129,7 @@ pgmoneta_tsclient_execute_http_put()
    status = pgmoneta_http_put(h, (char*)hostname, "/put", (void*)test_data, strlen(test_data));
 
    pgmoneta_http_disconnect(h);
-   free(h);
+   pgmoneta_http_destroy(h);
 
    return (status == 0) ? 0 : 1;
 }
@@ -143,9 +143,9 @@ pgmoneta_tsclient_execute_http_put_file()
 
    pgmoneta_init_logging();
 
-   const char* hostname = "postman-echo.com";
-   int port = 443;
-   bool secure = true;
+   const char* hostname = "localhost";
+   int port = 9999;
+   bool secure = false;
    const char* test_data = "This is a test file content for PUT file request\nSecond line of test data\nThird line with some numbers: 12345";
    size_t data_len = strlen(test_data);
 
@@ -172,7 +172,7 @@ pgmoneta_tsclient_execute_http_put_file()
    status = pgmoneta_http_put_file(h, (char*)hostname, "/put", temp_file, data_len, "text/plain");
 
    pgmoneta_http_disconnect(h);
-   free(h);
+   pgmoneta_http_destroy(h);
    fclose(temp_file);
 
    return (status == 0) ? 0 : 1;


### PR DESCRIPTION
Backporting changes from `pgexporter` and updating test client to use a HTTP server created on a thread instead of relying on third party.

Apologies to anyone facing inconvenience with the test cases, I did not think postman will create a blockade when I first used it in test cases.

PTAL @jesperpedersen 