### PR TITLE
[#622] Add file existence check for walinfo config file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ Arshdeep Singh <balarsh535@gmail.com>
 Mingzhuo Yin <yinmingzhuo@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
 Bassam Adnan <mailbassam@gmail.com>
+Sara Nabih <nabihsara8@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -41,6 +41,7 @@ Din Xin Chen <s990346@gmail.com>
 Mingzhuo Yin <yinmingzhuo@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
 Bassam Adnan <mailbassam@gmail.com>
+Sara Nabih <nabihsara8@gmail.com>
 ```
 
 ## Committers

--- a/doc/manual/hi/97-acknowledgement.md
+++ b/doc/manual/hi/97-acknowledgement.md
@@ -41,6 +41,7 @@ Din Xin Chen <s990346@gmail.com>
 Mingzhuo Yin <yinmingzhuo@gmail.com>
 Vanes Angelo <k124k3n@gmail.com>
 Bassam Adnan <mailbassam@gmail.com>
+Sara Nabih <nabihsara8@gmail.com>
 ```
 
 ## [कमिटर्स]{lang=hi}

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -642,14 +642,18 @@ main(int argc, char** argv)
 
    if (configuration_path != NULL)
    {
-      if (pgmoneta_exists(configuration_path))
+      if (!pgmoneta_exists(configuration_path))
       {
-         loaded = pgmoneta_read_walinfo_configuration(shmem, configuration_path);
+         warnx("Configuration not found: %s", configuration_path);
+         goto error;
       }
-
+      
+      loaded = pgmoneta_read_walinfo_configuration(shmem, configuration_path);
+      
       if (loaded)
       {
          warnx("Configuration not found: %s", configuration_path);
+         goto error;
       }
    }
 


### PR DESCRIPTION
## Problem
When an incorrect configuration file path is provided to pgmoneta-walinfo (e.g., a typo), the program would crash without a clear error message.

## Solution
- Added file existence check before attempting to read the configuration file
- Display clear error message when config file is not found
- Program now exits gracefully with helpful error message

## Testing
Tested with:
1. Non-existent file: Shows "Configuration file not found" error
2. Typo in filename: Shows clear error instead of crashing
3. Valid config file: Works normally

Fixes #622