### PR TITLE
[#757] Store the information about maximum block number modified

### DIFF
--- a/src/include/brt.h
+++ b/src/include/brt.h
@@ -107,6 +107,7 @@ typedef struct block_ref_table_entry
 {
    block_ref_table_key key;           /**< The key used to search for the block entry in the ART */
    block_number limit_block;          /**< The limit block for the relation fork */
+   block_number max_block_number;     /**< The maximum block number encoutered */     
    uint32_t nchunks;                  /**< The number of chunks for the relation fork */
    uint16_t* chunk_size;              /**< The size of each chunk in the relation fork */
    uint16_t* chunk_usage;             /**< The number of used entries in each chunk, if a chunk has bitmap representation, the value of chunk_usage for that chunk is MAX_ENTRIES_PER_CHUNK */

--- a/src/libpgmoneta/brt.c
+++ b/src/libpgmoneta/brt.c
@@ -93,6 +93,7 @@ pgmoneta_brt_set_limit_block(block_ref_table* brt, const struct rel_file_locator
    {
       /* No existing entry, set the limit block for this relation block and initialize other fields */
       brt_entry->limit_block = limit_block;
+      brt_entry->max_block_number = -1;
       brt_entry->nchunks = 0;
       brt_entry->chunk_size = NULL;
       brt_entry->chunk_usage = NULL;
@@ -134,6 +135,7 @@ pgmoneta_brt_mark_block_modified(block_ref_table* brt, const struct rel_file_loc
        * than any legal block number. InvalidBlockNumber fits the bill.
        */
       brt_entry->limit_block = InvalidBlockNumber;
+      brt_entry->max_block_number = -1;
       brt_entry->nchunks = 0;
       brt_entry->chunk_size = NULL;
       brt_entry->chunk_usage = NULL;
@@ -593,6 +595,7 @@ brt_mark_block_modified(block_ref_table_entry* entry, block_number blknum)
    unsigned chunkoffset;
    unsigned i;
 
+   entry->max_block_number = MAX(entry->max_block_number, blknum);
    /* get the chunk and offset on which the modified block resides */
    chunkno = blknum / BLOCKS_PER_CHUNK;
    chunkoffset = blknum % BLOCKS_PER_CHUNK;


### PR DESCRIPTION
Need this field to get an idea of total number of segments for a relation file using the formula:
```
segments = max_block_number / rel_seg_size + 1
```

If this field was not present, we have to iterate through the chunks in the BRT entry.

Note: we are not serializing this field and the reason is, on reading a serialized BRT, the field is recalculated on the fly.

@jesperpedersen @Jubilee101 PTAL