### PR TITLE
[#792] Memory Leak in `pgmoneta_split()`

### DIFF
--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -4244,6 +4244,7 @@ pgmoneta_split(const char* string, char*** results, int* count, char delimiter)
       goto error;
    }
 
+   free(temp);
    temp = strdup(string);
    if (!temp)
    {


### PR DESCRIPTION
I was getting this error while executing `pgmoneta_split()`
```
Direct leak of 212 byte(s) in 1 object(s) allocated from:
    #0 0x5fa4d41088ce in strdup (/home/ashu3103/Desktop/pgmoneta/build/test/pgmoneta-test+0xd18ce) (BuildId: 7fb0b4825e9f465dcf65b23d0c759c853d761b90)
    #1 0x78ced597ffe4 in pgmoneta_split /home/ashu3103/Desktop/pgmoneta/src/libpgmoneta/utils.c:4208:17
    #2 0x78ced594c262 in transform_text_to_label_file_contents /home/ashu3103/Desktop/pgmoneta/src/libpgmoneta/server.c:1481:8
    #3 0x78ced594bef1 in pgmoneta_server_stop_backup /home/ashu3103/Desktop/pgmoneta/src/libpgmoneta/server.c:690:8
    #4 0x5fa4d4185888 in test_server_api_backup_fn /home/ashu3103/Desktop/pgmoneta/test/testcases/test_server_api.c:107:11
    #5 0x5fa4d4192438 in tcase_run_tfun_nofork check_run.o
```

@jesperpedersen @Mohab96 PTAL