### PR TITLE
[#752] Create Incr Backup Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,31 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # Define all possible variables
       matrix:
         compiler: [gcc, clang]
         build_type: [Debug, Release]
+        pg_version: [14, 15, 17]
+        # Exclude the unwanted v14 combinations
+        exclude:
+          - pg_version: 14
+            compiler: gcc
+            build_type: Debug
+          - pg_version: 14
+            compiler: gcc
+            build_type: Release
+          - pg_version: 14
+            compiler: clang
+            build_type: Release
+          - pg_version: 15
+            compiler: gcc
+            build_type: Debug
+          - pg_version: 15
+            compiler: gcc
+            build_type: Release
+          - pg_version: 15
+            compiler: clang
+            build_type: Release
       fail-fast: false
 
     steps:
@@ -35,19 +57,31 @@ jobs:
           python3-docutils libbz2-dev libarchive-dev \
           bzip2 net-tools check libyaml-dev llvm
 
-      - name: Install PostgreSQL
+      - name: Install PostgreSQL v${{ matrix.pg_version }}
         run: |
           sudo apt install curl ca-certificates
           sudo install -d /usr/share/postgresql-common/pgdg
           sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
           sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt update
-          sudo apt install -y postgresql-17
+          sudo apt install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
 
       - name: Set Env Path Variable
         run: |
-          echo "PATH=$PATH:/usr/lib/postgresql/17/bin" >> $GITHUB_ENV
+          echo "PATH=/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH" >> $GITHUB_ENV
           echo $PATH
+
+      - name: Install pgmoneta_ext
+        run: |
+          git_repo="https://github.com/pgmoneta/pgmoneta_ext.git"
+          cd /tmp/
+          git clone --branch "main" --single-branch --depth 1 "$git_repo"
+          cd /tmp/pgmoneta_ext/
+          mkdir build
+          cd /tmp/pgmoneta_ext/build/
+          cmake -DDOCS=false ..
+          make
+          sudo make install
 
       - name: Build Project
         run: |
@@ -64,6 +98,7 @@ jobs:
 
       - name: Run Tests
         run: |
+          export TEST_PG_VERSION=${{ matrix.pg_version }}
           if [ "${{ matrix.compiler }}" = "clang" ] && [ "${{ matrix.build_type }}" = "Debug" ]; then
             $(which bash) ./test/check.sh ci
           fi
@@ -73,7 +108,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports-${{ matrix.compiler }}-${{ matrix.build_type }}
+          name: coverage-reports-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ matrix.pg_version }}
           path: /tmp/pgmoneta-test/coverage
           retention-days: 90
 
@@ -81,7 +116,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ matrix.compiler }}-${{ matrix.build_type }}
+          name: logs-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ matrix.pg_version }}
           path: /tmp/pgmoneta-test/log
           retention-days: 90
 

