### PR TITLE
[#791] Support for backup start and stop server APIs

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1405,7 +1405,7 @@ pgmoneta_is_wal_file(char* file);
 
 /**
  * Derive the file name from the timeline_id, segment number and segment size
- * 
+ *
  * @param tli The timeline id
  * @param segno The segment number
  * @param segsize The WAL segemnt size

--- a/test/postgresql/src/postgresql17/conf/setup.sql
+++ b/test/postgresql/src/postgresql17/conf/setup.sql
@@ -36,3 +36,6 @@ GRANT pg_read_server_files TO PG_REPL_USER_NAME;
 GRANT EXECUTE ON FUNCTION pg_catalog.pg_switch_wal() TO PG_REPL_USER_NAME;
 GRANT EXECUTE ON FUNCTION pg_read_binary_file(text, bigint, bigint, boolean) TO PG_REPL_USER_NAME;
 GRANT EXECUTE ON FUNCTION pg_stat_file(text, boolean) TO PG_REPL_USER_NAME;
+-- GRANT REPL_USER execute privileges on backup admin functions
+GRANT EXECUTE ON FUNCTION pg_backup_start(text, boolean) TO PG_REPL_USER_NAME;
+GRANT EXECUTE ON FUNCTION pg_backup_stop(boolean) TO PG_REPL_USER_NAME;

--- a/test/testcases/test_server_api.c
+++ b/test/testcases/test_server_api.c
@@ -94,6 +94,23 @@ START_TEST(test_server_api_read_file_metadata)
    ck_assert_msg(ret, "failed to read metatdata of file: %s", file_path);
 }
 END_TEST
+START_TEST(test_server_api_backup)
+{
+   int ret;
+   char* start_lsn = NULL;
+   char* stop_lsn = NULL;
+   struct label_file_contents lf = {0};
+
+   ret = !pgmoneta_server_start_backup(PRIMARY_SERVER, srv_ssl, srv_socket, "test_backup", &start_lsn);
+   ck_assert_msg(ret, "failed to start backup");
+
+   ret = !pgmoneta_server_stop_backup(PRIMARY_SERVER, srv_ssl, srv_socket, &stop_lsn, &lf);
+   ck_assert_msg(ret, "failed to stop backup");
+
+   free(start_lsn);
+   free(stop_lsn);
+}
+END_TEST
 
 Suite*
 pgmoneta_test_server_api_suite()
@@ -110,6 +127,7 @@ pgmoneta_test_server_api_suite()
    tcase_add_test(tc_server_api, test_server_api_checkpoint);
    tcase_add_test(tc_server_api, test_server_api_read_file);
    tcase_add_test(tc_server_api, test_server_api_read_file_metadata);
+   tcase_add_test(tc_server_api, test_server_api_backup);
    suite_add_tcase(s, tc_server_api);
 
    return s;


### PR DESCRIPTION
This patch will add support for `pg_backup_start()` and `pg_backup_stop()` APIs and will also solve #769

Currently, we will be capturing the contents of label file from the `pg_backup_stop()` output and will add `spcmapfile` data in later phases when tablespaces support is to be added.

@jesperpedersen @Jubilee101 PTAL