### PR TITLE
[#820] Log test case start to identify failing tests faster

### DIFF
--- a/test/testcases/test_art.c
+++ b/test/testcases/test_art.c
@@ -49,6 +49,7 @@ static void test_obj_destroy_cb(uintptr_t obj);
 
 START_TEST(test_art_create)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    pgmoneta_art_create(&t);
 
@@ -59,6 +60,7 @@ START_TEST(test_art_create)
 END_TEST
 START_TEST(test_art_insert)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    void* mem = NULL;
    struct art_test_obj* obj = NULL;
@@ -89,6 +91,7 @@ START_TEST(test_art_insert)
 END_TEST
 START_TEST(test_art_search)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    struct art_test_obj* obj1 = NULL;
    struct art_test_obj* obj2 = NULL;
@@ -149,6 +152,7 @@ START_TEST(test_art_search)
 END_TEST
 START_TEST(test_art_basic_delete)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    void* mem = NULL;
    struct art_test_obj* obj = NULL;
@@ -213,6 +217,7 @@ START_TEST(test_art_basic_delete)
 END_TEST
 START_TEST(test_art_double_delete)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    pgmoneta_art_create(&t);
 
@@ -237,6 +242,7 @@ START_TEST(test_art_double_delete)
 END_TEST
 START_TEST(test_art_clear)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    void* mem = NULL;
    struct art_test_obj* obj = NULL;
@@ -274,6 +280,7 @@ START_TEST(test_art_clear)
 END_TEST
 START_TEST(test_art_iterator_read)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    struct art_iterator* iter = NULL;
    void* mem = NULL;
@@ -350,6 +357,7 @@ START_TEST(test_art_iterator_read)
 END_TEST
 START_TEST(test_art_iterator_remove)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    struct art_iterator* iter = NULL;
    void* mem = NULL;
@@ -442,6 +450,7 @@ START_TEST(test_art_iterator_remove)
 END_TEST
 START_TEST(test_art_insert_search_extensive)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    char buf[512];
    FILE* f = NULL;
@@ -483,6 +492,7 @@ START_TEST(test_art_insert_search_extensive)
 END_TEST
 START_TEST(test_art_insert_very_long)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t;
    pgmoneta_art_create(&t);
 
@@ -533,6 +543,7 @@ START_TEST(test_art_insert_very_long)
 END_TEST
 START_TEST(test_art_random_delete)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t = NULL;
    char buf[512];
    FILE* f = NULL;
@@ -589,6 +600,7 @@ START_TEST(test_art_random_delete)
 END_TEST
 START_TEST(test_art_insert_index_out_of_range)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct art* t;
    pgmoneta_art_create(&t);
    char* s1 = "abcdefghijklmnxyz";

--- a/test/testcases/test_backup.c
+++ b/test/testcases/test_backup.c
@@ -33,11 +33,14 @@
 #include <tscommon.h>
 #include <tssuite.h>
 
+#include <stdio.h>
+
 #include "logging.h"
 
 // test backup
 START_TEST(test_pgmoneta_backup_full)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int ret = 0;
    ret = !pgmoneta_tsclient_backup("primary", NULL);
    ck_assert_msg(ret, "failed to add full backup");
@@ -45,6 +48,7 @@ START_TEST(test_pgmoneta_backup_full)
 END_TEST
 START_TEST(test_pgmoneta_backup_incremental_basic)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int ret = 0;
    char* d = NULL;
    int num_backups = 0;

--- a/test/testcases/test_brt_io.c
+++ b/test/testcases/test_brt_io.c
@@ -34,6 +34,7 @@
 #include <tssuite.h>
 #include <utils.h>
 #include <walfile/wal_reader.h>
+#include <stdio.h>
 
 static void relation_fork_init(int spcoid, int dboid, int relnum, enum fork_number forknum, struct rel_file_locator* r, enum fork_number* frk);
 static void consecutive_mark_block_modified(block_ref_table* brt, struct rel_file_locator* rlocator, enum fork_number frk, block_number blkno, int n);
@@ -43,6 +44,7 @@ static char* get_backup_summary_path();
 
 START_TEST(test_pgmoneta_write_multiple_chunks_multiple_representations)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    block_ref_table* brt;
    // This test will create a block reference table with multiple chunks
    // and switch from bitmap representation to array representation
@@ -62,6 +64,7 @@ START_TEST(test_pgmoneta_write_multiple_chunks_multiple_representations)
 END_TEST
 START_TEST(test_pgmoneta_read_chunks)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int size = 4096;
    int nblocks;
    block_number start_blk = 0;

--- a/test/testcases/test_delete.c
+++ b/test/testcases/test_delete.c
@@ -33,10 +33,12 @@
 #include <tssuite.h>
 #include <tscommon.h>
 #include <utils.h>
+#include <stdio.h>
 
 // test delete a single full backup
 START_TEST(test_pgmoneta_delete_full)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int found = 0;
    found = !pgmoneta_tsclient_delete("primary", "oldest");
    ck_assert_msg(found, "success status not found");
@@ -45,6 +47,7 @@ END_TEST
 // test delete the last incremental backup in the chain
 START_TEST(test_pgmoneta_delete_chain_last)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int found = 0;
    char* d = NULL;
    int num_bck_before = 0;
@@ -80,6 +83,7 @@ END_TEST
 // test delete the middle incremental backup in the chain
 START_TEST(test_pgmoneta_delete_chain_middle)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int found = 0;
    char* d = NULL;
    int num_bck_before = 0;
@@ -116,6 +120,7 @@ END_TEST
 // test delete the root full backup in the chain
 START_TEST(test_pgmoneta_delete_chain_root)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int found = 0;
    char* d = NULL;
    int num_bck_before = 0;

--- a/test/testcases/test_deque.c
+++ b/test/testcases/test_deque.c
@@ -32,6 +32,7 @@
 #include <tssuite.h>
 #include <utils.h>
 #include <value.h>
+#include <stdio.h>
 
 struct deque_test_obj
 {
@@ -45,6 +46,7 @@ static void test_obj_destroy_cb(uintptr_t obj);
 
 START_TEST(test_deque_create)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
 
    ck_assert(!pgmoneta_deque_create(false, &dq));
@@ -56,6 +58,7 @@ START_TEST(test_deque_create)
 END_TEST
 START_TEST(test_deque_add_poll)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
 
    pgmoneta_deque_create(false, &dq);
@@ -85,6 +88,7 @@ START_TEST(test_deque_add_poll)
 END_TEST
 START_TEST(test_deque_add_poll_last)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
 
    pgmoneta_deque_create(false, &dq);
@@ -115,6 +119,7 @@ START_TEST(test_deque_add_poll_last)
 END_TEST
 START_TEST(test_deque_clear)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
 
    pgmoneta_deque_create(false, &dq);
@@ -132,6 +137,7 @@ START_TEST(test_deque_clear)
 END_TEST
 START_TEST(test_deque_remove)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
    char* value1 = NULL;
    char* tag = NULL;
@@ -158,6 +164,7 @@ START_TEST(test_deque_remove)
 END_TEST
 START_TEST(test_deque_add_with_config_and_get)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
    struct value_config test_obj_config = {.destroy_data = test_obj_destroy_cb, .to_string = NULL};
    struct deque_test_obj* obj1 = NULL;
@@ -188,6 +195,7 @@ START_TEST(test_deque_add_with_config_and_get)
 END_TEST
 START_TEST(test_deque_iterator_read)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
    struct deque_iterator* iter = NULL;
    int cnt = 0;
@@ -220,6 +228,7 @@ START_TEST(test_deque_iterator_read)
 END_TEST
 START_TEST(test_deque_iterator_remove)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
    struct deque_iterator* iter = NULL;
    int cnt = 0;
@@ -263,6 +272,7 @@ START_TEST(test_deque_iterator_remove)
 END_TEST
 START_TEST(test_deque_sort)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct deque* dq = NULL;
    struct deque_iterator* iter = NULL;
    int cnt = 0;

--- a/test/testcases/test_http.c
+++ b/test/testcases/test_http.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <sys/select.h>
 #include <sys/time.h>
+#include <stdio.h>
 
 struct echo_server
 {
@@ -56,6 +57,7 @@ static void teardown_echo_server(void);
 
 START_TEST(test_pgmoneta_http_get)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int status;
    struct http* connection = NULL;
    struct http_request* request = NULL;
@@ -79,6 +81,7 @@ START_TEST(test_pgmoneta_http_get)
 END_TEST
 START_TEST(test_pgmoneta_http_post)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int status;
    struct http* connection = NULL;
    struct http_request* request = NULL;
@@ -104,6 +107,7 @@ START_TEST(test_pgmoneta_http_post)
 END_TEST
 START_TEST(test_pgmoneta_http_put)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int status;
    struct http* connection = NULL;
    struct http_request* request = NULL;
@@ -129,6 +133,7 @@ START_TEST(test_pgmoneta_http_put)
 END_TEST
 START_TEST(test_pgmoneta_http_put_file)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int status;
    struct http* connection = NULL;
    struct http_request* request = NULL;
@@ -173,6 +178,7 @@ START_TEST(test_pgmoneta_http_put_file)
 END_TEST
 START_TEST(test_pgmoneta_http_header_operations)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct http_request* request = NULL;
    char* header_value = NULL;
 

--- a/test/testcases/test_json.c
+++ b/test/testcases/test_json.c
@@ -31,9 +31,11 @@
 #include <tscommon.h>
 #include <tssuite.h>
 #include <utils.h>
+#include <stdio.h>
 
 START_TEST(test_json_create)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct json* obj = NULL;
 
    ck_assert(!pgmoneta_json_create(&obj));
@@ -45,6 +47,7 @@ START_TEST(test_json_create)
 END_TEST
 START_TEST(test_json_put_basic)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct json* obj = NULL;
 
    ck_assert(!pgmoneta_json_create(&obj));
@@ -68,6 +71,7 @@ START_TEST(test_json_put_basic)
 END_TEST
 START_TEST(test_json_append_basic)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct json* obj = NULL;
 
    ck_assert(!pgmoneta_json_create(&obj));
@@ -85,6 +89,7 @@ START_TEST(test_json_append_basic)
 END_TEST
 START_TEST(test_json_parse_to_string)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct json* obj = NULL;
    struct json* obj_parsed = NULL;
    char* str_obj = NULL;
@@ -219,6 +224,7 @@ START_TEST(test_json_parse_to_string)
 END_TEST
 START_TEST(test_json_remove)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct json* obj = NULL;
    struct json* array = NULL;
    pgmoneta_json_create(&obj);
@@ -255,6 +261,7 @@ START_TEST(test_json_remove)
 END_TEST
 START_TEST(test_json_iterator)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    struct json* item = NULL;
    struct json* array = NULL;
    struct json_iterator* iiter = NULL;

--- a/test/testcases/test_restore.c
+++ b/test/testcases/test_restore.c
@@ -30,10 +30,12 @@
 #include <tssuite.h>
 #include <tsclient.h>
 #include <tscommon.h>
+#include <stdio.h>
 
 // test restore
 START_TEST(test_pgmoneta_restore)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int found = 0;
    found = !pgmoneta_tsclient_restore("primary", "newest", "current");
    ck_assert_msg(found, "success status not found");

--- a/test/testcases/test_server_api.c
+++ b/test/testcases/test_server_api.c
@@ -45,6 +45,7 @@ static void teardown_server_connection(void);
 
 START_TEST(test_server_api_info)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int ret;
    struct main_configuration* config = NULL;
    struct server srv;
@@ -62,6 +63,7 @@ START_TEST(test_server_api_info)
 END_TEST
 START_TEST(test_server_api_checkpoint)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int ret;
    uint64_t chkt;
    uint32_t tli;
@@ -72,6 +74,7 @@ START_TEST(test_server_api_checkpoint)
 END_TEST
 START_TEST(test_server_api_read_file)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int ret;
    uint8_t* data;
    int data_length;
@@ -86,6 +89,7 @@ START_TEST(test_server_api_read_file)
 END_TEST
 START_TEST(test_server_api_read_file_metadata)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int ret;
    struct file_stats stat;
    char file_path[] = "postgresql.conf";
@@ -96,6 +100,7 @@ START_TEST(test_server_api_read_file_metadata)
 END_TEST
 START_TEST(test_server_api_backup)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    int ret;
    char* start_lsn = NULL;
    char* stop_lsn = NULL;

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -33,9 +33,11 @@
 #include <utils.h>
 
 #include <stdlib.h>
+#include <stdio.h>
 
 START_TEST(test_resolve_path_trailing_env_var)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    char* resolved = NULL;
    char* env_key = "PGMONETA_TEST_PATH_KEY";
    char* env_value = "PGMONETA_TEST_PATH_VALUE";

--- a/test/testcases/test_wal_summary.c
+++ b/test/testcases/test_wal_summary.c
@@ -46,9 +46,11 @@
 #include <walfile.h>
 #include <walfile/wal_reader.h>
 #include <walfile/wal_summary.h>
+#include <stdio.h>
 
 START_TEST(test_pgmoneta_wal_summary)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    char* summary_dir = NULL;
    struct main_configuration* config = NULL;
    SSL* srv_ssl = NULL;

--- a/test/testcases/test_wal_utils.c
+++ b/test/testcases/test_wal_utils.c
@@ -61,6 +61,7 @@ static void destroy_walfile(struct walfile* wf);
 
 START_TEST(test_check_point_shutdown_v17)
 {
+   fprintf(stderr, "TEST START: %s\n", __func__);
    test_walfile(pgmoneta_test_generate_check_point_shutdown_v17);
 }
 END_TEST


### PR DESCRIPTION
## Problem
When a test failed in CI or local runs, it was difficult and time-consuming to identify which specific test case was executing at the time of failure, especially for long-running or flaky tests (e.g. container-based tests).

The test output often only showed a failure or timeout without clearly indicating the last executed test case.

## Solution
Added a lightweight log at the start of every test case to clearly indicate which test is being executed.

Each test now prints:

`TEST START: <test_function_name>`

### Implementation Details

Logged the test start using:

`fprintf(stderr, "TEST START: %s\n", __func__);`

Applied consistently across all test cases

-  Uses stderr to ensure output is visible in CI and ctest logs

- No test logic or behavior was changed

- No additional dependencies introduced

### Fixes-[#820]