### PR TITLE
[#607] Get set postgres GUC variables

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -305,6 +305,29 @@ void
 pgmoneta_conf_get(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
 
 /**
+ * Get a postgresql configuration parameter value
+ * @param ssl The SSL connection
+ * @param client_fd The client
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The payload
+ */
+void
+pgmoneta_conf_get_postgresql(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
+
+/**
+ * Set a PostgreSQL GUC parameter value
+ * @param ssl The SSL connection
+ * @param client_fd The client
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The payload
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_conf_set_postgresql(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
+
+/**
  * Set a configuration parameter value
  * @param ssl The SSL connection
  * @param client_fd The client

--- a/src/include/extension.h
+++ b/src/include/extension.h
@@ -127,6 +127,19 @@ int
 pgmoneta_ext_promote(SSL* ssl, int socket, struct query_response** qr);
 
 /**
+ * Set a GUC parameter on the server
+ * @param ssl The SSL structure
+ * @param socket The socket
+ * @param guc_param The GUC parameter name
+ * @param guc_val The GUC parameter value
+ * @param reload Whether to reload the server configuration (optional)
+ * @param qr The query result
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_ext_set_guc(SSL* ssl, int socket, char* guc_param, char* guc_val, bool reload, struct query_response** qr);
+
+/**
  * Parse a semantic version string (e.g., "1.8.2" or "2.1") into version struct
  * @param version_str The version string to parse
  * @param version Output version struct

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -59,37 +59,39 @@ extern "C" {
 /**
  * Management commands
  */
-#define MANAGEMENT_UNKNOWN        0
-#define MANAGEMENT_BACKUP         1
-#define MANAGEMENT_LIST_BACKUP    2
-#define MANAGEMENT_RESTORE        3
-#define MANAGEMENT_ARCHIVE        4
-#define MANAGEMENT_DELETE         5
-#define MANAGEMENT_SHUTDOWN       6
-#define MANAGEMENT_STATUS         7
-#define MANAGEMENT_STATUS_DETAILS 8
-#define MANAGEMENT_PING           9
-#define MANAGEMENT_RESET          10
-#define MANAGEMENT_RELOAD         11
-#define MANAGEMENT_RETAIN         12
-#define MANAGEMENT_EXPUNGE        13
-#define MANAGEMENT_DECRYPT        14
-#define MANAGEMENT_ENCRYPT        15
-#define MANAGEMENT_DECOMPRESS     16
-#define MANAGEMENT_COMPRESS       17
-#define MANAGEMENT_INFO           18
-#define MANAGEMENT_VERIFY         19
-#define MANAGEMENT_ANNOTATE       20
-#define MANAGEMENT_CONF_LS        21
-#define MANAGEMENT_CONF_GET       22
-#define MANAGEMENT_CONF_SET       23
-#define MANAGEMENT_MODE           24
+#define MANAGEMENT_UNKNOWN             0
+#define MANAGEMENT_BACKUP              1
+#define MANAGEMENT_LIST_BACKUP         2
+#define MANAGEMENT_RESTORE             3
+#define MANAGEMENT_ARCHIVE             4
+#define MANAGEMENT_DELETE              5
+#define MANAGEMENT_SHUTDOWN            6
+#define MANAGEMENT_STATUS              7
+#define MANAGEMENT_STATUS_DETAILS      8
+#define MANAGEMENT_PING                9
+#define MANAGEMENT_RESET               10
+#define MANAGEMENT_RELOAD              11
+#define MANAGEMENT_RETAIN              12
+#define MANAGEMENT_EXPUNGE             13
+#define MANAGEMENT_DECRYPT             14
+#define MANAGEMENT_ENCRYPT             15
+#define MANAGEMENT_DECOMPRESS          16
+#define MANAGEMENT_COMPRESS            17
+#define MANAGEMENT_INFO                18
+#define MANAGEMENT_VERIFY              19
+#define MANAGEMENT_ANNOTATE            20
+#define MANAGEMENT_CONF_LS             21
+#define MANAGEMENT_CONF_GET            22
+#define MANAGEMENT_CONF_SET            23
+#define MANAGEMENT_MODE                24
+#define MANAGEMENT_CONF_SET_POSTGRESQL 25
+#define MANAGEMENT_CONF_GET_POSTGRESQL 26
 
-#define MANAGEMENT_MASTER_KEY     24
-#define MANAGEMENT_ADD_USER       25
-#define MANAGEMENT_UPDATE_USER    26
-#define MANAGEMENT_REMOVE_USER    27
-#define MANAGEMENT_LIST_USERS     28
+#define MANAGEMENT_MASTER_KEY          24
+#define MANAGEMENT_ADD_USER            25
+#define MANAGEMENT_UPDATE_USER         26
+#define MANAGEMENT_REMOVE_USER         27
+#define MANAGEMENT_LIST_USERS          28
 
 /**
  * Management categories
@@ -179,6 +181,9 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_WORKERS               "Workers"
 #define MANAGEMENT_ARGUMENT_WORKFLOW              "Workflow"
 #define MANAGEMENT_ARGUMENT_WORKSPACE_FREE_SPACE  "WorkspaceFreeSpace"
+#define MANAGEMENT_ARGUMENT_GUC_PARAM             "GucParam"
+#define MANAGEMENT_ARGUMENT_GUC_VALUE             "GucValue"
+#define MANAGEMENT_ARGUMENT_RELOAD                "Reload"
 
 /**
  * Management error
@@ -362,6 +367,23 @@ extern "C" {
 #define MANAGEMENT_ERROR_MODE_NETWORK                       2803
 #define MANAGEMENT_ERROR_MODE_ERROR                         2804
 #define MANAGEMENT_ERROR_MODE_UNKNOWN_ACTION                2805
+
+#define MANAGEMENT_ERROR_CONF_GET_POSTGRESQL                2900
+#define MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_NOUSER         2901
+#define MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_AUTH           2902
+#define MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_QUERY          2903
+#define MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_NOSERVER       2904
+#define MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_OFFLINE        2905
+#define MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_NOFORK         2906
+
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL                3000
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_NOEXT          3001
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_NOUSER         3002
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_AUTH           3003
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_QUERY          3004
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_NOSERVER       3005
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_OFFLINE        3006
+#define MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_NOFORK         3007
 
 /**
  * Output formats
@@ -600,6 +622,23 @@ int
 pgmoneta_management_request_conf_get(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
+ * Create a conf get request for postgresql query
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The postgresql server
+ * @param guc_param The postgresql GUC parameter
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_request_conf_get_postgresql(SSL* ssl, int socket,
+                                                char* server, char* guc_param,
+                                                uint8_t compression, uint8_t encryption,
+                                                int32_t output_format);
+
+/**
  * Create a conf get request
  * @param ssl The SSL connection
  * @param socket The socket descriptor
@@ -612,6 +651,22 @@ pgmoneta_management_request_conf_get(SSL* ssl, int socket, uint8_t compression, 
  */
 int
 pgmoneta_management_request_conf_set(SSL* ssl, int socket, char* config_key, char* config_value, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Create a conf get request
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The postgresql server
+ * @param guc_param The postgresql GUC parameter
+ * @param guc_value The postgresql GUC value
+ * @param reload Whether to reload the configuration
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_request_conf_set_postgresql(SSL* ssl, int socket, char* server, char* guc_param, char* guc_value, bool reload, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Create a retain request

--- a/src/libpgmoneta/extension.c
+++ b/src/libpgmoneta/extension.c
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <utils.h>
 #include <extension.h>
 #include <logging.h>
 #include <message.h>
@@ -92,6 +93,15 @@ int
 pgmoneta_ext_promote(SSL* ssl, int socket, struct query_response** qr)
 {
    return query_execute(ssl, socket, "SELECT pgmoneta_ext_promote();", qr);
+}
+
+int
+pgmoneta_ext_set_guc(SSL* ssl, int socket, char* guc_param, char* guc_val, bool reload, struct query_response** qr)
+{
+   char query[MAX_QUERY_LENGTH];
+   const char* reload_str = reload ? "true" : "false";
+   pgmoneta_snprintf(query, MAX_QUERY_LENGTH, "SELECT pgmoneta_ext_set_guc('%s', '%s', %s);", guc_param, guc_val, reload_str);
+   return query_execute(ssl, socket, query, qr);
 }
 
 static int

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -526,6 +526,42 @@ error:
 }
 
 int
+pgmoneta_management_request_conf_get_postgresql(SSL* ssl, int socket,
+                                                char* server, char* guc_param,
+                                                uint8_t compression, uint8_t encryption,
+                                                int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgmoneta_management_create_header(MANAGEMENT_CONF_GET_POSTGRESQL, compression, encryption,
+                                         output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_GUC_PARAM, (uintptr_t)guc_param, ValueString);
+
+   if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_destroy(j);
+   return 0;
+
+error:
+   pgmoneta_json_destroy(j);
+   return 1;
+}
+
+int
 pgmoneta_management_request_conf_set(SSL* ssl, int socket, char* config_key, char* config_value, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    struct json* j = NULL;
@@ -543,6 +579,43 @@ pgmoneta_management_request_conf_set(SSL* ssl, int socket, char* config_key, cha
 
    pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_CONFIG_KEY, (uintptr_t)config_key, ValueString);
    pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_CONFIG_VALUE, (uintptr_t)config_value, ValueString);
+
+   if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgmoneta_json_destroy(j);
+
+   return 1;
+}
+
+int
+pgmoneta_management_request_conf_set_postgresql(SSL* ssl, int socket, char* server, char* guc_param, char* guc_value, bool reload, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgmoneta_management_create_header(MANAGEMENT_CONF_SET_POSTGRESQL, compression, encryption, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_GUC_PARAM, (uintptr_t)guc_param, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_GUC_VALUE, (uintptr_t)guc_value, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_RELOAD, (uintptr_t)reload, ValueBool);
 
    if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
    {

--- a/src/main.c
+++ b/src/main.c
@@ -1431,6 +1431,27 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          pgmoneta_conf_get(NULL, client_fd, compression, encryption, pyl);
       }
    }
+   else if (id == MANAGEMENT_CONF_GET_POSTGRESQL)
+   {
+      pid = fork();
+      if (pid == -1)
+      {
+         pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_NOFORK, NAME, compression, encryption, payload);
+         pgmoneta_log_error("Conf Get PostgreSQL: No fork %s (%d)", server, MANAGEMENT_ERROR_CONF_GET_POSTGRESQL_NOFORK);
+         goto error;
+      }
+      else if (pid == 0)
+      {
+         struct json* pyl = NULL;
+
+         shutdown_ports();
+
+         pgmoneta_json_clone(payload, &pyl);
+
+         pgmoneta_set_proc_title(1, ai->argv, "conf get-postgresql", NULL);
+         pgmoneta_conf_get_postgresql(NULL, client_fd, compression, encryption, pyl);
+      }
+   }
    else if (id == MANAGEMENT_CONF_SET)
    {
       pid = fork();
@@ -1450,6 +1471,27 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
          pgmoneta_set_proc_title(1, ai->argv, "conf set", NULL);
          reload_set_configuration(NULL, client_fd, compression, encryption, pyl);
+      }
+   }
+   else if (id == MANAGEMENT_CONF_SET_POSTGRESQL)
+   {
+      pid = fork();
+      if (pid == -1)
+      {
+         pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_NOFORK, NAME, compression, encryption, payload);
+         pgmoneta_log_error("Conf Set PostgreSQL: No fork %s (%d)", server, MANAGEMENT_ERROR_CONF_SET_POSTGRESQL_NOFORK);
+         goto error;
+      }
+      else if (pid == 0)
+      {
+         struct json* pyl = NULL;
+
+         shutdown_ports();
+
+         pgmoneta_json_clone(payload, &pyl);
+
+         pgmoneta_set_proc_title(1, ai->argv, "conf set-postgresql", NULL);
+         pgmoneta_conf_set_postgresql(NULL, client_fd, compression, encryption, pyl);
       }
    }
    else if (id == MANAGEMENT_STATUS)


