### PR TITLE
[#635] walinfo: Summary

### DIFF
--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -420,6 +420,7 @@ Options:
   -x,  --xid         Filter on an XID
   -l,  --limit       Limit number of outputs
   -v,  --verbose     Output result
+  -S,  --summary     Show a summary of WAL record counts grouped by resource manager
   -V,  --version     Display version information
   -m,  --mapping     Provide mappings file for OID translation
   -t,  --translate   Translate OIDs to object names in XLOG records

--- a/doc/man/pgmoneta-walinfo.1.rst
+++ b/doc/man/pgmoneta-walinfo.1.rst
@@ -45,6 +45,9 @@ OPTIONS
 -v, --verbose
   Output result
 
+-S, --summary
+  Show a summary of WAL record counts grouped by resource manager
+
 -V, --version
   Display version information
 

--- a/doc/manual/dev-08-wal.md
+++ b/doc/manual/dev-08-wal.md
@@ -40,6 +40,7 @@ Options:
   -x,  --xid         Filter on an XID
   -l,  --limit       Limit number of outputs
   -v,  --verbose     Output result
+  -S,  --summary     Show a summary of WAL record counts grouped by resource manager
   -V,  --version     Display version information
   -m,  --mapping     Provide mappings file for OID translation
   -t,  --translate   Translate OIDs to object names in XLOG records
@@ -234,9 +235,9 @@ pgmoneta_destroy_walfile(wf);
 #### `pgmoneta_describe_walfile`
 
 ```c
-int pgmoneta_describe_walfile(char* path, enum value_type type, char* output, bool quiet, bool color,
+int pgmoneta_describe_walfile(char* path, enum value_type type, FILE* output, bool quiet, bool color,
                               struct deque* rms, uint64_t start_lsn, uint64_t end_lsn, struct deque* xids,
-                              uint32_t limit, char** included_objects);
+                              uint32_t limit, bool summary, char** included_objects);
 ```
 
 ##### Description:
@@ -245,7 +246,7 @@ This function reads a single WAL file at the specified `path`, filters its recor
 ##### Parameters:
 - **path**: Path to the WAL file to be described
 - **type**: Output format type (raw or JSON)
-- **output**: File path for output; if NULL, prints to stdout
+- **output**: File stream for output; if NULL, prints to stdout
 - **quiet**: If true, suppresses detailed output
 - **color**: If true, enables colored output for better readability
 - **rms**: Deque of resource managers to filter on
@@ -253,6 +254,7 @@ This function reads a single WAL file at the specified `path`, filters its recor
 - **end_lsn**: Ending LSN to filter records (0 for no filter)
 - **xids**: Deque of transaction IDs to filter on
 - **limit**: Maximum number of records to output (0 for no limit)
+- **summary**: Show a summary of WAL record counts grouped by resource manager 
 - **included_objects**: Array of object names to filter on (NULL for all objects)
 
 ##### Return:
@@ -263,10 +265,10 @@ This function reads a single WAL file at the specified `path`, filters its recor
 #### `pgmoneta_describe_walfiles_in_directory`
 
 ```c
-int pgmoneta_describe_walfiles_in_directory(char* dir_path, enum value_type type, char* output,
+int pgmoneta_describe_walfiles_in_directory(char* dir_path, enum value_type type, FILE* output,
                                             bool quiet, bool color, struct deque* rms,
                                             uint64_t start_lsn, uint64_t end_lsn, struct deque* xids,
-                                            uint32_t limit, char** included_objects);
+                                            uint32_t limit, bool summary, char** included_objects);
 ```
 
 ##### Description:
@@ -275,7 +277,7 @@ This function processes all WAL files in the directory specified by `dir_path`, 
 ##### Parameters:
 - **dir_path**: Path to the directory containing WAL files
 - **type**: Output format type (raw or JSON)
-- **output**: File path for output; if NULL, prints to stdout
+- **output**: File stream for output; if NULL, prints to stdout
 - **quiet**: If true, suppresses detailed output
 - **color**: If true, enables colored output for better readability
 - **rms**: Deque of resource managers to filter on
@@ -283,6 +285,7 @@ This function processes all WAL files in the directory specified by `dir_path`, 
 - **end_lsn**: Ending LSN to filter records (0 for no filter)
 - **xids**: Deque of transaction IDs to filter on
 - **limit**: Maximum number of records to output (0 for no limit)
+- **summary**: Show a summary of WAL record counts grouped by resource manager
 - **included_objects**: Array of object names to filter on (NULL for all objects)
 
 ##### Return:

--- a/src/include/walfile.h
+++ b/src/include/walfile.h
@@ -135,13 +135,14 @@ pgmoneta_destroy_walfile(struct walfile* wf);
  * @param end_lsn The end LSN
  * @param xids The XIDs
  * @param limit The limit
+ * @param summary is summary enabled
  * @param included_objects The objects to include the wal records for, if NULL, all objects are included
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_describe_walfile(char* path, enum value_type type, char* output, bool quiet, bool color,
+pgmoneta_describe_walfile(char* path, enum value_type type, FILE* output, bool quiet, bool color,
                           struct deque* rms, uint64_t start_lsn, uint64_t end_lsn, struct deque* xids,
-                          uint32_t limit, char** included_objects);
+                          uint32_t limit, bool summary, char** included_objects);
 
 /**
  * Describe WAL files in a directory
@@ -155,13 +156,14 @@ pgmoneta_describe_walfile(char* path, enum value_type type, char* output, bool q
  * @param end_lsn The end LSN
  * @param xids The XIDs
  * @param limit The limit
+ * @param summary is summary enabled
  * @param included_objects The objects to include the wal records for, if NULL, all objects are included
  * @return 0 upon success, otherwise 1
  */
 
 int
-pgmoneta_describe_walfiles_in_directory(char* dir_path, enum value_type type, char* output, bool quiet, bool color,
+pgmoneta_describe_walfiles_in_directory(char* dir_path, enum value_type type, FILE* output, bool quiet, bool color,
                                         struct deque* rms, uint64_t start_lsn, uint64_t end_lsn, struct deque* xids,
-                                        uint32_t limit, char** included_objects);
+                                        uint32_t limit, bool summary, char** included_objects);
 
 #endif //PGMONETA_WALFILE_H

--- a/src/include/walfile/rmgr.h
+++ b/src/include/walfile/rmgr.h
@@ -58,6 +58,7 @@ extern "C" {
 #include <stdint.h>
 
 #define PG_RMGR(symname, name, desc) {name, desc},
+#define PG_RMGR_SUMMARY(symname, name, number_of_records) {name, number_of_records},
 #define RM_MAX_ID           UINT8_MAX
 
 /**
@@ -75,32 +76,24 @@ struct rmgr_data
 };
 
 /**
+ * @struct rmgr_summary
+ * @brief Represents a Resource Manager (RMGR) data structure.
+ *
+ * Fields:
+ * - name: The name of the resource manager.
+ * - number_of_records: A function pointer to the description function for the resource manager.
+ */
+struct rmgr_summary
+{
+   char* name;             /**< The name of the resource manager */
+   int number_of_records;  /**< The number of records of a specific type */
+};
+
+/**
  * Table of resource managers. Each entry corresponds to a specific RMGR identified by an ID.
  */
-struct rmgr_data RmgrTable[RM_MAX_ID + 1] = {
-   PG_RMGR(RM_XLOG_ID, "XLOG", pgmoneta_wal_xlog_desc)
-   PG_RMGR(RM_XACT_ID, "Transaction", pgmoneta_wal_xact_desc)
-   PG_RMGR(RM_SMGR_ID, "Storage", pgmoneta_wal_storage_desc)
-   PG_RMGR(RM_CLOG_ID, "CLOG", pgmoneta_wal_clog_desc)
-   PG_RMGR(RM_DBASE_ID, "Database", pgmoneta_wal_database_desc)
-   PG_RMGR(RM_TBLSPC_ID, "Tablespace", pgmoneta_wal_tablespace_desc)
-   PG_RMGR(RM_MULTIXACT_ID, "MultiXact", pgmoneta_wal_multixact_desc)
-   PG_RMGR(RM_RELMAP_ID, "RelMap", pgmoneta_wal_relmap_desc)
-   PG_RMGR(RM_STANDBY_ID, "Standby", pgmoneta_wal_standby_desc)
-   PG_RMGR(RM_HEAP2_ID, "Heap2", pgmoneta_wal_heap2_desc)
-   PG_RMGR(RM_HEAP_ID, "Heap", pgmoneta_wal_heap_desc)
-   PG_RMGR(RM_BTREE_ID, "Btree", pgmoneta_wal_btree_desc)
-   PG_RMGR(RM_HASH_ID, "Hash", pgmoneta_wal_hash_desc)
-   PG_RMGR(RM_GIN_ID, "Gin", pgmoneta_wal_gin_desc)
-   PG_RMGR(RM_GIST_ID, "Gist", pgmoneta_wal_gist_desc)
-   PG_RMGR(RM_SEQ_ID, "Sequence", pgmoneta_wal_seq_desc)
-   PG_RMGR(RM_SPGIST_ID, "SPGist", pgmoneta_wal_spg_desc)
-   PG_RMGR(RM_BRIN_ID, "BRIN", pgmoneta_wal_brin_desc)
-   PG_RMGR(RM_COMMIT_TS_ID, "CommitTs", pgmoneta_wal_commit_ts_desc)
-   PG_RMGR(RM_REPLORIGIN_ID, "ReplicationOrigin", pgmoneta_wal_replorigin_desc)
-   PG_RMGR(RM_GENERIC_ID, "Generic", pgmoneta_wal_generic_desc)
-   PG_RMGR(RM_LOGICALMSG_ID, "LogicalMessage", pgmoneta_wal_logicalmsg_desc)
-};
+extern struct rmgr_data rmgr_table[RM_MAX_ID + 1];
+extern struct rmgr_summary rmgr_summary_table[RM_MAX_ID + 1];
 
 #ifdef __cplusplus
 }

--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -439,6 +439,16 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
 char*
 pgmoneta_wal_encode_xlog_record(struct decoded_xlog_record* decoded, uint16_t magic_value, char* buffer);
 
+/**
+ * This function tracks the number of WAL records for each resource manager
+ *
+ * @param decoded The decoded WAL record to encode.
+ * @param start_lsn The start LSN
+ * @param end_lsn The end LSN
+ */
+void
+pgmoneta_wal_record_modify_rmgr_occurance(struct decoded_xlog_record* record, uint64_t start_lsn, uint64_t end_lsn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgmoneta/walfile/rmgr.c
+++ b/src/libpgmoneta/walfile/rmgr.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <walfile/rmgr.h>
+
+struct rmgr_data rmgr_table[RM_MAX_ID + 1] = {
+   PG_RMGR(RM_XLOG_ID, "XLOG", pgmoneta_wal_xlog_desc)
+   PG_RMGR(RM_XACT_ID, "Transaction", pgmoneta_wal_xact_desc)
+   PG_RMGR(RM_SMGR_ID, "Storage", pgmoneta_wal_storage_desc)
+   PG_RMGR(RM_CLOG_ID, "CLOG", pgmoneta_wal_clog_desc)
+   PG_RMGR(RM_DBASE_ID, "Database", pgmoneta_wal_database_desc)
+   PG_RMGR(RM_TBLSPC_ID, "Tablespace", pgmoneta_wal_tablespace_desc)
+   PG_RMGR(RM_MULTIXACT_ID, "MultiXact", pgmoneta_wal_multixact_desc)
+   PG_RMGR(RM_RELMAP_ID, "RelMap", pgmoneta_wal_relmap_desc)
+   PG_RMGR(RM_STANDBY_ID, "Standby", pgmoneta_wal_standby_desc)
+   PG_RMGR(RM_HEAP2_ID, "Heap2", pgmoneta_wal_heap2_desc)
+   PG_RMGR(RM_HEAP_ID, "Heap", pgmoneta_wal_heap_desc)
+   PG_RMGR(RM_BTREE_ID, "Btree", pgmoneta_wal_btree_desc)
+   PG_RMGR(RM_HASH_ID, "Hash", pgmoneta_wal_hash_desc)
+   PG_RMGR(RM_GIN_ID, "Gin", pgmoneta_wal_gin_desc)
+   PG_RMGR(RM_GIST_ID, "Gist", pgmoneta_wal_gist_desc)
+   PG_RMGR(RM_SEQ_ID, "Sequence", pgmoneta_wal_seq_desc)
+   PG_RMGR(RM_SPGIST_ID, "SPGist", pgmoneta_wal_spg_desc)
+   PG_RMGR(RM_BRIN_ID, "BRIN", pgmoneta_wal_brin_desc)
+   PG_RMGR(RM_COMMIT_TS_ID, "CommitTs", pgmoneta_wal_commit_ts_desc)
+   PG_RMGR(RM_REPLORIGIN_ID, "ReplicationOrigin", pgmoneta_wal_replorigin_desc)
+   PG_RMGR(RM_GENERIC_ID, "Generic", pgmoneta_wal_generic_desc)
+   PG_RMGR(RM_LOGICALMSG_ID, "LogicalMessage", pgmoneta_wal_logicalmsg_desc)
+};
+
+struct rmgr_summary rmgr_summary_table[RM_MAX_ID + 1] = {
+   PG_RMGR_SUMMARY(RM_XLOG_ID, "XLOG", 0)
+   PG_RMGR_SUMMARY(RM_XACT_ID, "Transaction", 0)
+   PG_RMGR_SUMMARY(RM_SMGR_ID, "Storage", 0)
+   PG_RMGR_SUMMARY(RM_CLOG_ID, "CLOG", 0)
+   PG_RMGR_SUMMARY(RM_DBASE_ID, "Database", 0)
+   PG_RMGR_SUMMARY(RM_TBLSPC_ID, "Tablespace", 0)
+   PG_RMGR_SUMMARY(RM_MULTIXACT_ID, "MultiXact", 0)
+   PG_RMGR_SUMMARY(RM_RELMAP_ID, "RelMap", 0)
+   PG_RMGR_SUMMARY(RM_STANDBY_ID, "Standby", 0)
+   PG_RMGR_SUMMARY(RM_HEAP2_ID, "Heap2", 0)
+   PG_RMGR_SUMMARY(RM_HEAP_ID, "Heap", 0)
+   PG_RMGR_SUMMARY(RM_BTREE_ID, "Btree", 0)
+   PG_RMGR_SUMMARY(RM_HASH_ID, "Hash", 0)
+   PG_RMGR_SUMMARY(RM_GIN_ID, "Gin", 0)
+   PG_RMGR_SUMMARY(RM_GIST_ID, "Gist", 0)
+   PG_RMGR_SUMMARY(RM_SEQ_ID, "Sequence", 0)
+   PG_RMGR_SUMMARY(RM_SPGIST_ID, "SPGist", 0)
+   PG_RMGR_SUMMARY(RM_BRIN_ID, "BRIN", 0)
+   PG_RMGR_SUMMARY(RM_COMMIT_TS_ID, "CommitTs", 0)
+   PG_RMGR_SUMMARY(RM_REPLORIGIN_ID, "ReplicationOrigin", 0)
+   PG_RMGR_SUMMARY(RM_GENERIC_ID, "Generic", 0)
+   PG_RMGR_SUMMARY(RM_LOGICALMSG_ID, "LogicalMessage", 0)
+};


### PR DESCRIPTION
### Work in Progress

#### Changes

- Introduced a new flag `-S` for walinfo summary
- Introduced a new global data structure: `RmgrTableSummary` - a mapping of resource manager and their count in parsed WAL records.
- Before the output stream is created inside the `pgmoneta_describe_walfile`, this PR would create the output stream on the top level (because we want to flush summary at the top level) in `walinfo` process.
- With summary (if `-S`) is enabled only filters accepted are `start_lsn` (`-s`) and `end_lsn` (`-e`), rest all filter flags will be ignored.

#### Usage

`./pgmoenta-walinfo -S </path/to/wal_file>`
or
`./pgmoenta-walinfo -S </path/to/wal_dir>`

@jesperpedersen PTAL