--- a/doc/manual/en/80-server-api.md
+++ b/doc/manual/en/80-server-api.md
@@ -28,7 +28,7 @@ You can checkout the list of all pre-defined roles available in PostgreSQL 17 [h
 
 **pgmoneta_server_info**
 
-Fetch trivial information about a configured postgres server like:
+Fetch trivial information about a configured PostgreSQL server like:
 - PostgreSQL version of the server
 - status of checksums (enabled/disabled)
 - type of server (primary/non-primary)
@@ -120,3 +120,30 @@ Privileges:
 - Default (all PostgreSQL versions)
 
 Note: connection user must be granted `EXECUTE` privilege on the function `pg_stat_file(text, boolean)`
+
+**pgmoneta_server_backup_start**
+
+Accepts a backup label as input and invokes `do_pg_backup_start()` internally, this marks the onset of a backup. It returns a LSN which represents the starting point of backup.
+
+Privileges:
+- Default (for all PostgreSQL 14+)
+
+Note: connection user must be granted `EXECUTE` privilege on the function `pg_backup_start(text, boolean)` for PostgreSQL version 15+ and `pg_start_backup(text, boolean, boolean)` for PostgreSQL version < 15.
+
+**pgmoneta_server_backup_stop**
+
+Invokes `do_pg_backup_stop()` internally, this marks the end of a backup, that was previously started. It returns a LSN which represents the ending point of backup and also the contents of a `backup_label` file.
+
+Label file contents (returned by this API):
+- START WAL LOCATION
+- CHECKPOINT LOCATION
+- BACKUP METHOD
+- BACKUP FROM
+- LABEL
+- START TIMELINE
+- START TIME
+
+Privileges:
+- Default (for all PostgreSQL 14+)
+
+Note: connection user must be granted `EXECUTE` privilege on the function `pg_backup_stop(boolean)` for PostgreSQL version 15+ and `pg_stop_backup(boolean, boolean)` for PostgreSQL version < 15.

--- a/src/include/manifest.h
+++ b/src/include/manifest.h
@@ -35,6 +35,7 @@ extern "C" {
 
 #include <pgmoneta.h>
 #include <art.h>
+#include <backup.h>
 #include <json.h>
 
 #define MANIFEST_CHUNK_SIZE 8192
@@ -90,6 +91,37 @@ pgmoneta_compare_manifests(char* old_manifest, char* new_manifest, struct art** 
  */
 int
 pgmoneta_write_postgresql_manifest(struct json* manifest, char* path);
+
+/**
+ * Generate the manifest in memory (json format)
+ * @param version The manifest file version
+ * @param system_id The system identifier, an optional parameter for manifest version 2 and above
+ * @param backup_data The data directory
+ * @param backup The backup related to the manifest
+ * @param manifest [out] The json manifest generated
+ * @return 0 on success, otherwise 1
+ */
+int
+pgmoneta_generate_manifest(int version, uint64_t system_id, char* backup_data, struct backup* bck, struct json** manifest);
+
+/**
+ * Get the manifest record of a file
+ * @param path The system path of the file
+ * @param manifest_path The path to be used in manifest record entry
+ * @param file [out] The json returning the manifest record
+ * @return 0 on success, otherwise 1
+ */
+int
+pgmoneta_get_file_manifest(char* path, char* manifest_path, struct json** file);
+
+/**
+ * Generate the files manifest (in json format)
+ * @param path The path to walk for manifest creation
+ * @param files The json to append results
+ * @return 0 if success, otherwise 1
+ */
+int
+pgmoneta_generate_files_manifest(char* path, struct json* files);
 
 #ifdef __cplusplus
 }

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -174,11 +174,13 @@ pgmoneta_server_start_backup(int srv, SSL* ssl, int socket, char* label, char** 
  * @param srv The server index
  * @param ssl The SSL connection
  * @param socket The socket
- * @param label The backup label
+ * @param bl_dir The directory where the file must be generated
+ * @param lsn [out] The stop backup lsn
+ * @param lf [out] The label file contents
  * @return return 0 if success, otherwise failure
  */
 int
-pgmoneta_server_stop_backup(int srv, SSL* ssl, int socket, char** lsn, struct label_file_contents* lf);
+pgmoneta_server_stop_backup(int srv, SSL* ssl, int socket, char* bl_dir, char** lsn, struct label_file_contents* lf);
 
 #ifdef __cplusplus
 }

--- a/src/include/workflow_funcs.h
+++ b/src/include/workflow_funcs.h
@@ -47,6 +47,13 @@ struct workflow*
 pgmoneta_create_basebackup(void);
 
 /**
+ * Create a workflow for the incremental backup
+ * @return The workflow
+ */
+struct workflow*
+pgmoneta_create_incremental_backup(void);
+
+/**
  * Create a workflow for the restore
  * @return The workflow
  */

--- a/src/libpgmoneta/backup.c
+++ b/src/libpgmoneta/backup.c
@@ -134,7 +134,7 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
    if (incremental != NULL)
    {
       backup_incremental = false;
-      if (config->common.servers[server].version < 17)
+      if (config->common.servers[server].version < 14)
       {
          pgmoneta_log_error("Incremental backup not supported for server %s at version %d",
                             config->common.servers[server].name, config->common.servers[server].version);
@@ -302,6 +302,9 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
    exit(0);
 
 error:
+
+   config->common.servers[server].active_backup = false;
+   atomic_store(&config->common.servers[server].repository, false);
 
    pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
                                       ec != -1 ? ec : MANAGEMENT_ERROR_BACKUP_ERROR,

--- a/src/libpgmoneta/extension.c
+++ b/src/libpgmoneta/extension.c
@@ -76,7 +76,7 @@ int
 pgmoneta_ext_get_files(SSL* ssl, int socket, char* file_path, struct query_response** qr)
 {
    char query[MAX_QUERY_LENGTH];
-   snprintf(query, MAX_QUERY_LENGTH, "SELECT pgmoneta_ext_get_files('%s');", file_path);
+   snprintf(query, MAX_QUERY_LENGTH, "SELECT * FROM pgmoneta_ext_get_files('%s');", file_path);
    return query_execute(ssl, socket, query, qr);
 }
 

--- a/src/libpgmoneta/walfile.c
+++ b/src/libpgmoneta/walfile.c
@@ -681,7 +681,14 @@ pgmoneta_summarize_walfiles(char* dir_path, uint64_t start_lsn, uint64_t end_lsn
 
    for (int i = 0; i < file_count; i++)
    {
-      snprintf(file_path, MAX_PATH, "%s/%s", dir_path, files[i]);
+      if (!pgmoneta_ends_with(dir_path, "/"))
+      {
+         snprintf(file_path, MAX_PATH, "%s/%s", dir_path, files[i]);
+      }
+      else
+      {
+         snprintf(file_path, MAX_PATH, "%s%s", dir_path, files[i]);
+      }
 
       if (pgmoneta_summarize_walfile(file_path, start_lsn, end_lsn, brt))
       {

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -1,0 +1,1872 @@
+/*
+ * Copyright (C) 2025 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* pgmoneta */
+#include <pgmoneta.h>
+#include <achv.h>
+#include <backup.h>
+#include <extension.h>
+#include <json.h>
+#include <logging.h>
+#include <manifest.h>
+#include <memory.h>
+#include <message.h>
+#include <network.h>
+#include <security.h>
+#include <server.h>
+#include <tablespace.h>
+#include <utils.h>
+#include <walfile/wal_reader.h>
+#include <walfile/wal_summary.h>
+#include <workflow.h>
+
+/* system */
+#include <assert.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SPCOID_PG_DEFAULT 1663
+#define SPCOID_PG_GLOBAL 1664
+
+/* fetch/compute these from server configuration inside create workflow */
+size_t block_size;       // size of each block (default 8KB)
+size_t segment_size;     // segment size
+size_t rel_seg_size;     // number of blocks in a segment
+size_t wal_segment_size; // wal segment size
+
+static int send_upload_manifest(SSL* ssl, int socket);
+static int upload_manifest(SSL* ssl, int socket, char* path);
+/**
+ * Handle incremental backup for PostgreSQL version 17+
+ */
+static int incr_backup_execute_17_plus(char* name __attribute__((unused)), struct art* nodes);
+/**
+ * Handle incremental backup for PostgreSQL version 14-16
+ */
+static int incr_backup_execute_14_to_16(char* name __attribute__((unused)), struct art* nodes);
+/**
+ * Get the size of the incremental file
+ */
+static size_t get_incremental_file_size(uint32_t num_incr_blocks);
+/**
+ * Get the size of the header of incremental file
+ */
+static size_t get_incremental_header_size(uint32_t num_incr_blocks);
+/**
+ * Comparator for block number
+ */
+static int compare_block_numbers(const void* a, const void* b);
+/**
+ * Given a relative file path, derive the rlocator, fork number and segment number, also create
+ * necessary directories
+ */
+static int parse_relation_file(char* backup_data, char* rel_file_path, struct rel_file_locator* rlocator, enum fork_number* frk, int* segno);
+/**
+ * Create standard directories inside data directory of backup, returns a set of paths of all the files
+ * inside server data directory
+ */
+static int create_standard_directories(SSL* ssl, int socket, char* backup_data, char*** paths, int* count);
+static char** get_paths(char* backup_data, struct query_response* data, int* count);
+/**
+ * free an array of string
+ */
+static void free_string_array(char** arr, int count);
+/**
+ * add additional fields for incremental backup in backup_label
+ */
+static int add_incremental_label_fields(char* label_file_path, char* prev_data);
+/**
+ * Serialize the incremental blocks for a relation file
+ */
+static int write_incremental_file(int server, SSL* ssl, int socket, char* backup_data,
+                                  char* relative_filename, uint32_t num_incr_blocks,
+                                  block_number* incr_blocks, uint32_t truncation_block_length, bool empty);
+/**
+ * Serialize all the blocks for a relation file
+ */
+static int write_full_file(int server, SSL* ssl, int socket, char* backup_data,
+                           char* relative_filename, size_t expected_size);
+/**
+ * Append padding (0 bytes) to the file stream
+ */
+static int write_padding(FILE* file, size_t padding_length, size_t* bytes_written);
+/**
+ * copy the wal files from the archive, the idea is copy only wal files that are generated between
+ * the backup was started and ended
+ */
+static int copy_wal_from_archive(char* start_wal_file, char* wal_dir, char* backup_data);
+/*
+ * Wait until the WAL segment file appears in the wal archive directory
+ */
+static int wait_for_wal_switch(char* wal_dir, char* wal_file);
+static char* incr_backup_name(void);
+static int incr_backup_execute(char*, struct art*);
+
+struct workflow*
+pgmoneta_create_incremental_backup(void)
+{
+   struct workflow* wf = NULL;
+
+   wf = (struct workflow*)malloc(sizeof(struct workflow));
+
+   if (wf == NULL)
+   {
+      return NULL;
+   }
+
+   wf->name = &incr_backup_name;
+   wf->setup = &pgmoneta_common_setup;
+   wf->execute = &incr_backup_execute;
+   wf->teardown = &pgmoneta_common_teardown;
+   wf->next = NULL;
+
+   return wf;
+}
+
+static char*
+incr_backup_name(void)
+{
+   return "Incremental backup";
+}
+
+static int
+incr_backup_execute_14_to_16(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server = -1;
+   char* label = NULL;
+   struct timespec start_t;
+   struct timespec end_t;
+   char* backup_base = NULL;
+   char* backup_data = NULL;
+   char* backup_label = NULL;
+   char* server_backup = NULL;
+   char* incremental = NULL;
+   char* incremental_label = NULL;
+   int usr;
+   char* tag = NULL;
+   char* wal = NULL;
+   SSL* ssl = NULL;
+   int socket = -1;
+   double incr_backup_elapsed_time;
+   int hours;
+   int minutes;
+   double seconds;
+   char elapsed[128];
+   char version[10];
+   char minor_version[10];
+   unsigned int size;
+   uint64_t biggest_file_size;
+   char* prev_backup_data = NULL;
+   char* wal_dir = NULL;
+   char* chkpt_lsn = NULL;
+   uint64_t prev_backup_chkpt_lsn = 0;
+   uint64_t start_backup_lsn = 0;
+   char* start_backup_xlog = NULL;
+   char* stop_backup_xlog = NULL;
+   struct label_file_contents lf = {0};
+   uint32_t stop_tli = 0;
+   block_ref_table* summarized_brt = NULL;
+   char* start_wal_filename = NULL;
+   int num_incr_blocks = 0;
+   block_number* incr_blocks = NULL;
+   uint32_t truncation_block_length = 0;
+
+   block_ref_table_entry* brtentry = NULL;
+   block_number start_blk = 0;
+   block_number end_blk = 0;
+
+   int segno = 0;
+   struct rel_file_locator rlocator = {0};
+   enum fork_number frk = MAIN_FORKNUM;
+   struct file_stats fs = {0};
+
+   struct backup* backup = NULL;
+   struct main_configuration* config;
+
+   struct message* msg = NULL;
+   struct query_response* response = NULL;
+   char** server_files = NULL;
+   int num_of_server_files = 0;
+
+   config = (struct main_configuration*)shmem;
+
+#ifdef DEBUG
+   pgmoneta_dump_art(nodes);
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
+   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP));
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP_BASE));
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP_DATA));
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_BACKUP));
+#endif
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+   backup = (struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP);
+   backup_base = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_BASE);
+   backup_data = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_DATA);
+   server_backup = (char*)pgmoneta_art_search(nodes, NODE_SERVER_BACKUP);
+
+   pgmoneta_log_debug("Incremental backup (execute): %s", config->common.servers[server].name, label);
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+#endif
+
+   incremental = (char*)pgmoneta_art_search(nodes, NODE_INCREMENTAL_BASE);
+   incremental_label = (char*)pgmoneta_art_search(nodes, NODE_INCREMENTAL_LABEL);
+
+   if (incremental == NULL || incremental_label == NULL)
+   {
+      pgmoneta_log_error("Incremental label is required for incremental backup");
+      goto error;
+   }
+
+   pgmoneta_memory_init();
+
+   usr = -1;
+   // find the corresponding user's index of the given server
+   for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
+   {
+      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      {
+         usr = i;
+      }
+   }
+   // establish a connection, with replication flag set
+   if (pgmoneta_server_authenticate(server, "postgres", config->common.users[usr].username, config->common.users[usr].password, false, &ssl, &socket) != AUTH_SUCCESS)
+   {
+      pgmoneta_log_info("Invalid credentials for %s", config->common.users[usr].username);
+      goto error;
+   }
+
+   if (!pgmoneta_server_valid(server))
+   {
+      pgmoneta_server_info(server, ssl, socket);
+
+      if (!pgmoneta_server_valid(server))
+      {
+         goto error;
+      }
+   }
+   memset(version, 0, sizeof(version));
+   snprintf(version, sizeof(version), "%d", config->common.servers[server].version);
+   memset(minor_version, 0, sizeof(minor_version));
+   snprintf(minor_version, sizeof(minor_version), "%d", config->common.servers[server].minor_version);
+
+   block_size = config->common.servers[server].block_size;
+   segment_size = config->common.servers[server].segment_size;
+   rel_seg_size = config->common.servers[server].relseg_size;
+   wal_segment_size = config->common.servers[server].wal_size;
+
+   /* Get the checkpoint information of the preceding backup using backup_label */
+   prev_backup_data = pgmoneta_get_server_backup_identifier_data(server, incremental_label);
+   pgmoneta_read_checkpoint_info(prev_backup_data, &chkpt_lsn);
+
+   prev_backup_chkpt_lsn = pgmoneta_string_to_lsn(chkpt_lsn);
+
+   tag = pgmoneta_append(tag, "pgmoneta_");
+   tag = pgmoneta_append(tag, label);
+
+   /* Start Backup */
+   if (pgmoneta_server_start_backup(server, ssl, socket, tag, &start_backup_xlog))
+   {
+      pgmoneta_log_error("Incremental backup couldn't start");
+      goto error;
+   }
+   start_backup_lsn = pgmoneta_string_to_lsn(start_backup_xlog);
+
+   wal_dir = pgmoneta_get_server_wal(server);
+
+   /* Do WAL Summarization */
+   if (pgmoneta_summarize_wal(server, wal_dir, prev_backup_chkpt_lsn, start_backup_lsn, &summarized_brt))
+   {
+      pgmoneta_log_error("WAL summation for incremental backup failed");
+      goto error;
+   }
+
+   pgmoneta_mkdir(backup_data);
+   if (create_standard_directories(ssl, socket, backup_data, &server_files, &num_of_server_files))
+   {
+      pgmoneta_log_error("Incremental backup: Failed to creating standard directories");
+      goto error;
+   }
+
+   for (int i = 0; i < num_of_server_files; i++)
+   {
+      block_number limit_block = InvalidBlockNumber;
+
+      if (pgmoneta_starts_with(server_files[i], "pg_wal"))
+      {
+         continue;
+      }
+
+      /* handle other files and directories */
+      if (!pgmoneta_starts_with(server_files[i], "base") && !pgmoneta_starts_with(server_files[i], "global"))
+      {
+         // full backup
+         if (write_full_file(server, ssl, socket, backup_data, server_files[i], 0))
+         {
+            pgmoneta_log_error("Incremental backup: Error during backup of: %s", server_files[i]);
+            goto error;
+         }
+         continue;
+      }
+
+      /* handle base and global directories */
+      if (pgmoneta_ends_with(server_files[i], "pg_internal.init"))   // ignore this file for backup
+      {
+         continue;
+      }
+
+      if (pgmoneta_ends_with(server_files[i], "pg_filenode.map") || pgmoneta_ends_with(server_files[i], "PG_VERSION") || pgmoneta_ends_with(server_files[i], "pg_control"))
+      {
+         /* undergo full backup */
+         if (write_full_file(server, ssl, socket, backup_data, server_files[i], 0))
+         {
+            pgmoneta_log_error("Incremental backup: Error during backup of: %s", server_files[i]);
+            goto error;
+         }
+         continue;
+      }
+
+      /* parse the relation file */
+      if (parse_relation_file(backup_data, server_files[i], &rlocator, &frk, &segno))
+      {
+         pgmoneta_log_error("Incremental backup: Unable to parse: %s", server_files[i]);
+         goto error;
+      }
+
+      /* find the file stat */
+      if (pgmoneta_server_file_stat(server, ssl, socket, server_files[i], &fs))
+      {
+         pgmoneta_log_error("Incremental backup: Error getting stats for %s", server_files[i]);
+         goto error;
+      }
+
+      /* file size is not multiple of block size */
+      if (fs.size % block_size != 0)
+      {
+         if (write_full_file(server, ssl, socket, backup_data, server_files[i], fs.size))
+         {
+            pgmoneta_log_error("Incremental backup: Error doing backup of %s", server_files[i]);
+            goto error;
+         }
+         continue;
+      }
+
+      /*
+          The free-space map fork is not properly WAL-logged,  so we need to backup the
+          entire file every time.
+       */
+      if (frk == FSM_FORKNUM)
+      {
+         if (write_full_file(server, ssl, socket, backup_data, server_files[i], fs.size))
+         {
+            pgmoneta_log_error("Incremental backup: Error during backup of %s", server_files[i]);
+            goto error;
+         }
+         continue;
+      }
+
+      /* check if the brtentry for this path is available */
+      brtentry = pgmoneta_brt_get_entry(summarized_brt, &rlocator, frk, &limit_block);
+
+      /*
+          If no entry exists, it means the relation hasn’t had any WAL-recorded
+          modifications since the previous backup. In that case, we can include it
+          as part of the incremental backup without copying any changed blocks.
+
+          However, if the file’s size is zero, we should perform a full backup
+          instead. Incremental files are never empty, and creating an incremental
+          backup would actually be larger than a full one in this scenario.
+       */
+      if (brtentry == NULL)
+      {
+         if (fs.size == 0)
+         {
+            if (write_full_file(server, ssl, socket, backup_data, server_files[i], fs.size))
+            {
+               pgmoneta_log_error("Incremental backup: Error during backup of %s", server_files[i]);
+               goto error;
+            }
+            continue;
+         }
+
+         num_incr_blocks = 0;
+         truncation_block_length = fs.size / block_size;
+         if (write_incremental_file(server, ssl, socket, backup_data, server_files[i],
+                                    num_incr_blocks, NULL, truncation_block_length, true))
+         {
+            goto error;
+         }
+
+         continue;
+      }
+
+      /*
+          Sometimes the smgr manager cuts the relation file to a block boundary, which means
+          all the blocks beyond that cut are truncated/chopped. If that cut lies in a segment
+          backup it fully
+       */
+      if (limit_block <= segno * rel_seg_size)
+      {
+         if (write_full_file(server, ssl, socket, backup_data, server_files[i], fs.size))
+         {
+            pgmoneta_log_error("Incremental backup: Error during backup of %s", server_files[i]);
+            goto error;
+         }
+         continue;
+      }
+
+      start_blk = segno * rel_seg_size;
+      end_blk = start_blk + rel_seg_size;
+
+      if (start_blk / rel_seg_size != (size_t)segno || end_blk < start_blk)
+      {
+         pgmoneta_log_error("Incremental backup: Overflow computing block number bounds for segment %u with size %zu", segno, fs.size);
+         goto error;
+      }
+
+      incr_blocks = (block_number*)malloc(rel_seg_size * sizeof(block_number));
+      if (pgmoneta_brt_entry_get_blocks(brtentry, start_blk, end_blk, incr_blocks, rel_seg_size, &num_incr_blocks))
+      {
+         pgmoneta_log_error("Incremental backup: Error getting modified blocks from BRT entry");
+         goto error;
+      }
+
+      /*
+          sort the blocks numbers and translate the absolute block numbers to relative
+       */
+      qsort(incr_blocks, num_incr_blocks, sizeof(block_number), compare_block_numbers);
+      if (start_blk != 0)
+      {
+         for (int i = 0; i < num_incr_blocks; i++)
+         {
+            incr_blocks[i] -= start_blk;
+         }
+      }
+
+      /*
+          Calculate truncation length which is minimum length of the reconstructed file. Any
+          block numbers below this threshold that are not present in the backup need to be
+          fetched from the prior backup.
+       */
+      truncation_block_length = fs.size / block_size;
+      if (brtentry->limit_block != InvalidBlockNumber)
+      {
+         uint32_t relative_limit = brtentry->limit_block - segno * rel_seg_size;
+         if (truncation_block_length < relative_limit)
+         {
+            truncation_block_length = relative_limit;
+         }
+      }
+
+      /* serialize the incremental changes */
+      if (write_incremental_file(server, ssl, socket, backup_data, server_files[i],
+                                 num_incr_blocks, incr_blocks, truncation_block_length, false))
+      {
+         goto error;
+      }
+      free(incr_blocks);
+      incr_blocks = NULL;
+   }
+
+   /* Stop Backup */
+   if (pgmoneta_server_stop_backup(server, ssl, socket, backup_data, &stop_backup_xlog, &lf))
+   {
+      pgmoneta_log_error("Incremental backup: Couldn't stop backup because checkpoint failed");
+      goto error;
+   }
+
+   /* Get stop timeline id */
+   pgmoneta_create_query_message("SELECT timeline_id FROM pg_control_checkpoint();", &msg);
+   if (pgmoneta_query_execute(ssl, socket, msg, &response) || response == NULL || response->number_of_columns != 1)
+   {
+      goto error;
+   }
+
+   stop_tli = pgmoneta_atoi(pgmoneta_query_response_get_data(response, 0));
+
+   /* copy wal */
+   start_wal_filename = pgmoneta_wal_file_name(lf.start_tli, start_backup_lsn / wal_segment_size, wal_segment_size);
+
+   /* wait for start_wal_file to get switched */
+   if (wait_for_wal_switch(wal_dir, start_wal_filename))
+   {
+      pgmoneta_log_error("Error during WAL switch for %s", start_wal_filename);
+      goto error;
+   }
+
+   if (copy_wal_from_archive(start_wal_filename, wal_dir, backup_data))
+   {
+      pgmoneta_log_error("Incremental backup: Error copying WAL from archive");
+      goto error;
+   }
+
+   /* add additional fields to backup_label */
+   backup_label = pgmoneta_append(backup_label, backup_data);
+   backup_label = pgmoneta_append(backup_label, "backup_label");
+
+   if (add_incremental_label_fields(backup_label, prev_backup_data))
+   {
+      goto error;
+   }
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+#endif
+
+   incr_backup_elapsed_time = pgmoneta_compute_duration(start_t, end_t);
+   hours = (int)incr_backup_elapsed_time / 3600;
+   minutes = ((int)incr_backup_elapsed_time % 3600) / 60;
+   seconds = (int)incr_backup_elapsed_time % 60 + (incr_backup_elapsed_time - ((long)incr_backup_elapsed_time));
+
+   memset(&elapsed[0], 0, sizeof(elapsed));
+   sprintf(&elapsed[0], "%02i:%02i:%.4f", hours, minutes, seconds);
+
+   size = pgmoneta_directory_size(backup_data);
+   biggest_file_size = pgmoneta_biggest_file(backup_data);
+
+   pgmoneta_log_debug("Incremental: %s/%s (Elapsed: %s)", config->common.servers[server].name, label, &elapsed[0]);
+
+   pgmoneta_read_wal(backup_data, &wal);
+
+   backup->valid = VALID_TRUE;
+   snprintf(backup->label, sizeof(backup->label), "%s", label);
+   backup->number_of_tablespaces = 0;
+   backup->compression = config->compression_type;
+   backup->encryption = config->encryption;
+   snprintf(backup->wal, sizeof(backup->wal), "%s", wal);
+   backup->restore_size = size;
+   backup->biggest_file_size = biggest_file_size;
+   backup->major_version = atoi(version);
+   backup->minor_version = atoi(minor_version);
+   backup->keep = false;
+
+   sscanf(start_backup_xlog, "%X/%X", &backup->start_lsn_hi32, &backup->start_lsn_lo32);
+   sscanf(stop_backup_xlog, "%X/%X", &backup->end_lsn_hi32, &backup->end_lsn_lo32);
+   backup->start_timeline = lf.start_tli;
+   backup->end_timeline = stop_tli;
+   backup->basebackup_elapsed_time = incr_backup_elapsed_time;
+   backup->type = TYPE_INCREMENTAL;
+   snprintf(backup->parent_label, sizeof(backup->parent_label), "%s", incremental_label);
+   sscanf(lf.checkpoint_lsn, "%X/%X", &backup->checkpoint_lsn_hi32, &backup->checkpoint_lsn_lo32);
+
+   if (pgmoneta_save_info(server_backup, backup))
+   {
+      pgmoneta_log_error("Incremental backup: Could not save backup %s", label);
+      goto error;
+   }
+
+   pgmoneta_close_ssl(ssl);
+   if (socket != -1)
+   {
+      pgmoneta_disconnect(socket);
+   }
+   free_string_array(server_files, num_of_server_files);
+
+   free(chkpt_lsn);
+   free(backup_label);
+   free(start_backup_xlog);
+   free(stop_backup_xlog);
+   free(wal_dir);
+   free(wal);
+   free(tag);
+   free(start_wal_filename);
+   free(prev_backup_data);
+   pgmoneta_free_message(msg);
+   pgmoneta_free_query_response(response);
+   pgmoneta_brt_destroy(summarized_brt);
+   pgmoneta_memory_destroy();
+   return 0;
+
+error:
+   if (backup_base == NULL)
+   {
+      backup_base = pgmoneta_get_server_backup_identifier(server, label);
+   }
+
+   if (pgmoneta_exists(backup_base))
+   {
+      pgmoneta_delete_directory(backup_base);
+   }
+
+   pgmoneta_close_ssl(ssl);
+   if (socket != -1)
+   {
+      pgmoneta_disconnect(socket);
+   }
+   free_string_array(server_files, num_of_server_files);
+
+   free(chkpt_lsn);
+   free(backup_label);
+   free(start_backup_xlog);
+   free(stop_backup_xlog);
+   free(incr_blocks);
+   free(wal_dir);
+   free(wal);
+   free(tag);
+   free(start_wal_filename);
+   free(prev_backup_data);
+   pgmoneta_free_message(msg);
+   pgmoneta_free_query_response(response);
+   pgmoneta_brt_destroy(summarized_brt);
+   pgmoneta_memory_destroy();
+   return 1;
+}
+
+static int
+incr_backup_execute_17_plus(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server = -1;
+   char* label = NULL;
+   struct timespec start_t;
+   struct timespec end_t;
+   int status;
+   char* backup_base = NULL;
+   char* backup_data = NULL;
+   char* server_backup = NULL;
+   unsigned long size = 0;
+   int usr;
+   SSL* ssl = NULL;
+   int socket = -1;
+   double basebackup_elapsed_time;
+   int hours;
+   int minutes;
+   double seconds;
+   char elapsed[128];
+   char* tag = NULL;
+   char* incremental = NULL;
+   char* incremental_label = NULL;
+   char* manifest_path = NULL;
+   char version[10];
+   char minor_version[10];
+   char* wal = NULL;
+   char startpos[20];
+   char endpos[20];
+   char* chkptpos = NULL;
+   uint32_t start_timeline = 0;
+   uint32_t end_timeline = 0;
+   char old_label_path[MAX_PATH];
+   int backup_max_rate;
+   int network_max_rate;
+   uint64_t biggest_file_size;
+   struct main_configuration* config;
+   struct message* basebackup_msg = NULL;
+   struct message* tablespace_msg = NULL;
+   struct stream_buffer* buffer = NULL;
+   struct query_response* response = NULL;
+   struct tablespace* tablespaces = NULL;
+   struct tablespace* current_tablespace = NULL;
+   struct tuple* tup = NULL;
+   struct token_bucket* bucket = NULL;
+   struct token_bucket* network_bucket = NULL;
+   struct backup* backup = NULL;
+
+   config = (struct main_configuration*)shmem;
+
+   #ifdef DEBUG
+   pgmoneta_dump_art(nodes);
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
+   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP));
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP_BASE));
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP_DATA));
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_BACKUP));
+   #endif
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+   backup = (struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP);
+   backup_base = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_BASE);
+   backup_data = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_DATA);
+   server_backup = (char*)pgmoneta_art_search(nodes, NODE_SERVER_BACKUP);
+
+   pgmoneta_log_debug("Incremental backup (execute): %s", config->common.servers[server].name, label);
+
+   #ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+   #else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+   #endif
+
+   incremental = (char*)pgmoneta_art_search(nodes, NODE_INCREMENTAL_BASE);
+   incremental_label = (char*)pgmoneta_art_search(nodes, NODE_INCREMENTAL_LABEL);
+
+   if (incremental == NULL || incremental_label == NULL)
+   {
+      pgmoneta_log_error("Incremental label is required for incremental backup");
+      goto error;
+   }
+
+   pgmoneta_memory_init();
+
+   backup_max_rate = pgmoneta_get_backup_max_rate(server);
+   if (backup_max_rate)
+   {
+      bucket = (struct token_bucket*)malloc(sizeof(struct token_bucket));
+      if (pgmoneta_token_bucket_init(bucket, backup_max_rate))
+      {
+         pgmoneta_log_error("Failed to initialize the token bucket for backup");
+         goto error;
+      }
+   }
+
+   network_max_rate = pgmoneta_get_network_max_rate(server);
+   if (network_max_rate)
+   {
+      network_bucket = (struct token_bucket*)malloc(sizeof(struct token_bucket));
+      if (pgmoneta_token_bucket_init(network_bucket, network_max_rate))
+      {
+         pgmoneta_log_error("Failed to initialize the network token bucket for backup");
+         goto error;
+      }
+   }
+   usr = -1;
+   // find the corresponding user's index of the given server
+   for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
+   {
+      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      {
+         usr = i;
+      }
+   }
+   // establish a connection, with replication flag set
+   if (pgmoneta_server_authenticate(server, "postgres", config->common.users[usr].username, config->common.users[usr].password, false, &ssl, &socket) != AUTH_SUCCESS)
+   {
+      pgmoneta_log_info("Invalid credentials for %s", config->common.users[usr].username);
+      goto error;
+   }
+
+   if (!pgmoneta_server_valid(server))
+   {
+      pgmoneta_server_info(server, ssl, socket);
+
+      if (!pgmoneta_server_valid(server))
+      {
+         goto error;
+      }
+   }
+   memset(version, 0, sizeof(version));
+   snprintf(version, sizeof(version), "%d", config->common.servers[server].version);
+   memset(minor_version, 0, sizeof(minor_version));
+   snprintf(minor_version, sizeof(minor_version), "%d", config->common.servers[server].minor_version);
+
+   pgmoneta_create_query_message("SELECT spcname, pg_tablespace_location(oid) FROM pg_tablespace;", &tablespace_msg);
+   if (pgmoneta_query_execute(ssl, socket, tablespace_msg, &response) || response == NULL)
+   {
+      goto error;
+   }
+
+   tup = response->tuples;
+   while (tup != NULL)
+   {
+      char* tablespace_name = tup->data[0];
+      char* tablespace_path = tup->data[1];
+
+      if (tablespace_name != NULL && tablespace_path != NULL)
+      {
+         pgmoneta_log_debug("tablespace_name: %s", tablespace_name);
+         pgmoneta_log_debug("tablespace_path: %s", tablespace_path);
+
+         if (tablespaces == NULL)
+         {
+            pgmoneta_create_tablespace(tablespace_name, tablespace_path, &tablespaces);
+         }
+         else
+         {
+            struct tablespace* append = NULL;
+
+            pgmoneta_create_tablespace(tablespace_name, tablespace_path, &append);
+            pgmoneta_append_tablespace(&tablespaces, append);
+         }
+      }
+      tup = tup->next;
+   }
+   pgmoneta_free_query_response(response);
+   response = NULL;
+   pgmoneta_close_ssl(ssl);
+   pgmoneta_disconnect(socket);
+
+   if (pgmoneta_server_authenticate(server, "postgres", config->common.users[usr].username, config->common.users[usr].password, true, &ssl, &socket) != AUTH_SUCCESS)
+   {
+      pgmoneta_log_info("Invalid credentials for %s", config->common.users[usr].username);
+      goto error;
+   }
+
+   pgmoneta_memory_stream_buffer_init(&buffer);
+
+   // send UPLOAD_MANIFEST
+   if (send_upload_manifest(ssl, socket))
+   {
+      pgmoneta_log_error("Fail to send UPLOAD_MANIFEST to server %s", config->common.servers[server].name);
+      goto error;
+   }
+   manifest_path = pgmoneta_append(NULL, incremental);
+   manifest_path = pgmoneta_append(manifest_path, "data/backup_manifest");
+   if (upload_manifest(ssl, socket, manifest_path))
+   {
+      pgmoneta_log_error("Fail to upload manifest to server %s", config->common.servers[server].name);
+      goto error;
+   }
+   // receive and ignore the result set for UPLOAD_MANIFEST
+   if (pgmoneta_consume_data_row_messages(server, ssl, socket, buffer, &response))
+   {
+      goto error;
+   }
+   pgmoneta_free_query_response(response);
+   response = NULL;
+
+   tag = pgmoneta_append(tag, "pgmoneta_");
+   tag = pgmoneta_append(tag, label);
+
+   pgmoneta_create_base_backup_message(config->common.servers[server].version, true, tag, true,
+                                       config->compression_type, config->compression_level,
+                                       &basebackup_msg);
+
+   status = pgmoneta_write_message(ssl, socket, basebackup_msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   // Receive the first result set, which contains the WAL starting point
+   if (pgmoneta_consume_data_row_messages(server, ssl, socket, buffer, &response))
+   {
+      goto error;
+   }
+   memset(startpos, 0, sizeof(startpos));
+   memcpy(startpos, response->tuples[0].data[0], strlen(response->tuples[0].data[0]));
+   start_timeline = atoi(response->tuples[0].data[1]);
+   pgmoneta_free_query_response(response);
+   response = NULL;
+
+   pgmoneta_mkdir(backup_base);
+
+   if (pgmoneta_receive_archive_stream(server, ssl, socket, buffer, backup_base, tablespaces, bucket, network_bucket))
+   {
+      pgmoneta_log_error("Incremental backup: Could not backup %s", config->common.servers[server].name);
+
+      backup->valid = VALID_FALSE;
+      snprintf(backup->label, sizeof(backup->label), "%s", label);
+      if (pgmoneta_save_info(server_backup, backup))
+      {
+         pgmoneta_log_error("Incremental backup: Could not save backup %s", label);
+         goto error;
+      }
+
+      goto error;
+   }
+
+   // Receive the final result set, which contains the WAL ending point
+   if (pgmoneta_consume_data_row_messages(server, ssl, socket, buffer, &response))
+   {
+      goto error;
+   }
+   memset(endpos, 0, sizeof(endpos));
+   memcpy(endpos, response->tuples[0].data[0], strlen(response->tuples[0].data[0]));
+   end_timeline = atoi(response->tuples[0].data[1]);
+   pgmoneta_free_query_response(response);
+   response = NULL;
+
+   // remove backup_label.old if it exists
+   memset(old_label_path, 0, MAX_PATH);
+   if (pgmoneta_ends_with(backup_base, "/"))
+   {
+      snprintf(old_label_path, MAX_PATH, "%sdata/%s", backup_base, "backup_label.old");
+   }
+   else
+   {
+      snprintf(old_label_path, MAX_PATH, "%s/data/%s", backup_base, "backup_label.old");
+   }
+
+   if (pgmoneta_exists(old_label_path))
+   {
+      if (pgmoneta_exists(old_label_path))
+      {
+         pgmoneta_delete_file(old_label_path, NULL);
+      }
+      else
+      {
+         pgmoneta_log_debug("%s doesn't exists", old_label_path);
+      }
+   }
+
+   // receive and ignore the last result set, it's just a summary
+   pgmoneta_consume_data_row_messages(server, ssl, socket, buffer, &response);
+
+   #ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+   #else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+   #endif
+
+   basebackup_elapsed_time = pgmoneta_compute_duration(start_t, end_t);
+   hours = (int)basebackup_elapsed_time / 3600;
+   minutes = ((int)basebackup_elapsed_time % 3600) / 60;
+   seconds = (int)basebackup_elapsed_time % 60 + (basebackup_elapsed_time - ((long)basebackup_elapsed_time));
+
+   memset(&elapsed[0], 0, sizeof(elapsed));
+   sprintf(&elapsed[0], "%02i:%02i:%.4f", hours, minutes, seconds);
+
+   pgmoneta_log_debug("Incremental Backup: %s/%s (Elapsed: %s)", config->common.servers[server].name, label, &elapsed[0]);
+
+   if (pgmoneta_backup_size(server, label, &size, &biggest_file_size))
+   {
+      pgmoneta_log_error("Incremental Backup: Could not get incremental size for %s", config->common.servers[server].name);
+      goto error;
+   }
+   pgmoneta_read_wal(backup_data, &wal);
+   pgmoneta_read_checkpoint_info(backup_data, &chkptpos);
+
+   backup->valid = VALID_TRUE;
+   snprintf(backup->label, sizeof(backup->label), "%s", label);
+   backup->number_of_tablespaces = 0;
+   backup->compression = config->compression_type;
+   backup->encryption = config->encryption;
+   snprintf(backup->wal, sizeof(backup->wal), "%s", wal);
+   backup->restore_size = size;
+   backup->biggest_file_size = biggest_file_size;
+   backup->major_version = atoi(version);
+   backup->minor_version = atoi(minor_version);
+   backup->keep = false;
+   sscanf(startpos, "%X/%X", &backup->start_lsn_hi32, &backup->start_lsn_lo32);
+   sscanf(endpos, "%X/%X", &backup->end_lsn_hi32, &backup->end_lsn_lo32);
+   backup->start_timeline = start_timeline;
+   backup->end_timeline = end_timeline;
+   backup->basebackup_elapsed_time = basebackup_elapsed_time;
+
+   backup->type = TYPE_INCREMENTAL;
+   snprintf(backup->parent_label, sizeof(backup->parent_label), "%s", incremental_label);
+
+   // in case of parsing error
+   if (chkptpos != NULL)
+   {
+      sscanf(chkptpos, "%X/%X", &backup->checkpoint_lsn_hi32, &backup->checkpoint_lsn_lo32);
+   }
+
+   current_tablespace = tablespaces;
+   backup->number_of_tablespaces = 0;
+
+   while (current_tablespace != NULL && backup->number_of_tablespaces < MAX_NUMBER_OF_TABLESPACES)
+   {
+      int i = backup->number_of_tablespaces;
+
+      snprintf(backup->tablespaces[i], sizeof(backup->tablespaces[i]), "tblspc_%s", current_tablespace->name);
+      snprintf(backup->tablespaces_oids[i], sizeof(backup->tablespaces_oids[i]), "%u", current_tablespace->oid);
+      snprintf(backup->tablespaces_paths[i], sizeof(backup->tablespaces_paths[i]), "%s", current_tablespace->path);
+
+      backup->number_of_tablespaces++;
+      current_tablespace = current_tablespace->next;
+   }
+
+   if (pgmoneta_save_info(server_backup, backup))
+   {
+      pgmoneta_log_error("Backup: Could not save backup %s", label);
+      goto error;
+   }
+   pgmoneta_close_ssl(ssl);
+   if (socket != -1)
+   {
+      pgmoneta_disconnect(socket);
+   }
+   pgmoneta_memory_destroy();
+   pgmoneta_memory_stream_buffer_free(buffer);
+   pgmoneta_free_tablespaces(tablespaces);
+   pgmoneta_free_message(basebackup_msg);
+   pgmoneta_free_message(tablespace_msg);
+   pgmoneta_free_query_response(response);
+   pgmoneta_token_bucket_destroy(bucket);
+   pgmoneta_token_bucket_destroy(network_bucket);
+   free(manifest_path);
+   free(chkptpos);
+   free(tag);
+   free(wal);
+
+   return 0;
+
+error:
+
+   if (backup_base == NULL)
+   {
+      backup_base = pgmoneta_get_server_backup_identifier(server, label);
+   }
+
+   if (pgmoneta_exists(backup_base))
+   {
+      pgmoneta_delete_directory(backup_base);
+   }
+
+   pgmoneta_close_ssl(ssl);
+   if (socket != -1)
+   {
+      pgmoneta_disconnect(socket);
+   }
+   pgmoneta_memory_destroy();
+   pgmoneta_memory_stream_buffer_free(buffer);
+   pgmoneta_free_message(tablespace_msg);
+   pgmoneta_free_tablespaces(tablespaces);
+   pgmoneta_free_message(basebackup_msg);
+   pgmoneta_free_query_response(response);
+   pgmoneta_token_bucket_destroy(bucket);
+   pgmoneta_token_bucket_destroy(network_bucket);
+   free(manifest_path);
+   free(chkptpos);
+   free(tag);
+   free(wal);
+
+   return 1;
+}
+
+static int
+incr_backup_execute(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server = -1;
+   struct main_configuration* config = NULL;
+
+   config = (struct main_configuration*)shmem;
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+
+   if (config->common.servers[server].version < 17)
+   {
+      return incr_backup_execute_14_to_16(name, nodes);
+   }
+   else
+   {
+      return incr_backup_execute_17_plus(name, nodes);
+   }
+}
+
+static size_t
+get_incremental_header_size(uint32_t num_incr_blocks)
+{
+   size_t result;
+
+   /*
+      compute header size
+      (magic_number, truncation block length, block count) followed by block numbers
+    */
+   result = 3 * sizeof(uint32_t) + (sizeof(block_number) * num_incr_blocks);
+   /* round the header to a multiple of Block Size */
+   if ((num_incr_blocks > 0) && (result % block_size != 0))
+   {
+      result += block_size - (result % block_size);
+   }
+
+   return result;
+}
+
+static size_t
+get_incremental_file_size(uint32_t num_incr_blocks)
+{
+   size_t result;
+
+   result = get_incremental_header_size(num_incr_blocks);
+   result += block_size * num_incr_blocks;
+
+   return result;
+}
+
+static int
+compare_block_numbers(const void* a, const void* b)
+{
+   block_number aa = *(block_number*)a;
+   block_number bb = *(block_number*)b;
+
+   if (aa < bb)
+   {
+      return -1;
+   }
+   else if (aa > bb)
+   {
+      return 1;
+   }
+   return 0;
+}
+
+static int
+create_standard_directories(SSL* ssl, int socket, char* backup_data, char*** p, int* c)
+{
+   struct query_response* qr = NULL;
+   char** paths = NULL;
+   int count = 0;
+
+   /* get all the paths */
+   pgmoneta_ext_get_files(ssl, socket, ".", &qr);
+   if (qr != NULL && qr->number_of_columns == 3)
+   {
+      paths = get_paths(backup_data, qr, &count);
+   }
+   else
+   {
+      pgmoneta_log_warn("Retrieving extra files: Query failed");
+      goto error;
+   }
+
+   *p = paths;
+   *c = count;
+
+   pgmoneta_free_query_response(qr);
+   return 0;
+error:
+   if (paths)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(paths[i]);
+      }
+      free(paths);
+   }
+   pgmoneta_free_query_response(qr);
+   return 1;
+}
+
+static void
+free_string_array(char** arr, int count)
+{
+   if (arr)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(arr[i]);
+      }
+      free(arr);
+      arr = NULL;
+   }
+}
+
+static int
+add_incremental_label_fields(char* label_file_path, char* prev_data)
+{
+   char label[MAX_PATH];
+   char read_buffer[MAX_PATH];
+   char* write_buffer = NULL;
+   FILE* label_file = NULL;
+   FILE* prev_label_file = NULL;
+
+   memset(label, 0, MAX_PATH);
+   snprintf(label, MAX_PATH, "%s/backup_label", prev_data);
+
+   label_file = fopen(label_file_path, "a");
+   if (label_file == NULL)
+   {
+      pgmoneta_log_error("Unable to open backup_label file: %s", label_file_path);
+      goto error;
+   }
+
+   prev_label_file = fopen(label, "r");
+   if (prev_label_file == NULL)
+   {
+      pgmoneta_log_error("Unable to open backup_label file: %s", label);
+      goto error;
+   }
+   while (fgets(read_buffer, sizeof(read_buffer), prev_label_file) != NULL)
+   {
+      if (pgmoneta_starts_with(read_buffer, "START WAL LOCATION"))
+      {
+         char buf[MAX_PATH];
+
+         memset(buf, 0, sizeof(buf));
+         if (sscanf(read_buffer, "START WAL LOCATION: %s\n", buf) != 1)
+         {
+            pgmoneta_log_error("Error parsing start wal location");
+            goto error;
+         }
+
+         write_buffer = pgmoneta_append(write_buffer, "INCREMENTAL FROM LSN: ");
+         write_buffer = pgmoneta_append(write_buffer, buf);
+         write_buffer = pgmoneta_append(write_buffer, "\n");
+
+         if (fwrite(write_buffer, 1, strlen(write_buffer), label_file) <= 0)
+         {
+            pgmoneta_log_error("Error writing line to: %s", label_file_path);
+            goto error;
+         }
+         free(write_buffer);
+         write_buffer = NULL;
+      }
+      if (pgmoneta_starts_with(read_buffer, "START TIMELINE"))
+      {
+         char buf[MAX_PATH];
+
+         memset(buf, 0, sizeof(buf));
+         if (sscanf(read_buffer, "START TIMELINE: %s\n", buf) != 1)
+         {
+            pgmoneta_log_error("Error parsing start timeline");
+            goto error;
+         }
+
+         write_buffer = pgmoneta_append(write_buffer, "INCREMENTAL FROM TLI: ");
+         write_buffer = pgmoneta_append(write_buffer, buf);
+         write_buffer = pgmoneta_append(write_buffer, "\n");
+
+         if (fwrite(write_buffer, 1, strlen(write_buffer), label_file) <= 0)
+         {
+            pgmoneta_log_error("Error writing line to: %s", label_file_path);
+            goto error;
+         }
+         free(write_buffer);
+         write_buffer = NULL;
+      }
+      memset(read_buffer, 0, sizeof(read_buffer));
+   }
+
+   fclose(label_file);
+   fclose(prev_label_file);
+   return 0;
+error:
+   if (label_file)
+   {
+      fclose(label_file);
+   }
+   if (prev_label_file)
+   {
+      fclose(prev_label_file);
+   }
+   free(write_buffer);
+   return 1;
+}
+
+static int
+parse_relation_file(char* backup_data, char* rel_file_path, struct rel_file_locator* r, enum fork_number* f, int* s)
+{
+   char** results = NULL;
+   int count = 0;
+   char* base_directory_path = NULL;
+   char* relation_file = NULL;
+   struct rel_file_locator rlocator = {0};
+   enum fork_number frk = MAIN_FORKNUM;
+   int segno = 0;
+
+   /* split the file path */
+   if (pgmoneta_split(rel_file_path, &results, &count, '/'))
+   {
+      pgmoneta_log_error("Cannot split the file: %s with delimiter '/'", rel_file_path);
+      goto error;
+   }
+
+   if (count < 2)
+   {
+      pgmoneta_log_error("Invalid relation path: %s", rel_file_path);
+      goto error;
+   }
+
+   if (!strcmp(results[0], "base"))
+   {
+      /*
+          Parse the database path
+
+          file_format: base/<dboid>/<relation_file_format>
+       */
+      if (count < 3)
+      {
+         pgmoneta_log_error("Invalid base relation path: %s", rel_file_path);
+         goto error;
+      }
+
+      rlocator.spcOid = SPCOID_PG_DEFAULT;
+      rlocator.dbOid = pgmoneta_atoi(results[1]);
+      relation_file = pgmoneta_append(relation_file, results[2]);
+
+      /* create directory */
+      base_directory_path = pgmoneta_append(base_directory_path, backup_data);
+      base_directory_path = pgmoneta_append(base_directory_path, "/base/");
+      base_directory_path = pgmoneta_append(base_directory_path, results[1]);
+
+      pgmoneta_mkdir(base_directory_path);
+   }
+   else if (!strcmp(results[0], "global"))
+   {
+      rlocator.spcOid = SPCOID_PG_GLOBAL;
+      rlocator.dbOid = 0;
+      relation_file = pgmoneta_append(relation_file, results[1]);
+   }
+   else
+   {
+      // do nothing
+      goto done;
+   }
+
+   free_string_array(results, count);
+   /*
+       Parse the relation file
+
+       relation_file_format: <relation_file_oid>_<fork_identifier>.<segment_number>
+
+       - fork_identifier: tells us about the variant of the relation file (heap/index)
+           - main data file
+           - free space map file (`_fsm`)
+           - visibility map file (`_vm`)
+           - init file (`_init`)
+
+       - segment_number: When a table or index exceeds 1 GB, it is divided into
+       gigabyte-sized segments. The first segment's file name is the same as the filenode;
+       subsequent segments are named filenode.1, filenode.2, etc. This arrangement avoids
+       problems on platforms that have file size limitations.
+    */
+
+   /* parse seg number */
+   if (pgmoneta_split(relation_file, &results, &count, '.'))
+   {
+      pgmoneta_log_error("Cannot split the file: %s with delimiter '.'", rel_file_path);
+      goto error;
+   }
+
+   if (count == 2)
+   {
+      segno = pgmoneta_atoi(results[1]);
+   }
+   free(relation_file);
+   relation_file = NULL;
+
+   relation_file = pgmoneta_append(relation_file, results[0]);
+
+   /* parse forknumber */
+   free_string_array(results, count);
+
+   if (pgmoneta_split(relation_file, &results, &count, '_'))
+   {
+      pgmoneta_log_error("Cannot split the file: %s with delimiter '_'", rel_file_path);
+      goto error;
+   }
+
+   if (count == 2)
+   {
+      if (!strcmp(results[1], "fsm"))
+      {
+         frk = FSM_FORKNUM;
+      }
+      else if (!strcmp(results[1], "vm"))
+      {
+         frk = VISIBILITYMAP_FORKNUM;
+      }
+      else if (!strcmp(results[1], "init"))
+      {
+         frk = INIT_FORKNUM;
+      }
+      else
+      {
+         pgmoneta_log_error("Invalid fork number: %s encountered", results[1]);
+         goto error;
+      }
+   }
+
+   rlocator.relNumber = pgmoneta_atoi(results[0]);
+
+   *r = rlocator;
+   *f = frk;
+   *s = segno;
+done:
+   free_string_array(results, count);
+   free(relation_file);
+   free(base_directory_path);
+   return 0;
+error:
+   free_string_array(results, count);
+   free(relation_file);
+   free(base_directory_path);
+   return 1;
+}
+
+static int
+write_incremental_file(int server, SSL* ssl, int socket, char* backup_data,
+                       char* relative_filename, uint32_t num_incr_blocks,
+                       block_number* incr_blocks, uint32_t truncation_block_length, bool empty)
+{
+   FILE* file = NULL;
+   size_t expected_file_size;
+   uint32_t magic = INCREMENTAL_MAGIC;
+   char* filepath = NULL;
+   char* file_name = NULL;
+   char* rel_path = NULL;
+   size_t padding_length = 0;
+   size_t padding_bytes = 0;
+   block_number blkno;
+   size_t bytes_written = 0;
+   uint8_t* binary_data = NULL;
+   int binary_data_length = 0;
+
+   /* preprocessing of incremental filename */
+   rel_path = pgmoneta_append(rel_path, relative_filename);
+   rel_path = dirname(rel_path);
+   file_name = pgmoneta_append(file_name, rel_path + strlen(rel_path) + 1);
+
+   filepath = pgmoneta_append(filepath, backup_data);
+   filepath = pgmoneta_append(filepath, rel_path);
+   if (!pgmoneta_ends_with(filepath, "/"))
+   {
+      filepath = pgmoneta_append(filepath, "/");
+   }
+   filepath = pgmoneta_append(filepath, INCREMENTAL_PREFIX);
+   filepath = pgmoneta_append(filepath, file_name);
+
+   /* Open the file in write mode, if not present create one */
+   file = fopen(filepath, "w+");
+   if (file == NULL)
+   {
+      pgmoneta_log_error("Write incremental file: failed to open the file at %s", relative_filename);
+      goto error;
+   }
+
+   /* Write the file header */
+   bytes_written += fwrite(&magic, sizeof(magic), 1, file);
+   bytes_written += fwrite(&num_incr_blocks, sizeof(num_incr_blocks), 1, file);
+   bytes_written += fwrite(&truncation_block_length, sizeof(truncation_block_length), 1, file);
+
+   if (empty)
+   {
+      goto done;
+   }
+
+   bytes_written += fwrite(incr_blocks, sizeof(block_number), num_incr_blocks, file);
+
+   if ((num_incr_blocks > 0) && (bytes_written % block_size != 0))
+   {
+      padding_length = (block_size - (bytes_written % block_size));
+      if (write_padding(file, padding_length, &padding_bytes))
+      {
+         goto error;
+      }
+      bytes_written += padding_bytes;
+   }
+
+   if (bytes_written != get_incremental_header_size(num_incr_blocks))
+   {
+      pgmoneta_log_error("Write incremental file: failed to open the file at %s", relative_filename);
+      goto error;
+   }
+
+   expected_file_size = get_incremental_file_size(num_incr_blocks);
+   /*
+       Request the blocks from the server
+
+       Assume the incremental block array is sorted, also note that we may have to consider
+       the filename with their segment number, which can be determined using the block number
+       segment_number = block_number / (# of blocks in each segment)
+
+       Will try to fetch untill either we get all the blocks (from server) with block number
+       provided by the caller or request failed due to side effects like concurrent truncation.
+    */
+   for (uint32_t i = 0; i < num_incr_blocks; i++)
+   {
+      blkno = incr_blocks[i];
+
+      if (pgmoneta_server_read_binary_file(server, ssl, relative_filename,
+                                           block_size * blkno, block_size, socket, &binary_data, &binary_data_length))
+      {
+         pgmoneta_log_error("Write incremental file: error fetching the block#%d of file: %s from the server", blkno, relative_filename);
+         goto error;
+      }
+
+      /*
+          If partial read, means the relation is truncated after the incremental workflow has started.
+          Not to worry, just fill all the blocks including this one with 0, untill we wrote the number
+           of bytes expected by caller, WAL replay will take care of it later.
+       */
+      if ((size_t)binary_data_length < block_size)
+      {
+         free(binary_data);
+         break;
+      }
+
+      bytes_written += fwrite(binary_data, sizeof(uint8_t), binary_data_length, file);
+      /* read/write content must be of multiple of block size length */
+      if (bytes_written % block_size)
+      {
+         pgmoneta_log_error("Write incremental file: partial write/read");
+         goto error;
+      }
+
+      free(binary_data);
+   }
+
+   /* Handle truncation, by padding with 0 */
+   padding_length = expected_file_size - bytes_written;
+   if (write_padding(file, padding_length, &padding_bytes))
+   {
+      goto error;
+   }
+   bytes_written += padding_bytes;
+
+done:
+   free(filepath);
+   free(file_name);
+   free(rel_path);
+   fclose(file);
+   return 0;
+
+error:
+   free(binary_data);
+   free(filepath);
+   free(file_name);
+   free(rel_path);
+   fclose(file);
+   return 1;
+}
+
+static int
+write_full_file(int server, SSL* ssl, int socket, char* backup_data,
+                char* relative_filename, size_t expected_size)
+{
+   FILE* file = NULL;
+   size_t chunk_size = block_size * 1024;
+   size_t offset = 0;
+   char* filepath = NULL;
+   uint8_t* binary_data = NULL;
+   int binary_data_length = 0;
+   size_t bytes_written = 0;
+
+   if (expected_size % block_size)
+   {
+      pgmoneta_log_error("expected size: %ld is not block aligned for file: %s", expected_size, relative_filename);
+      goto error;
+   }
+
+   filepath = pgmoneta_append(filepath, backup_data);
+   filepath = pgmoneta_append(filepath, relative_filename);
+   /* Open the file in write mode, if not present create one */
+   file = fopen(filepath, "w+");
+   if (file == NULL)
+   {
+      pgmoneta_log_error("Write full file: failed to open the file at %s", relative_filename);
+      goto error;
+   }
+
+   while (true)
+   {
+      if (pgmoneta_server_read_binary_file(server, ssl, relative_filename, offset, chunk_size,
+                                           socket, &binary_data, &binary_data_length))
+      {
+         goto error;
+      }
+
+      /* EOF */
+      if (binary_data_length == 0)
+      {
+         free(binary_data);
+         break;
+      }
+
+      /* write the output */
+      bytes_written = fwrite(binary_data, sizeof(uint8_t), binary_data_length, file);
+      if (bytes_written != (size_t)binary_data_length)
+      {
+         goto error;
+      }
+
+      offset += binary_data_length;
+      free(binary_data);
+   }
+
+   free(filepath);
+   fclose(file);
+   return 0;
+error:
+   free(binary_data);
+   free(filepath);
+   fclose(file);
+   return 1;
+}
+
+static int
+write_padding(FILE* file, size_t padding_length, size_t* bw)
+{
+   size_t bytes_written = 0;
+   size_t chunk;
+   size_t written;
+
+   /* Use a fixed-size zero buffer to minimize syscalls */
+   char zero_byte_buf[DEFAULT_BURST] = {0};
+
+   while (padding_length > 0)
+   {
+      chunk = padding_length < DEFAULT_BURST ? padding_length : DEFAULT_BURST;
+
+      written = fwrite(zero_byte_buf, 1, chunk, file);
+      if (written != chunk)
+      {
+         pgmoneta_log_error("Write incremental file: failed to write padding to file");
+         goto error;
+      }
+
+      bytes_written += written;
+      padding_length -= written;
+   }
+
+   *bw = bytes_written;
+
+   return 0;
+error:
+   return 1;
+}
+
+static char**
+get_paths(char* backup_data, struct query_response* response, int* c)
+{
+   char** paths = NULL;
+   int count = 0;
+   int idx = 0;
+   char* dest_path = NULL;
+   struct tuple* tuple = NULL;
+
+   if (response == NULL || response->number_of_columns != 3)
+   {
+      goto error;
+   }
+
+   /* count the number of server file and create any directory along the way */
+   tuple = response->tuples;
+   while (tuple != NULL)
+   {
+      if (pgmoneta_compare_string(tuple->data[1], "f"))
+      {
+         count++;
+      }
+      else
+      {
+         /* create the directory */
+         dest_path = pgmoneta_append(dest_path, backup_data);
+
+         if (pgmoneta_starts_with(tuple->data[0], "./"))
+         {
+            dest_path = pgmoneta_append(dest_path, tuple->data[0] + 2);
+         }
+         else
+         {
+            dest_path = pgmoneta_append(dest_path, tuple->data[0]);
+         }
+
+         if (pgmoneta_mkdir(dest_path))
+         {
+            pgmoneta_log_error("error creating directory: %s", dest_path);
+            goto error;
+         }
+
+         free(dest_path);
+         dest_path = NULL;
+      }
+      tuple = tuple->next;
+   }
+
+   paths = (char**)calloc(count + 1, sizeof(char*));
+
+   /* get the server files */
+   tuple = response->tuples;
+   while (tuple != NULL && idx < count)
+   {
+      if (pgmoneta_compare_string(tuple->data[1], "f"))
+      {
+         if (pgmoneta_starts_with(tuple->data[0], "./"))
+         {
+            dest_path = pgmoneta_append(dest_path, tuple->data[0] + 2);
+         }
+         else
+         {
+            dest_path = pgmoneta_append(dest_path, tuple->data[0]);
+         }
+
+         paths[idx++] = dest_path;
+         dest_path = NULL;
+      }
+      tuple = tuple->next;
+   }
+
+   *c = count;
+
+   return paths;
+error:
+   free(dest_path);
+   return NULL;
+}
+
+static int
+copy_wal_from_archive(char* start_wal_file, char* wal_dir, char* backup_data)
+{
+   char* pg_wal_dir = NULL;
+   char* dst_file = NULL;
+   char* src_file = NULL;
+
+   pg_wal_dir = pgmoneta_append(pg_wal_dir, backup_data);
+   if (!pgmoneta_ends_with(pg_wal_dir, "/"))
+   {
+      pg_wal_dir = pgmoneta_append_char(pg_wal_dir, '/');
+   }
+   pg_wal_dir = pgmoneta_append(pg_wal_dir, "pg_wal/");
+
+   int num_files = 0;
+   char** files = NULL;
+
+   if (pgmoneta_get_wal_files(wal_dir, &num_files, &files))
+   {
+      pgmoneta_log_warn("Unable to get WAL segments under %s", wal_dir);
+      goto error;
+   }
+
+   for (int i = 0; i < num_files; i++)
+   {
+      if (strcmp(files[i], start_wal_file) >= 0)
+      {
+         dst_file = pgmoneta_append(dst_file, pg_wal_dir);
+         dst_file = pgmoneta_append(dst_file, files[i]);
+         src_file = pgmoneta_append(src_file, wal_dir);
+         src_file = pgmoneta_append(src_file, files[i]);
+
+         // copy and extract
+         if (pgmoneta_copy_and_extract_file(src_file, &dst_file))
+         {
+            goto error;
+         }
+
+         free(dst_file);
+         free(src_file);
+         dst_file = NULL;
+         src_file = NULL;
+      }
+      free(files[i]);
+   }
+
+   free(files);
+   free(pg_wal_dir);
+   return 0;
+error:
+   for (int i = 0; i < num_files; i++)
+   {
+      free(files[i]);
+   }
+   free(files);
+   free(dst_file);
+   free(src_file);
+   free(pg_wal_dir);
+   return 1;
+}
+
+static int
+wait_for_wal_switch(char* wal_dir, char* wal_file)
+{
+   int loop = 1;
+   int num_files = 0;
+   char** files = NULL;
+
+   while (loop)
+   {
+      files = NULL;
+      if (pgmoneta_get_wal_files(wal_dir, &num_files, &files))
+      {
+         pgmoneta_log_warn("Unable to get WAL segments under %s", wal_dir);
+         goto error;
+      }
+      for (int i = 0; i < num_files; i++)
+      {
+         if (strcmp(files[i], wal_file) == 0)
+         {
+            loop = 0;
+         }
+         free(files[i]);
+      }
+      free(files);
+      SLEEP(1); // avoid wasting CPU cycles for searching
+   }
+
+   return 0;
+error:
+   for (int i = 0; i < num_files; i++)
+   {
+      free(files[i]);
+   }
+   free(files);
+   return 1;
+}
+
+static int
+send_upload_manifest(SSL* ssl, int socket)
+{
+   struct message* msg = NULL;
+   int status;
+   pgmoneta_create_query_message("UPLOAD_MANIFEST", &msg);
+   status = pgmoneta_write_message(ssl, socket, msg);
+   if (status != MESSAGE_STATUS_OK)
+   {
+      goto error;
+   }
+
+   pgmoneta_free_message(msg);
+   return 0;
+
+error:
+   pgmoneta_free_message(msg);
+   return 1;
+}
+
+static int
+upload_manifest(SSL* ssl, int socket, char* path)
+{
+   FILE* manifest = NULL;
+   size_t nbytes = 0;
+   char buffer[65536];
+
+   manifest = fopen(path, "r");
+   if (manifest == NULL)
+   {
+      pgmoneta_log_error("Upload manifest: failed to open manifest file at %s", path);
+      goto error;
+   }
+   while ((nbytes = fread(buffer, 1, sizeof(buffer), manifest)) > 0)
+   {
+      if (pgmoneta_send_copy_data(ssl, socket, buffer, nbytes))
+      {
+         pgmoneta_log_error("Upload manifest: failed to send copy data");
+         goto error;
+      }
+   }
+   if (pgmoneta_send_copy_done_message(ssl, socket))
+   {
+      goto error;
+   }
+
+   if (manifest != NULL)
+   {
+      fclose(manifest);
+   }
+   return 0;
+
+error:
+   if (manifest != NULL)
+   {
+      fclose(manifest);
+   }
+   return 1;
+}

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -737,7 +737,7 @@ wf_incremental_backup(void)
 
    config = (struct main_configuration*)shmem;
 
