### PR TITLE
Replace desc of records with <empty> if empty

### DIFF
--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -1472,6 +1472,10 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
          start_lsn_string = pgmoneta_lsn_to_string(record->header.xl_prev);
          end_lsn_string = pgmoneta_lsn_to_string(record->lsn);
 
+         bool has_desc = enhanced_desc && strlen(enhanced_desc) > 0;
+         bool has_backup = backup_str && strlen(backup_str) > 0;
+         bool both_empty = !has_desc && !has_backup;
+
          if (color)
          {
             fprintf(out, "%s%-*s%s | %s%-*s%s | %s%-*s%s | %s%-*d%s | %s%-*d%s | %s%-*u%s | %s%s%s%s%s\n",
@@ -1481,9 +1485,9 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
                     COLOR_BLUE, widths->rec_width, rec_len, COLOR_RESET,
                     COLOR_YELLOW, widths->tot_width, record->header.xl_tot_len, COLOR_RESET,
                     COLOR_CYAN, widths->xid_width, record->header.xl_xid, COLOR_RESET,
-                    COLOR_GREEN, enhanced_desc,
-                    backup_str && strlen(backup_str) > 0 ? " " : "",
-                    backup_str ? backup_str : "", COLOR_RESET);
+                    COLOR_GREEN, both_empty ? "<empty>" : (has_desc ? enhanced_desc : ""),
+                    has_backup ? " " : "",
+                    has_backup ? backup_str : "", COLOR_RESET);
          }
          else
          {
@@ -1494,9 +1498,9 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
                     widths->rec_width, rec_len,
                     widths->tot_width, record->header.xl_tot_len,
                     widths->xid_width, record->header.xl_xid,
-                    enhanced_desc,
-                    backup_str && strlen(backup_str) > 0 ? " " : "",
-                    backup_str ? backup_str : "");
+                    both_empty ? "<empty>" : (has_desc ? enhanced_desc : ""),
+                    has_backup ? " " : "",
+                    has_backup ? backup_str : "");
          }
       }
       goto cleanup;


### PR DESCRIPTION
Updates the record with an empty desc like this one

```
➜  build git:(main) ✗ pgmoneta-walinfo ~/Downloads/000000010000000000000007.partial.gz
Standby | 0/6000120 | 0/7000028 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
XLOG    | 0/7000028 | 0/7000060 | 114 | 114 | 0 | CHECKPOINT_SHUTDOWN redo 0/7000060; tli 1; prev tli 1; fpw true; wal_level replica; xid 0:756; oid 16402; multi 1; offset 0; oldest xid 730 in DB 1; oldest multi 1 in DB 1; oldest/newest commit timestamp xid: 0/0; oldest running xid 0 shutdown
XLOG    | 0/7000060 | 0/70000D8 | 49  | 305 | 0 | FPI_FOR_HINT blkref #0: rel 1663/5/3079 forknum 0 blk 0 (FPW); hole: offset: 32, length: 7936, compression saved: 0, method: unknown blkref #0: rel 1663/5/3079 forknum 0 blk 0 (FPW); hole: offset: 32, length: 7936, compression saved: 0, method: unknown
Standby | 0/70000D8 | 0/7000210 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
XLOG    | 0/7000210 | 0/7000248 | 30  | 30  | 0 |
Standby | 0/7000248 | 0/7000268 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
XLOG    | 0/7000268 | 0/70002A0 | 114 | 114 | 0 | CHECKPOINT_ONLINE redo 0/7000248; tli 1; prev tli 1; fpw true; wal_level replica; xid 0:756; oid 16402; multi 1; offset 0; oldest xid 730 in DB 1; oldest multi 1 in DB 1; oldest/newest commit timestamp xid: 0/0; oldest running xid 756 online
Standby | 0/70002A0 | 0/7000318 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
```

to put `<empty>` like this one

```
➜  build git:(main) ✗ pgmoneta-walinfo ~/Downloads/000000010000000000000007.partial.gz
Standby | 0/6000120 | 0/7000028 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
XLOG    | 0/7000028 | 0/7000060 | 114 | 114 | 0 | CHECKPOINT_SHUTDOWN redo 0/7000060; tli 1; prev tli 1; fpw true; wal_level replica; xid 0:756; oid 16402; multi 1; offset 0; oldest xid 730 in DB 1; oldest multi 1 in DB 1; oldest/newest commit timestamp xid: 0/0; oldest running xid 0 shutdown
XLOG    | 0/7000060 | 0/70000D8 | 49  | 305 | 0 | FPI_FOR_HINT blkref #0: rel 1663/5/3079 forknum 0 blk 0 (FPW); hole: offset: 32, length: 7936, compression saved: 0, method: unknown blkref #0: rel 1663/5/3079 forknum 0 blk 0 (FPW); hole: offset: 32, length: 7936, compression saved: 0, method: unknown
Standby | 0/70000D8 | 0/7000210 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
XLOG    | 0/7000210 | 0/7000248 | 30  | 30  | 0 | <empty>
Standby | 0/7000248 | 0/7000268 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
XLOG    | 0/7000268 | 0/70002A0 | 114 | 114 | 0 | CHECKPOINT_ONLINE redo 0/7000248; tli 1; prev tli 1; fpw true; wal_level replica; xid 0:756; oid 16402; multi 1; offset 0; oldest xid 730 in DB 1; oldest multi 1 in DB 1; oldest/newest commit timestamp xid: 0/0; oldest running xid 756 online
Standby | 0/70002A0 | 0/7000318 | 50  | 50  | 0 | RUNNING_XACTS next_xid 756 latest_completed_xid 755 oldest_running_xid 756
```