### PR DESCRIPTION
Relates #607

- [x] Implement `get-postgresql` command
- [x] Implement `set-postgresql` command on pgmoneta
- [x] Add `reload` option for the `set-postgresql` command
- [ ] https://github.com/pgmoneta/pgmoneta_ext/pull/33

## Semantics
An alternative command spelling (get-postgresql) is currently used to avoid ambiguity (possible confusion on user side). This can be aligned with existing `get <object>` semantics if preferred.

## Implementation

### Get-postgresql command (similar response to get)
`get-postgresql <server>` -> returns all the guc param values
`get-postgresql <server> <guc_param>` -> returns the value only of the guc_param

### Set-postgresql command (similar response to set)
`set-postgresql <server> <guc_param> <guc_value>` -> sets the value to guc parameter

To get over the limitation of not able to send set command over the message protocol, the [pgmoneta_ext](https://github.com/pgmoneta/pgmoneta_ext) will be used to get the response from server.

## Constraints

The `set` command will require the installation of the `pgmoneta_ext` and `EXECUTE` privilege on the function (to be created) `pgmoneta_ext_set_guc ` be granted to the pgmoneta role.

### Requirements from the extension function
- Be a `SECURITY DEFINER` function
- Raise errors when running on standby, unknown guc param, and return any error that postgres raises
- Return the response in such format
`
{
  "parameter": "param",
  "old_value": "old",
  "new_value": "new",
  "restart_required": "t"
}
`