-   head = pgmoneta_create_basebackup();
+   head = pgmoneta_create_incremental_backup();
    current = head;
 
    current->next = pgmoneta_create_manifest();

--- a/test/postgresql/src/postgresql14/Dockerfile
+++ b/test/postgresql/src/postgresql14/Dockerfile
@@ -1,0 +1,82 @@
+ # Copyright (C) 2025 The pgmoneta community
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice, this list
+ # of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice, this
+ # list of conditions and the following disclaimer in the documentation and/or other
+ # materials provided with the distribution.
+ #
+ # 3. Neither the name of the copyright holder nor the names of its contributors may
+ # be used to endorse or promote products derived from this software without specific
+ # prior written permission.
+ #
+ # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ # OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ # THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ # OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM rockylinux:9
+
+LABEL maintainer="Jesper Pedersen <jesperpedersen.db@gmail.com>"
+
+LABEL summary="PostgreSQL 14" \
+      description="PostgreSQL 14"
+
+ENV PGVERSION="14"
+ENV PGROOT="/usr/pgsql-${PGVERSION}"
+ENV PATH="/usr/pgsql-${PGVERSION}/bin:$PATH"
+ENV EXTENSION_NAME="pgmoneta_ext"
+ENV GITHUB_REPO="https://github.com/pgmoneta/pgmoneta_ext.git"
+
+# Base installation from the template
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN dnf -y install --nogpgcheck --allowerasing https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf -qy --nogpgcheck module disable postgresql
+RUN dnf -y upgrade
+RUN dnf install -y dnf-plugins-core
+RUN dnf config-manager --set-enabled crb
+RUN dnf makecache
+
+# Install dependencies
+RUN dnf -y install git gcc cmake make postgresql14-devel
+RUN dnf -y install procps wget iputils net-tools
+RUN dnf -y install postgresql14 postgresql14-server postgresql14-contrib postgresql14-libs 
+
+# Build and Install pgmoneta_ext
+WORKDIR /tmp/pg_extension
+RUN git clone --depth 1 ${GITHUB_REPO}
+WORKDIR /tmp/pg_extension/${EXTENSION_NAME}
+
+RUN mkdir build
+WORKDIR /tmp/pg_extension/${EXTENSION_NAME}/build
+RUN cmake -DDOCS=false ..
+RUN make
+RUN make install
+
+RUN rm -rf /tmp/pg_extension
+RUN dnf --nogpgcheck clean all
+
+WORKDIR /
+RUN rm -Rf /conf /pgconf /pgdata /pgwal
+COPY root/ /
+RUN mkdir -p /conf /pgconf /pgdata /pgwal /pglog
+COPY conf/* /conf/
+RUN chown -R postgres:postgres /conf /pgconf /pgdata /pgwal /pglog
+RUN chmod 700 /conf /pgconf /pgdata /pgwal
+RUN chmod +x /usr/bin/run-postgresql
+RUN mkdir -p /usr/local/bin
+
+EXPOSE 5432
+
+USER 26
+
+CMD ["/usr/bin/run-postgresql"]

--- a/test/postgresql/src/postgresql14/Makefile
+++ b/test/postgresql/src/postgresql14/Makefile
@@ -1,0 +1,48 @@
+# Copyright (C) 2025 The pgmoneta community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+IMAGE_SHORT_NAME = pgmoneta-test-postgresql14
+IMAGE_NAME = pgmoneta-test-postgresql14-rocky9
+CONTAINER_ENGINE := $(shell \
+	if command -v podman >/dev/null 2>&1; then echo podman; \
+	elif command -v docker >/dev/null 2>&1; then echo "sudo docker"; \
+	else echo "Neither Docker nor Podman is installed" >&2; exit 1; \
+	fi)
+
+.PHONY: all build clean
+
+all:
+	make clean
+	make build
+
+build:
+	# Detect container engine: Docker or Podman
+	$(CONTAINER_ENGINE) build --no-cache -t $(IMAGE_NAME) .
+
+clean:
+	$(CONTAINER_ENGINE) stop $(IMAGE_SHORT_NAME) 2>/dev/null || true
+	$(CONTAINER_ENGINE) rm -f $(IMAGE_SHORT_NAME) 2>/dev/null || true
+	$(CONTAINER_ENGINE) rmi -f $(IMAGE_NAME) 2>/dev/null || true

--- a/test/postgresql/src/postgresql14/conf/pg_hba.conf
+++ b/test/postgresql/src/postgresql14/conf/pg_hba.conf
@@ -1,0 +1,6 @@
+local   all             all                                       trust
+local   replication     all                                       trust
+host    PG_DATABASE     PG_USER_NAME         all                  trust
+local   postgres        PG_REPL_USER_NAME                         md5
+host    postgres        PG_REPL_USER_NAME    all                  md5
+host    replication     PG_REPL_USER_NAME    all                  md5

--- a/test/postgresql/src/postgresql14/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql14/conf/postgresql.conf
@@ -1,0 +1,843 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'		# use data in another directory
+					# (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'		# what IP address(es) to listen on;
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+port = 5432				# (change requires restart)
+max_connections = PG_MAX_CONNECTIONS			# (change requires restart)
+#reserved_connections = 0		# (change requires restart)
+#superuser_reserved_connections = 3	# (change requires restart)
+unix_socket_directories = '/tmp'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+#tcp_user_timeout = 0			# TCP_USER_TIMEOUT, in milliseconds;
+					# 0 selects the system default
+
+#client_connection_check_interval = 0	# time between checks for client
+					# disconnection while running queries;
+					# 0 for never
+
+# - Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+password_encryption = md5	# scram-sha-256 or md5
+#scram_iterations = 4096
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
+#krb_caseins_users = off
+#gss_accept_delegation = off
+
+# - SSL -
+
+#ssl = off
+#ssl_ca_file = ''
+#ssl_cert_file = 'server.crt'
+#ssl_crl_file = ''
+#ssl_crl_dir = ''
+#ssl_key_file = 'server.key'
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL'	# allowed SSL ciphers
+#ssl_prefer_server_ciphers = on
+#ssl_ecdh_curve = 'prime256v1'
+#ssl_min_protocol_version = 'TLSv1.2'
+#ssl_max_protocol_version = ''
+#ssl_dh_params_file = ''
+#ssl_passphrase_command = ''
+#ssl_passphrase_command_supports_reload = off
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = PG_SHARED_BUFFERS			# min 128kB
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
+					# (change requires restart)
+#huge_page_size = 0			# zero for system default
+					# (change requires restart)
+#temp_buffers = 8MB			# min 800kB
+max_prepared_transactions = 100		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+work_mem = PG_WORK_MEM				# min 64kB
+#hash_mem_multiplier = 2.0		# 1-1000.0 multiplier on hash table work_mem
+#maintenance_work_mem = 64MB		# min 64kB
+#autovacuum_work_mem = -1		# min 64kB, or -1 to use maintenance_work_mem
+#logical_decoding_work_mem = 64MB	# min 64kB
+#max_stack_depth = 2MB			# min 100kB
+#shared_memory_type = mmap		# the default is the first option
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+dynamic_shared_memory_type = posix	# the default is usually the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+#min_dynamic_shared_memory = 0MB	# (change requires restart)
+#vacuum_buffer_usage_limit = 2MB	# size of vacuum and analyze buffer access strategy ring;
+					# 0 to disable vacuum buffer access strategy;
+					# range 128kB to 16GB
+
+# SLRU buffers (change requires restart)
+#commit_timestamp_buffers = 0		# memory for pg_commit_ts (0 = auto)
+#multixact_offset_buffers = 16		# memory for pg_multixact/offsets
+#multixact_member_buffers = 32		# memory for pg_multixact/members
+#notify_buffers = 16			# memory for pg_notify
+#serializable_buffers = 32		# memory for pg_serial
+#subtransaction_buffers = 0		# memory for pg_subtrans (0 = auto)
+#transaction_buffers = 0		# memory for pg_xact (0 = auto)
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-process temp file space
+					# in kilobytes, or -1 for no limit
+
+#max_notify_queue_pages = 1048576	# limits the number of SLRU pages allocated
+					# for NOTIFY / LISTEN queue
+
+# - Kernel Resources -
+
+#max_files_per_process = 1000		# min 64
+					# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-100 milliseconds (0 disables)
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 2		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 512kB		# measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+#backend_flush_after = 0		# measured in pages, 0 disables
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
+#io_combine_limit = 128kB		# usually 1-32 blocks (depends on OS)
+max_worker_processes = 8		# (change requires restart)
+max_parallel_workers_per_gather = 2	# limited by max_parallel_workers
+max_parallel_maintenance_workers = 2	# limited by max_parallel_workers
+max_parallel_workers = PG_MAX_PARALLEL_WORKERS		# number of max_worker_processes that
+					# can be used in parallel operations
+#parallel_leader_participation = on
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = replica			# minimal, replica, or logical
+					# (change requires restart)
+fsync = on				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
+synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, remote_apply, or on
+wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+full_page_writes = on			# recover from partial page writes
+wal_log_hints = on			# also do full page writes of non-critical updates
+					# (change requires restart)
+#wal_compression = off			# enables compression of full-page writes;
+					# off, pglz, lz4, zstd, or on
+#wal_init_zero = on			# zero-fill new WAL files
+#wal_recycle = on			# recycle WAL files
+#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+#wal_writer_flush_after = 1MB		# measured in pages, 0 disables
+#wal_skip_threshold = 2MB
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+checkpoint_timeout = 30min		# range 30s-1d
+checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_flush_after = 256kB		# measured in pages, 0 disables
+#checkpoint_warning = 30s		# 0 disables
+max_wal_size = PG_MAX_WAL_SIZE
+min_wal_size = 80MB
+
+# - Prefetching during recovery -
+
+#recovery_prefetch = try	# prefetch pages referenced in the WAL?
+#wal_decode_buffer_size = 512kB	# lookahead window used for prefetching
+				# (change requires restart)
+
+# - Archiving -
+
+#archive_mode = off		# enables archiving; off, on, or always
+				# (change requires restart)
+#archive_library = ''		# library to use to archive a WAL file
+				# (empty string indicates archive_command should
+				# be used)
+#archive_command = ''		# command to use to archive a WAL file
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a WAL file switch after this
+				# number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+#restore_command = ''		# command to use to restore an archived WAL file
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
+#archive_cleanup_command = ''	# command to execute at every restartpoint
+#recovery_end_command = ''	# command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+#recovery_target = ''		# 'immediate' to end recovery as soon as a
+				# consistent state is reached
+				# (change requires restart)
+#recovery_target_name = ''	# the named restore point to which recovery will proceed
+				# (change requires restart)
+#recovery_target_time = ''	# the time stamp up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_xid = ''	# the transaction ID up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_lsn = ''	# the WAL LSN up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_inclusive = on	# Specifies whether to stop:
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
+#recovery_target_timeline = 'latest'	# 'current', 'latest', or timeline ID
+					# (change requires restart)
+#recovery_target_action = 'pause'	# 'pause', 'promote', 'shutdown'
+					# (change requires restart)
+
+# - WAL Summarization -
+
+# summarize_wal = on		# run WAL summarizer process?
+#wal_summary_keep_time = '10d'	# when to remove old summary files, 0 = never
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the primary and on any standby that will send replication data.
+
+#max_wal_senders = 10		# max number of walsender processes
+				# (change requires restart)
+#max_replication_slots = 10	# max number of replication slots
+				# (change requires restart)
+#wal_keep_size = 0		# in megabytes; 0 disables
+#max_slot_wal_keep_size = -1	# in megabytes; -1 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+#track_commit_timestamp = off	# collect timestamp of transaction commit
+				# (change requires restart)
+
+# - Primary Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
+#synchronized_standby_slots = ''	# streaming replication standby server slot
+				# names that logical walsender processes will wait for
+
+# - Standby Servers -
+
+# These settings are ignored on a primary server.
+
+#primary_conninfo = ''			# connection string to sending server
+#primary_slot_name = ''			# replication slot on sending server
+hot_standby = on			# "off" disallows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_create_temp_slot = off	# create temp slot if primary_slot_name
+					# is not set
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from primary
+					# in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
+#recovery_min_apply_delay = 0		# minimum delay for applying changes during recovery
+#sync_replication_slots = off		# enables slot synchronization on the physical standby from the primary
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4	# taken from max_worker_processes
+					# (change requires restart)
+#max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
+#max_parallel_apply_workers_per_subscription = 2	# taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_async_append = on
+#enable_bitmapscan = on
+#enable_gathermerge = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_incremental_sort = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_memoize = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_parallel_append = on
+#enable_parallel_hash = on
+#enable_partition_pruning = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_presorted_aggregate = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+#enable_group_by_reordering = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#parallel_setup_cost = 1000.0		# same scale as above
+#parallel_tuple_cost = 0.1		# same scale as above
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
+effective_cache_size = PG_EFFECTIVE_CACHE_SIZE
+
+#jit_above_cost = 100000		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+#jit_inline_above_cost = 500000		# inline small functions if query is
+					# more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#jit = on				# allow JIT compilation
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+#plan_cache_mode = auto			# auto, force_generic_plan or
+					# force_custom_plan
+#recursive_worktable_factor = 10.0	# range 0.001-1000000
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, jsonlog, syslog, and
+					# eventlog, depending on platform.
+					# csvlog and jsonlog require
+					# logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = on		# Enable capturing of stderr, jsonlog,
+					# and csvlog into log files. Required
+					# to be on for csvlogs and jsonlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = '/pglog'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+log_filename = 'logfile'	# log file name pattern,
+							# can include strftime() escapes
+log_file_mode = 0600			# creation mode for log files,
+					# begin with 0 to use octal notation
+log_rotation_age = 0			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (Windows):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+log_min_messages = PG_LOG_LEVEL
+                    #   warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+#log_min_duration_sample = -1		# -1 is disabled, 0 logs a sample of statements
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
+
+#log_statement_sample_rate = 1.0	# fraction of logged statements exceeding
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
+
+#log_transaction_sample_rate = 0.0	# fraction of transactions whose statements
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+#log_startup_progress_interval = 10s	# Time between progress updates for
+					# long-running startup operations.
+					# 0 disables the feature, > 0 indicates
+					# the interval in milliseconds.
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+log_autovacuum_min_duration = 0	# log autovacuum activity;
+					# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#log_checkpoints = on
+#log_connections = off
+log_disconnections = on
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+log_line_prefix = '%p [%a] [%m] [%x] '		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %P = process ID of parallel group leader
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %Q = query ID (0 if none or not computed)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_recovery_conflict_waits = off	# log standby recovery conflict waits
+					# >= deadlock_timeout
+#log_parameter_max_length = -1		# when logging statements, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_parameter_max_length_on_error = 0	# when logging an error, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_statement = 'none'			# none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+log_timezone = 'America/New_York'
+
+# - Process Title -
+
+#cluster_name = ''			# added to process titles if nonempty
+					# (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Cumulative Query and Index Statistics -
+
+#track_activities = on
+#track_activity_query_size = 1024	# (change requires restart)
+#track_counts = on
+#track_io_timing = off
+#track_wal_io_timing = off
+#track_functions = none			# none, pl, all
+#stats_fetch_consistency = cache	# cache, none, snapshot
+
+
+# - Monitoring -
+
+#compute_query_id = auto
+#log_statement_stats = off
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_vacuum_insert_threshold = 1000	# min number of row inserts
+						# before vacuum; -1 disables insert
+						# vacuums
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_vacuum_insert_scale_factor = 0.2	# fraction of inserts over table
+						# size before insert vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+							# before forced vacuum
+							# (change requires restart)
+#autovacuum_vacuum_cost_delay = 2ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+#search_path = '"$user", public'	# schema names
+#row_security = on
+#default_table_access_method = 'heap'
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#default_toast_compression = 'pglz'	# 'pglz' or 'lz4'
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0				# in milliseconds, 0 is disabled
+#transaction_timeout = 0			# in milliseconds, 0 is disabled
+#lock_timeout = 0				# in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
+#idle_session_timeout = 0			# in milliseconds, 0 is disabled
+#vacuum_freeze_table_age = 150000000
+#vacuum_freeze_min_age = 50000000
+#vacuum_failsafe_age = 1600000000
+#vacuum_multixact_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_failsafe_age = 1600000000
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_pending_list_limit = 4MB
+#createrole_self_grant = ''		# set and/or inherit
+#event_triggers = on
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'America/New_York'
+#timezone_abbreviations = 'Default'	# Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 1			# min -15, max 3; any value >0 actually
+					# selects precise output mode
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+# lc_messages = 'en_US.UTF-8'		# locale for system error message
+					# strings
+# lc_monetary = 'en_US.UTF-8'		# locale for monetary formatting
+# lc_numeric = 'en_US.UTF-8'		# locale for number formatting
+# lc_time = 'en_US.UTF-8'			# locale for time formatting
+
+#icu_validation_level = warning		# report ICU locale validation
+					# errors at the given level
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Shared Library Preloading -
+
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+shared_preload_libraries = 'pg_stat_statements'		# (change requires restart)
+#jit_provider = 'llvmjit'		# JIT library to use
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#gin_fuzzy_search_limit = 0
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+#max_pred_locks_per_relation = -2	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2		# min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+#allow_alter_system = on
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+#data_sync_retry = off			# retry or panic on failure to fsync
+					# data?
+					# (change requires restart)
+#recovery_init_sync_method = fsync	# fsync, syncfs (Linux 5.8+)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+#include_dir = '...'			# include files ending in '.conf' from
+					# a directory, e.g., 'conf.d'
+#include_if_exists = '...'		# include file only if it exists
+#include = '...'			# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/test/postgresql/src/postgresql14/conf/setup.sql
+++ b/test/postgresql/src/postgresql14/conf/setup.sql
@@ -1,0 +1,47 @@
+-- Copyright (C) 2025 The pgmoneta community
+--
+-- Redistribution and use in source and binary forms, with or without modification,
+-- are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice, this list
+-- of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright notice, this
+-- list of conditions and the following disclaimer in the documentation and/or other
+-- materials provided with the distribution.
+--
+-- 3. Neither the name of the copyright holder nor the names of its contributors may
+-- be used to endorse or promote products derived from this software without specific
+-- prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+-- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+-- OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-- THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+-- OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-- HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-- TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+CREATE ROLE PG_USER_NAME WITH LOGIN PASSWORD 'PG_USER_PASSWORD';
+CREATE DATABASE PG_DATABASE WITH OWNER PG_USER_NAME TEMPLATE template0 ENCODING UTF8;
+
+-- create a replication role
+CREATE ROLE PG_REPL_USER_NAME WITH LOGIN REPLICATION PASSWORD 'PG_REPL_PASSWORD';
+
+-- create extension
+DROP EXTENSION IF EXISTS pgmoneta_ext;
+CREATE EXTENSION pgmoneta_ext;
+
+GRANT EXECUTE ON FUNCTION pgmoneta_ext_get_file(text) TO PG_REPL_USER_NAME;
+GRANT EXECUTE ON FUNCTION pgmoneta_ext_get_files(text) TO PG_REPL_USER_NAME;
+
+-- GRANT REPL_USER priviledge to fetch file from server
+GRANT pg_read_server_files TO PG_REPL_USER_NAME;
+
+GRANT EXECUTE ON FUNCTION pg_read_binary_file(text, bigint, bigint, boolean) TO PG_REPL_USER_NAME;
+GRANT EXECUTE ON FUNCTION pg_stat_file(text, boolean) TO PG_REPL_USER_NAME;
+-- GRANT REPL_USER execute privileges on backup admin functions
+GRANT EXECUTE ON FUNCTION pg_start_backup(text, boolean, boolean) TO PG_REPL_USER_NAME;
+GRANT EXECUTE ON FUNCTION pg_stop_backup(boolean, boolean) TO PG_REPL_USER_NAME;

--- a/test/postgresql/src/postgresql14/root/usr/bin/run-postgresql
+++ b/test/postgresql/src/postgresql14/root/usr/bin/run-postgresql
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Copyright (C) 2025 The pgmoneta community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS:-100}
+export PG_SHARED_BUFFERS=${PG_SHARED_BUFFERS:-256MB}
+export PG_WORK_MEM=${PG_WORK_MEM:-4MB}
+export PG_MAX_PARALLEL_WORKERS=${PG_MAX_PARALLEL_WORKERS:-8}
+export PG_EFFECTIVE_CACHE_SIZE=${PG_EFFECTIVE_CACHE_SIZE:-4GB}
+export PG_MAX_WAL_SIZE=${PG_MAX_WAL_SIZE:-1GB}
+export PG_LOG_LEVEL=${PG_LOG_LEVEL:-debug5}
+
+if [ -z "${PG_DATABASE}" ] ||
+   [ -z "${PG_USER_NAME}" ] || [ -z "${PG_USER_PASSWORD}" ] ||
+   [ -z "${PG_REPL_USER_NAME}" ] || [ -z "${PG_REPL_PASSWORD}" ]; then
+    echo "PG_DATABASE, PG_USER_NAME, PG_USER_PASSWORD, PG_REPL_USER_NAME and PG_REPL_PASSWORD needs to be defined."
+    exit 1
+fi
+
+export PG_DATABASE=${PG_DATABASE}
+export PG_USER_NAME=${PG_USER_NAME}
+export PG_USER_PASSWORD=${PG_USER_PASSWORD}
+export PG_REPL_USER_NAME=${PG_REPL_USER_NAME}
+export PG_REPL_PASSWORD=${PG_REPL_PASSWORD}
+/usr/pgsql-14/bin/initdb -k -X /pgwal/ /pgdata/
+
+sed -i "s/PG_MAX_CONNECTIONS/$PG_MAX_CONNECTIONS/g" /conf/postgresql.conf
+sed -i "s/PG_SHARED_BUFFERS/$PG_SHARED_BUFFERS/g" /conf/postgresql.conf
+sed -i "s/PG_WORK_MEM/$PG_WORK_MEM/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_PARALLEL_WORKERS/$PG_MAX_PARALLEL_WORKERS/g" /conf/postgresql.conf
+sed -i "s/PG_EFFECTIVE_CACHE_SIZE/$PG_EFFECTIVE_CACHE_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_WAL_SIZE/$PG_MAX_WAL_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_LOG_LEVEL/$PG_LOG_LEVEL/g" /conf/postgresql.conf
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/pg_hba.conf
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/pg_hba.conf
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/pg_hba.conf
+
+cp /conf/postgresql.conf /pgdata/
+cp /conf/pg_hba.conf /pgdata/
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/setup.sql
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_USER_PASSWORD/$PG_USER_PASSWORD/g" /conf/setup.sql
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_REPL_PASSWORD/$PG_REPL_PASSWORD/g" /conf/setup.sql
+
+touch /pglog/logfile
+chmod 666 /pglog/logfile
+
+/usr/pgsql-14/bin/pg_ctl -D /pgdata/ start
+/usr/pgsql-14/bin/psql -q -h /tmp -f /conf/setup.sql postgres
+/usr/pgsql-14/bin/pg_ctl -D /pgdata/ stop
+
+exec /usr/pgsql-14/bin/postgres -D /pgdata/ "$@"

--- a/test/postgresql/src/postgresql14/root/usr/bin/run-postgresql-local
+++ b/test/postgresql/src/postgresql14/root/usr/bin/run-postgresql-local
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright (C) 2025 The pgmoneta community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS:-100}
+export PG_SHARED_BUFFERS=${PG_SHARED_BUFFERS:-256MB}
+export PG_WORK_MEM=${PG_WORK_MEM:-4MB}
+export PG_MAX_PARALLEL_WORKERS=${PG_MAX_PARALLEL_WORKERS:-8}
+export PG_EFFECTIVE_CACHE_SIZE=${PG_EFFECTIVE_CACHE_SIZE:-4GB}
+export PG_MAX_WAL_SIZE=${PG_MAX_WAL_SIZE:-1GB}
+export PG_LOG_LEVEL=${PG_LOG_LEVEL:-debug5}
+
+/usr/lib/postgresql/14/bin/initdb -k -X /pgwal/ /pgdata/
+
+sed -i "s/PG_MAX_CONNECTIONS/$PG_MAX_CONNECTIONS/g" /conf/postgresql.conf
+sed -i "s/PG_SHARED_BUFFERS/$PG_SHARED_BUFFERS/g" /conf/postgresql.conf
+sed -i "s/PG_WORK_MEM/$PG_WORK_MEM/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_PARALLEL_WORKERS/$PG_MAX_PARALLEL_WORKERS/g" /conf/postgresql.conf
+sed -i "s/PG_EFFECTIVE_CACHE_SIZE/$PG_EFFECTIVE_CACHE_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_WAL_SIZE/$PG_MAX_WAL_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_LOG_LEVEL/$PG_LOG_LEVEL/g" /conf/postgresql.conf
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/pg_hba.conf
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/pg_hba.conf
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/pg_hba.conf
+
+cp /conf/postgresql.conf /pgdata/
+cp /conf/pg_hba.conf /pgdata/
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/setup.sql
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_USER_PASSWORD/$PG_USER_PASSWORD/g" /conf/setup.sql
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_REPL_PASSWORD/$PG_REPL_PASSWORD/g" /conf/setup.sql
+
+/usr/lib/postgresql/14/bin/pg_ctl -D /pgdata/ start
+/usr/lib/postgresql/14/bin/psql -q -h /tmp -f /conf/setup.sql postgres

--- a/test/postgresql/src/postgresql15/Dockerfile
+++ b/test/postgresql/src/postgresql15/Dockerfile
@@ -1,0 +1,82 @@
+ # Copyright (C) 2025 The pgmoneta community
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice, this list
+ # of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice, this
+ # list of conditions and the following disclaimer in the documentation and/or other
+ # materials provided with the distribution.
+ #
+ # 3. Neither the name of the copyright holder nor the names of its contributors may
+ # be used to endorse or promote products derived from this software without specific
+ # prior written permission.
+ #
+ # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ # OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ # THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ # OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM rockylinux:9
+
+LABEL maintainer="Jesper Pedersen <jesperpedersen.db@gmail.com>"
+
+LABEL summary="PostgreSQL 15" \
+      description="PostgreSQL 15"
+
+ENV PGVERSION="15"
+ENV PGROOT="/usr/pgsql-${PGVERSION}"
+ENV PATH="/usr/pgsql-${PGVERSION}/bin:$PATH"
+ENV EXTENSION_NAME="pgmoneta_ext"
+ENV GITHUB_REPO="https://github.com/pgmoneta/pgmoneta_ext.git"
+
+# Base installation from the template
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN dnf -y install --nogpgcheck --allowerasing https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf -qy --nogpgcheck module disable postgresql
+RUN dnf -y upgrade
+RUN dnf install -y dnf-plugins-core
+RUN dnf config-manager --set-enabled crb
+RUN dnf makecache
+
+# Install dependencies
+RUN dnf -y install git gcc cmake make postgresql15-devel
+RUN dnf -y install procps wget iputils net-tools
+RUN dnf -y install postgresql15 postgresql15-server postgresql15-contrib postgresql15-libs 
+
+# Build and Install pgmoneta_ext
+WORKDIR /tmp/pg_extension
+RUN git clone --depth 1 ${GITHUB_REPO}
+WORKDIR /tmp/pg_extension/${EXTENSION_NAME}
+
+RUN mkdir build
+WORKDIR /tmp/pg_extension/${EXTENSION_NAME}/build
+RUN cmake -DDOCS=false ..
+RUN make
+RUN make install
+
+RUN rm -rf /tmp/pg_extension
+RUN dnf --nogpgcheck clean all
+
+WORKDIR /
+RUN rm -Rf /conf /pgconf /pgdata /pgwal
+COPY root/ /
+RUN mkdir -p /conf /pgconf /pgdata /pgwal /pglog
+COPY conf/* /conf/
+RUN chown -R postgres:postgres /conf /pgconf /pgdata /pgwal /pglog
+RUN chmod 700 /conf /pgconf /pgdata /pgwal
+RUN chmod +x /usr/bin/run-postgresql
+RUN mkdir -p /usr/local/bin
+
+EXPOSE 5432
+
+USER 26
+
+CMD ["/usr/bin/run-postgresql"]

--- a/test/postgresql/src/postgresql15/Makefile
+++ b/test/postgresql/src/postgresql15/Makefile
@@ -1,0 +1,48 @@
+# Copyright (C) 2025 The pgmoneta community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+IMAGE_SHORT_NAME = pgmoneta-test-postgresql15
+IMAGE_NAME = pgmoneta-test-postgresql15-rocky9
+CONTAINER_ENGINE := $(shell \
+	if command -v podman >/dev/null 2>&1; then echo podman; \
+	elif command -v docker >/dev/null 2>&1; then echo "sudo docker"; \
+	else echo "Neither Docker nor Podman is installed" >&2; exit 1; \
+	fi)
+
+.PHONY: all build clean
+
+all:
+	make clean
+	make build
+
+build:
+	# Detect container engine: Docker or Podman
+	$(CONTAINER_ENGINE) build --no-cache -t $(IMAGE_NAME) .
+
+clean:
+	$(CONTAINER_ENGINE) stop $(IMAGE_SHORT_NAME) 2>/dev/null || true
+	$(CONTAINER_ENGINE) rm -f $(IMAGE_SHORT_NAME) 2>/dev/null || true
+	$(CONTAINER_ENGINE) rmi -f $(IMAGE_NAME) 2>/dev/null || true

--- a/test/postgresql/src/postgresql15/conf/pg_hba.conf
+++ b/test/postgresql/src/postgresql15/conf/pg_hba.conf
@@ -1,0 +1,6 @@
+local   all             all                                       trust
+local   replication     all                                       trust
+host    PG_DATABASE     PG_USER_NAME         all                  trust
+local   postgres        PG_REPL_USER_NAME                         md5
+host    postgres        PG_REPL_USER_NAME    all                  md5
+host    replication     PG_REPL_USER_NAME    all                  md5

--- a/test/postgresql/src/postgresql15/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql15/conf/postgresql.conf
@@ -1,0 +1,843 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'		# use data in another directory
+					# (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'		# what IP address(es) to listen on;
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+port = 5432				# (change requires restart)
+max_connections = PG_MAX_CONNECTIONS			# (change requires restart)
+#reserved_connections = 0		# (change requires restart)
+#superuser_reserved_connections = 3	# (change requires restart)
+unix_socket_directories = '/tmp'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+#tcp_user_timeout = 0			# TCP_USER_TIMEOUT, in milliseconds;
+					# 0 selects the system default
+
+#client_connection_check_interval = 0	# time between checks for client
+					# disconnection while running queries;
+					# 0 for never
+
+# - Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+password_encryption = md5	# scram-sha-256 or md5
+#scram_iterations = 4096
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
+#krb_caseins_users = off
+#gss_accept_delegation = off
+
+# - SSL -
+
+#ssl = off
+#ssl_ca_file = ''
+#ssl_cert_file = 'server.crt'
+#ssl_crl_file = ''
+#ssl_crl_dir = ''
+#ssl_key_file = 'server.key'
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL'	# allowed SSL ciphers
+#ssl_prefer_server_ciphers = on
+#ssl_ecdh_curve = 'prime256v1'
+#ssl_min_protocol_version = 'TLSv1.2'
+#ssl_max_protocol_version = ''
+#ssl_dh_params_file = ''
+#ssl_passphrase_command = ''
+#ssl_passphrase_command_supports_reload = off
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = PG_SHARED_BUFFERS			# min 128kB
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
+					# (change requires restart)
+#huge_page_size = 0			# zero for system default
+					# (change requires restart)
+#temp_buffers = 8MB			# min 800kB
+max_prepared_transactions = 100		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+work_mem = PG_WORK_MEM				# min 64kB
+#hash_mem_multiplier = 2.0		# 1-1000.0 multiplier on hash table work_mem
+#maintenance_work_mem = 64MB		# min 64kB
+#autovacuum_work_mem = -1		# min 64kB, or -1 to use maintenance_work_mem
+#logical_decoding_work_mem = 64MB	# min 64kB
+#max_stack_depth = 2MB			# min 100kB
+#shared_memory_type = mmap		# the default is the first option
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+dynamic_shared_memory_type = posix	# the default is usually the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+#min_dynamic_shared_memory = 0MB	# (change requires restart)
+#vacuum_buffer_usage_limit = 2MB	# size of vacuum and analyze buffer access strategy ring;
+					# 0 to disable vacuum buffer access strategy;
+					# range 128kB to 16GB
+
+# SLRU buffers (change requires restart)
+#commit_timestamp_buffers = 0		# memory for pg_commit_ts (0 = auto)
+#multixact_offset_buffers = 16		# memory for pg_multixact/offsets
+#multixact_member_buffers = 32		# memory for pg_multixact/members
+#notify_buffers = 16			# memory for pg_notify
+#serializable_buffers = 32		# memory for pg_serial
+#subtransaction_buffers = 0		# memory for pg_subtrans (0 = auto)
+#transaction_buffers = 0		# memory for pg_xact (0 = auto)
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-process temp file space
+					# in kilobytes, or -1 for no limit
+
+#max_notify_queue_pages = 1048576	# limits the number of SLRU pages allocated
+					# for NOTIFY / LISTEN queue
+
+# - Kernel Resources -
+
+#max_files_per_process = 1000		# min 64
+					# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-100 milliseconds (0 disables)
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 2		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 512kB		# measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+#backend_flush_after = 0		# measured in pages, 0 disables
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
+#io_combine_limit = 128kB		# usually 1-32 blocks (depends on OS)
+max_worker_processes = 8		# (change requires restart)
+max_parallel_workers_per_gather = 2	# limited by max_parallel_workers
+max_parallel_maintenance_workers = 2	# limited by max_parallel_workers
+max_parallel_workers = PG_MAX_PARALLEL_WORKERS		# number of max_worker_processes that
+					# can be used in parallel operations
+#parallel_leader_participation = on
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = replica			# minimal, replica, or logical
+					# (change requires restart)
+fsync = on				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
+synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, remote_apply, or on
+wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+full_page_writes = on			# recover from partial page writes
+wal_log_hints = on			# also do full page writes of non-critical updates
+					# (change requires restart)
+#wal_compression = off			# enables compression of full-page writes;
+					# off, pglz, lz4, zstd, or on
+#wal_init_zero = on			# zero-fill new WAL files
+#wal_recycle = on			# recycle WAL files
+#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+#wal_writer_flush_after = 1MB		# measured in pages, 0 disables
+#wal_skip_threshold = 2MB
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+checkpoint_timeout = 30min		# range 30s-1d
+checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_flush_after = 256kB		# measured in pages, 0 disables
+#checkpoint_warning = 30s		# 0 disables
+max_wal_size = PG_MAX_WAL_SIZE
+min_wal_size = 80MB
+
+# - Prefetching during recovery -
+
+#recovery_prefetch = try	# prefetch pages referenced in the WAL?
+#wal_decode_buffer_size = 512kB	# lookahead window used for prefetching
+				# (change requires restart)
+
+# - Archiving -
+
+#archive_mode = off		# enables archiving; off, on, or always
+				# (change requires restart)
+#archive_library = ''		# library to use to archive a WAL file
+				# (empty string indicates archive_command should
+				# be used)
+#archive_command = ''		# command to use to archive a WAL file
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a WAL file switch after this
+				# number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+#restore_command = ''		# command to use to restore an archived WAL file
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
+#archive_cleanup_command = ''	# command to execute at every restartpoint
+#recovery_end_command = ''	# command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+#recovery_target = ''		# 'immediate' to end recovery as soon as a
+				# consistent state is reached
+				# (change requires restart)
+#recovery_target_name = ''	# the named restore point to which recovery will proceed
+				# (change requires restart)
+#recovery_target_time = ''	# the time stamp up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_xid = ''	# the transaction ID up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_lsn = ''	# the WAL LSN up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_inclusive = on	# Specifies whether to stop:
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
+#recovery_target_timeline = 'latest'	# 'current', 'latest', or timeline ID
+					# (change requires restart)
+#recovery_target_action = 'pause'	# 'pause', 'promote', 'shutdown'
+					# (change requires restart)
+
+# - WAL Summarization -
+
+# summarize_wal = on		# run WAL summarizer process?
+#wal_summary_keep_time = '10d'	# when to remove old summary files, 0 = never
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the primary and on any standby that will send replication data.
+
+#max_wal_senders = 10		# max number of walsender processes
+				# (change requires restart)
+#max_replication_slots = 10	# max number of replication slots
+				# (change requires restart)
+#wal_keep_size = 0		# in megabytes; 0 disables
+#max_slot_wal_keep_size = -1	# in megabytes; -1 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+#track_commit_timestamp = off	# collect timestamp of transaction commit
+				# (change requires restart)
+
+# - Primary Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
+#synchronized_standby_slots = ''	# streaming replication standby server slot
+				# names that logical walsender processes will wait for
+
+# - Standby Servers -
+
+# These settings are ignored on a primary server.
+
+#primary_conninfo = ''			# connection string to sending server
+#primary_slot_name = ''			# replication slot on sending server
+hot_standby = on			# "off" disallows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_create_temp_slot = off	# create temp slot if primary_slot_name
+					# is not set
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from primary
+					# in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
+#recovery_min_apply_delay = 0		# minimum delay for applying changes during recovery
+#sync_replication_slots = off		# enables slot synchronization on the physical standby from the primary
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4	# taken from max_worker_processes
+					# (change requires restart)
+#max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
+#max_parallel_apply_workers_per_subscription = 2	# taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_async_append = on
+#enable_bitmapscan = on
+#enable_gathermerge = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_incremental_sort = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_memoize = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_parallel_append = on
+#enable_parallel_hash = on
+#enable_partition_pruning = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_presorted_aggregate = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+#enable_group_by_reordering = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#parallel_setup_cost = 1000.0		# same scale as above
+#parallel_tuple_cost = 0.1		# same scale as above
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
+effective_cache_size = PG_EFFECTIVE_CACHE_SIZE
+
+#jit_above_cost = 100000		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+#jit_inline_above_cost = 500000		# inline small functions if query is
+					# more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#jit = on				# allow JIT compilation
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+#plan_cache_mode = auto			# auto, force_generic_plan or
+					# force_custom_plan
+#recursive_worktable_factor = 10.0	# range 0.001-1000000
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, jsonlog, syslog, and
+					# eventlog, depending on platform.
+					# csvlog and jsonlog require
+					# logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = on		# Enable capturing of stderr, jsonlog,
+					# and csvlog into log files. Required
+					# to be on for csvlogs and jsonlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = '/pglog'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+log_filename = 'logfile'	# log file name pattern,
+							# can include strftime() escapes
+log_file_mode = 0600			# creation mode for log files,
+					# begin with 0 to use octal notation
+log_rotation_age = 0			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (Windows):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+log_min_messages = PG_LOG_LEVEL
+                    #   warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+#log_min_duration_sample = -1		# -1 is disabled, 0 logs a sample of statements
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
+
+#log_statement_sample_rate = 1.0	# fraction of logged statements exceeding
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
+
+#log_transaction_sample_rate = 0.0	# fraction of transactions whose statements
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+#log_startup_progress_interval = 10s	# Time between progress updates for
+					# long-running startup operations.
+					# 0 disables the feature, > 0 indicates
+					# the interval in milliseconds.
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+log_autovacuum_min_duration = 0	# log autovacuum activity;
+					# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#log_checkpoints = on
+#log_connections = off
+log_disconnections = on
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+log_line_prefix = '%p [%a] [%m] [%x] '		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %P = process ID of parallel group leader
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %Q = query ID (0 if none or not computed)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_recovery_conflict_waits = off	# log standby recovery conflict waits
+					# >= deadlock_timeout
+#log_parameter_max_length = -1		# when logging statements, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_parameter_max_length_on_error = 0	# when logging an error, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_statement = 'none'			# none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+log_timezone = 'America/New_York'
+
+# - Process Title -
+
+#cluster_name = ''			# added to process titles if nonempty
+					# (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Cumulative Query and Index Statistics -
+
+#track_activities = on
+#track_activity_query_size = 1024	# (change requires restart)
+#track_counts = on
+#track_io_timing = off
+#track_wal_io_timing = off
+#track_functions = none			# none, pl, all
+#stats_fetch_consistency = cache	# cache, none, snapshot
+
+
+# - Monitoring -
+
+#compute_query_id = auto
+#log_statement_stats = off
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_vacuum_insert_threshold = 1000	# min number of row inserts
+						# before vacuum; -1 disables insert
+						# vacuums
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_vacuum_insert_scale_factor = 0.2	# fraction of inserts over table
+						# size before insert vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+							# before forced vacuum
+							# (change requires restart)
+#autovacuum_vacuum_cost_delay = 2ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+#search_path = '"$user", public'	# schema names
+#row_security = on
+#default_table_access_method = 'heap'
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#default_toast_compression = 'pglz'	# 'pglz' or 'lz4'
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0				# in milliseconds, 0 is disabled
+#transaction_timeout = 0			# in milliseconds, 0 is disabled
+#lock_timeout = 0				# in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
+#idle_session_timeout = 0			# in milliseconds, 0 is disabled
+#vacuum_freeze_table_age = 150000000
+#vacuum_freeze_min_age = 50000000
+#vacuum_failsafe_age = 1600000000
+#vacuum_multixact_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_failsafe_age = 1600000000
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_pending_list_limit = 4MB
+#createrole_self_grant = ''		# set and/or inherit
+#event_triggers = on
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'America/New_York'
+#timezone_abbreviations = 'Default'	# Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 1			# min -15, max 3; any value >0 actually
+					# selects precise output mode
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+# lc_messages = 'en_US.UTF-8'		# locale for system error message
+					# strings
+# lc_monetary = 'en_US.UTF-8'		# locale for monetary formatting
+# lc_numeric = 'en_US.UTF-8'		# locale for number formatting
+# lc_time = 'en_US.UTF-8'			# locale for time formatting
+
+#icu_validation_level = warning		# report ICU locale validation
+					# errors at the given level
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Shared Library Preloading -
+
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+shared_preload_libraries = 'pg_stat_statements'		# (change requires restart)
+#jit_provider = 'llvmjit'		# JIT library to use
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#gin_fuzzy_search_limit = 0
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+#max_pred_locks_per_relation = -2	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2		# min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+#allow_alter_system = on
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+#data_sync_retry = off			# retry or panic on failure to fsync
+					# data?
+					# (change requires restart)
+#recovery_init_sync_method = fsync	# fsync, syncfs (Linux 5.8+)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+#include_dir = '...'			# include files ending in '.conf' from
+					# a directory, e.g., 'conf.d'
+#include_if_exists = '...'		# include file only if it exists
+#include = '...'			# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/test/postgresql/src/postgresql15/conf/setup.sql
+++ b/test/postgresql/src/postgresql15/conf/setup.sql
@@ -1,0 +1,47 @@
+-- Copyright (C) 2025 The pgmoneta community
+--
+-- Redistribution and use in source and binary forms, with or without modification,
+-- are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice, this list
+-- of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright notice, this
+-- list of conditions and the following disclaimer in the documentation and/or other
+-- materials provided with the distribution.
+--
+-- 3. Neither the name of the copyright holder nor the names of its contributors may
+-- be used to endorse or promote products derived from this software without specific
+-- prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+-- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+-- OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+-- THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+-- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+-- OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-- HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-- TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+CREATE ROLE PG_USER_NAME WITH LOGIN PASSWORD 'PG_USER_PASSWORD';
+CREATE DATABASE PG_DATABASE WITH OWNER PG_USER_NAME TEMPLATE template0 ENCODING UTF8;
+
+-- create a replication role
+CREATE ROLE PG_REPL_USER_NAME WITH LOGIN REPLICATION PASSWORD 'PG_REPL_PASSWORD';
+
+-- create extension
+DROP EXTENSION IF EXISTS pgmoneta_ext;
+CREATE EXTENSION pgmoneta_ext;
+
+GRANT EXECUTE ON FUNCTION pgmoneta_ext_get_file(text) TO PG_REPL_USER_NAME;
+GRANT EXECUTE ON FUNCTION pgmoneta_ext_get_files(text) TO PG_REPL_USER_NAME;
+
+-- GRANT REPL_USER priviledge to fetch file from server
+GRANT pg_read_server_files TO PG_REPL_USER_NAME;
+
+GRANT EXECUTE ON FUNCTION pg_read_binary_file(text, bigint, bigint, boolean) TO PG_REPL_USER_NAME;
+GRANT EXECUTE ON FUNCTION pg_stat_file(text, boolean) TO PG_REPL_USER_NAME;
+-- GRANT REPL_USER execute privileges on backup admin functions
+GRANT EXECUTE ON FUNCTION pg_backup_start(text, boolean) TO PG_REPL_USER_NAME;
+GRANT EXECUTE ON FUNCTION pg_backup_stop(boolean) TO PG_REPL_USER_NAME;

--- a/test/postgresql/src/postgresql15/root/usr/bin/run-postgresql
+++ b/test/postgresql/src/postgresql15/root/usr/bin/run-postgresql
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Copyright (C) 2025 The pgmoneta community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS:-100}
+export PG_SHARED_BUFFERS=${PG_SHARED_BUFFERS:-256MB}
+export PG_WORK_MEM=${PG_WORK_MEM:-4MB}
+export PG_MAX_PARALLEL_WORKERS=${PG_MAX_PARALLEL_WORKERS:-8}
+export PG_EFFECTIVE_CACHE_SIZE=${PG_EFFECTIVE_CACHE_SIZE:-4GB}
+export PG_MAX_WAL_SIZE=${PG_MAX_WAL_SIZE:-1GB}
+export PG_LOG_LEVEL=${PG_LOG_LEVEL:-debug5}
+
+if [ -z "${PG_DATABASE}" ] ||
+   [ -z "${PG_USER_NAME}" ] || [ -z "${PG_USER_PASSWORD}" ] ||
+   [ -z "${PG_REPL_USER_NAME}" ] || [ -z "${PG_REPL_PASSWORD}" ]; then
+    echo "PG_DATABASE, PG_USER_NAME, PG_USER_PASSWORD, PG_REPL_USER_NAME and PG_REPL_PASSWORD needs to be defined."
+    exit 1
+fi
+
+export PG_DATABASE=${PG_DATABASE}
+export PG_USER_NAME=${PG_USER_NAME}
+export PG_USER_PASSWORD=${PG_USER_PASSWORD}
+export PG_REPL_USER_NAME=${PG_REPL_USER_NAME}
+export PG_REPL_PASSWORD=${PG_REPL_PASSWORD}
+/usr/pgsql-15/bin/initdb -k -X /pgwal/ /pgdata/
+
+sed -i "s/PG_MAX_CONNECTIONS/$PG_MAX_CONNECTIONS/g" /conf/postgresql.conf
+sed -i "s/PG_SHARED_BUFFERS/$PG_SHARED_BUFFERS/g" /conf/postgresql.conf
+sed -i "s/PG_WORK_MEM/$PG_WORK_MEM/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_PARALLEL_WORKERS/$PG_MAX_PARALLEL_WORKERS/g" /conf/postgresql.conf
+sed -i "s/PG_EFFECTIVE_CACHE_SIZE/$PG_EFFECTIVE_CACHE_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_WAL_SIZE/$PG_MAX_WAL_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_LOG_LEVEL/$PG_LOG_LEVEL/g" /conf/postgresql.conf
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/pg_hba.conf
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/pg_hba.conf
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/pg_hba.conf
+
+cp /conf/postgresql.conf /pgdata/
+cp /conf/pg_hba.conf /pgdata/
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/setup.sql
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_USER_PASSWORD/$PG_USER_PASSWORD/g" /conf/setup.sql
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_REPL_PASSWORD/$PG_REPL_PASSWORD/g" /conf/setup.sql
+
+touch /pglog/logfile
+chmod 666 /pglog/logfile
+
+/usr/pgsql-15/bin/pg_ctl -D /pgdata/ start
+/usr/pgsql-15/bin/psql -q -h /tmp -f /conf/setup.sql postgres
+/usr/pgsql-15/bin/pg_ctl -D /pgdata/ stop
+
+exec /usr/pgsql-15/bin/postgres -D /pgdata/ "$@"

--- a/test/postgresql/src/postgresql15/root/usr/bin/run-postgresql-local
+++ b/test/postgresql/src/postgresql15/root/usr/bin/run-postgresql-local
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright (C) 2025 The pgmoneta community
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export PG_MAX_CONNECTIONS=${PG_MAX_CONNECTIONS:-100}
+export PG_SHARED_BUFFERS=${PG_SHARED_BUFFERS:-256MB}
+export PG_WORK_MEM=${PG_WORK_MEM:-4MB}
+export PG_MAX_PARALLEL_WORKERS=${PG_MAX_PARALLEL_WORKERS:-8}
+export PG_EFFECTIVE_CACHE_SIZE=${PG_EFFECTIVE_CACHE_SIZE:-4GB}
+export PG_MAX_WAL_SIZE=${PG_MAX_WAL_SIZE:-1GB}
+export PG_LOG_LEVEL=${PG_LOG_LEVEL:-debug5}
+
+/usr/lib/postgresql/15/bin/initdb -k -X /pgwal/ /pgdata/
+
+sed -i "s/PG_MAX_CONNECTIONS/$PG_MAX_CONNECTIONS/g" /conf/postgresql.conf
+sed -i "s/PG_SHARED_BUFFERS/$PG_SHARED_BUFFERS/g" /conf/postgresql.conf
+sed -i "s/PG_WORK_MEM/$PG_WORK_MEM/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_PARALLEL_WORKERS/$PG_MAX_PARALLEL_WORKERS/g" /conf/postgresql.conf
+sed -i "s/PG_EFFECTIVE_CACHE_SIZE/$PG_EFFECTIVE_CACHE_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_MAX_WAL_SIZE/$PG_MAX_WAL_SIZE/g" /conf/postgresql.conf
+sed -i "s/PG_LOG_LEVEL/$PG_LOG_LEVEL/g" /conf/postgresql.conf
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/pg_hba.conf
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/pg_hba.conf
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/pg_hba.conf
+
+cp /conf/postgresql.conf /pgdata/
+cp /conf/pg_hba.conf /pgdata/
+
+sed -i "s/PG_DATABASE/$PG_DATABASE/g" /conf/setup.sql
+sed -i "s/PG_USER_NAME/$PG_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_USER_PASSWORD/$PG_USER_PASSWORD/g" /conf/setup.sql
+sed -i "s/PG_REPL_USER_NAME/$PG_REPL_USER_NAME/g" /conf/setup.sql
+sed -i "s/PG_REPL_PASSWORD/$PG_REPL_PASSWORD/g" /conf/setup.sql
+
+/usr/lib/postgresql/15/bin/pg_ctl -D /pgdata/ start
+/usr/lib/postgresql/15/bin/psql -q -h /tmp -f /conf/setup.sql postgres

--- a/test/testcases/test_art.c
+++ b/test/testcases/test_art.c
@@ -611,6 +611,7 @@ pgmoneta_test_art_suite()
    s = suite_create("pgmoneta_test_art");
 
    tc_art_basic = tcase_create("art_basic_test");
+   tcase_set_tags(tc_art_basic, "common");
    tcase_set_timeout(tc_art_basic, 60);
    tcase_add_checked_fixture(tc_art_basic, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_art_basic, test_art_create);
@@ -623,6 +624,7 @@ pgmoneta_test_art_suite()
    tcase_add_test(tc_art_basic, test_art_iterator_remove);
 
    tc_art_advanced = tcase_create("art_advanced_test");
+   tcase_set_tags(tc_art_advanced, "common");
    tcase_set_timeout(tc_art_advanced, 60);
    tcase_add_checked_fixture(tc_art_advanced, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_art_advanced, test_art_insert_search_extensive);

--- a/test/testcases/test_backup.c
+++ b/test/testcases/test_backup.c
@@ -89,6 +89,7 @@ pgmoneta_test_backup_suite()
    s = suite_create("pgmoneta_test_backup");
 
    tc_backup_basic = tcase_create("backup_basic_test");
+   tcase_set_tags(tc_backup_basic, "common");
    tcase_set_timeout(tc_backup_basic, 60);
    tcase_add_checked_fixture(tc_backup_basic, pgmoneta_test_setup, pgmoneta_test_basedir_cleanup);
    tcase_add_test(tc_backup_basic, test_pgmoneta_backup_full);

--- a/test/testcases/test_brt_io.c
+++ b/test/testcases/test_brt_io.c
@@ -95,7 +95,7 @@ pgmoneta_test_brt_io_suite()
    s = suite_create("pgmoneta_test_brt_io");
 
    tc_brt_io = tcase_create("test_brt_io");
-
+   tcase_set_tags(tc_brt_io, "common");
    tcase_set_timeout(tc_brt_io, 60);
    tcase_add_checked_fixture(tc_brt_io, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_brt_io, test_pgmoneta_write_multiple_chunks_multiple_representations);

--- a/test/testcases/test_delete.c
+++ b/test/testcases/test_delete.c
@@ -157,12 +157,14 @@ pgmoneta_test_delete_suite()
    s = suite_create("pgmoneta_test_delete");
 
    tc_delete_full = tcase_create("delete_full_test");
+   tcase_set_tags(tc_delete_full, "common");
    tcase_set_timeout(tc_delete_full, 60);
    tcase_add_checked_fixture(tc_delete_full, pgmoneta_test_add_backup, pgmoneta_test_basedir_cleanup);
    tcase_add_test(tc_delete_full, test_pgmoneta_delete_full);
    suite_add_tcase(s, tc_delete_full);
 
    tc_delete_chain = tcase_create("delete_chain_test");
+   tcase_set_tags(tc_delete_chain, " common");
    tcase_set_timeout(tc_delete_chain, 120);
    tcase_add_checked_fixture(tc_delete_chain, pgmoneta_test_add_backup_chain, pgmoneta_test_basedir_cleanup);
    tcase_add_test(tc_delete_chain, test_pgmoneta_delete_chain_last);

--- a/test/testcases/test_deque.c
+++ b/test/testcases/test_deque.c
@@ -302,6 +302,7 @@ pgmoneta_test_deque_suite()
    s = suite_create("pgmoneta_test_deque");
 
    tc_deque_basic = tcase_create("deque_basic_test");
+   tcase_set_tags(tc_deque_basic, "common");
    tcase_set_timeout(tc_deque_basic, 60);
    tcase_add_checked_fixture(tc_deque_basic, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_deque_basic, test_deque_create);

--- a/test/testcases/test_http.c
+++ b/test/testcases/test_http.c
@@ -218,7 +218,7 @@ pgmoneta_test_http_suite()
    s = suite_create("pgmoneta_test_http");
 
    tc_http_basic = tcase_create("http_basic_test");
-
+   tcase_set_tags(tc_http_basic, "common");
    tcase_set_timeout(tc_http_basic, 60);
    tcase_add_checked_fixture(tc_http_basic, setup_echo_server, teardown_echo_server);
    tcase_add_test(tc_http_basic, test_pgmoneta_http_get);

--- a/test/testcases/test_json.c
+++ b/test/testcases/test_json.c
@@ -318,6 +318,7 @@ pgmoneta_test_json_suite()
    s = suite_create("pgmoneta_test_json");
 
    tc_json_basic = tcase_create("json_basic_test");
+   tcase_set_tags(tc_json_basic, "common");
    tcase_set_timeout(tc_json_basic, 60);
    tcase_add_checked_fixture(tc_json_basic, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_json_basic, test_json_create);

--- a/test/testcases/test_restore.c
+++ b/test/testcases/test_restore.c
@@ -50,12 +50,14 @@ pgmoneta_test_restore_suite()
    s = suite_create("pgmoneta_test_restore");
 
    tc_restore_full = tcase_create("full_restore_test");
+   tcase_set_tags(tc_restore_full, "common");
    tcase_set_timeout(tc_restore_full, 60);
    tcase_add_checked_fixture(tc_restore_full, pgmoneta_test_add_backup, pgmoneta_test_basedir_cleanup);
    tcase_add_test(tc_restore_full, test_pgmoneta_restore);
    suite_add_tcase(s, tc_restore_full);
 
    tc_restore_incremental = tcase_create("incremental_restore_test");
+   tcase_set_tags(tc_restore_incremental, "common");
    tcase_set_timeout(tc_restore_incremental, 60);
    tcase_add_checked_fixture(tc_restore_incremental, pgmoneta_test_add_backup_chain, pgmoneta_test_basedir_cleanup);
    tcase_add_test(tc_restore_incremental, test_pgmoneta_restore);

--- a/test/testcases/test_server_api.c
+++ b/test/testcases/test_server_api.c
@@ -104,7 +104,7 @@ START_TEST(test_server_api_backup)
    ret = !pgmoneta_server_start_backup(PRIMARY_SERVER, srv_ssl, srv_socket, "test_backup", &start_lsn);
    ck_assert_msg(ret, "failed to start backup");
 
-   ret = !pgmoneta_server_stop_backup(PRIMARY_SERVER, srv_ssl, srv_socket, &stop_lsn, &lf);
+   ret = !pgmoneta_server_stop_backup(PRIMARY_SERVER, srv_ssl, srv_socket, NULL, &stop_lsn, &lf);
    ck_assert_msg(ret, "failed to stop backup");
 
    free(start_lsn);
@@ -120,7 +120,6 @@ pgmoneta_test_server_api_suite()
    s = suite_create("pgmoneta_test_server_api");
 
    tc_server_api = tcase_create("test_server_api");
-
    tcase_set_timeout(tc_server_api, 60);
    tcase_add_checked_fixture(tc_server_api, setup_server_connection, teardown_server_connection);
    tcase_add_test(tc_server_api, test_server_api_info);

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -66,6 +66,7 @@ pgmoneta_test_utils_suite()
    s = suite_create("pgmoneta_test_utils");
 
    tc_utils = tcase_create("test_utils");
+   tcase_set_tags(tc_utils, "common");
    tcase_set_timeout(tc_utils, 60);
    tcase_add_checked_fixture(tc_utils, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_utils, test_resolve_path_trailing_env_var);

--- a/test/testcases/test_wal_summary.c
+++ b/test/testcases/test_wal_summary.c
@@ -154,7 +154,6 @@ pgmoneta_test_wal_summary_suite()
    s = suite_create("pgmoneta_test_wal_summary");
 
    tc_wal_summary = tcase_create("test_wal_summary");
-
    tcase_set_timeout(tc_wal_summary, 60);
    tcase_add_checked_fixture(tc_wal_summary, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_wal_summary, test_pgmoneta_wal_summary);

--- a/test/testcases/test_wal_utils.c
+++ b/test/testcases/test_wal_utils.c
@@ -71,7 +71,6 @@ pgmoneta_test_wal_utils_suite()
    Suite* s;
    TCase* tc_wal_utils;
    s = suite_create("pgmoneta_test_wal_utils");
-
    tc_wal_utils = tcase_create("test_wal_utils");
    tcase_add_checked_fixture(tc_wal_utils, pgmoneta_test_setup, pgmoneta_test_basedir_cleanup);
    tcase_set_timeout(tc_wal_utils, 60);


### PR DESCRIPTION
## WIP: Workflow for Incremental Backups

This feature aims to include a new workflow that executes the block-level incremental backups for PostgreSQL versions 14-16.

### Dependencies

- WAL Parser
- WAL Summarizer
- BRT APIs
- Server APIs

### Working

* The workflow will be provided with the label of the preceding backup, so the first step is to find the checkpoint location of that preceding backup.
* Once we have that, we will perform a checkpoint for our incr backup (`start_pos`) this marks the starting of our backup (can replace it with `pg_backup_start` in future).
* The next thing is to get all the changed blocks in all the relation files from the WAL records (WAL archive pool) starting form the checkpoint of preceding checkpoint to the `start_pos`, This step is called summarization since its is performed by WAL summarizer which returns a block reference table.
* BRT is indexed with the relation file locator, so iterate the BRT over the relation file locator
    * For each relation file, derive the relative file name in the server (this is used at various instances in the workflow like reading binary file, fetching file stat from the server)
    * check if the file was not truncated (`limit_block <= segment_size`) if yes, do full backup of the file
    * calculate the modified block number array, truncation block length (effectively the file size obtained from file stats) and write incremental file (prefixed with `.INCREMENTAL`)
* Stop the backup by performing checkpointing.
* copy the WAL files from the archive, the idea is copy only WAL files that are generated after the backup was started (including the file which was the current WAL segment at the time of backup)
* Save backup info in `backup.info` file

### Future Prospects

* Testing is definitely the primary prospect, since this workflow has not being tested on all the PostgreSQL versions from 13-16,
* Inclusion of all the other standard directories and files in the backup like `pg_tblspc/`, `pg_xact/` etc.
* Look into manifest generation and symlinks for non-changed files
* The part where we are waiting for `.partial` file to be transformed after WAL switch is taking major amount of time `~5-10 seconds`. We must improve the WAL parser to parse `.partial` files so that the records can be directly parsed from that file.

> Note: This new workflow is not being used currently so regular testing can't be possible or can be a bit cumbersome.

@Jubilee101 @jesperpedersen PTAL