### PR TITLE
Added pgmoneta_cli conf

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -14,7 +14,7 @@ Usage:
   pgmoneta-cli [ -c CONFIG_FILE ] [ COMMAND ]
 
 Options:
-  -c, --config CONFIG_FILE                        Set the path to the pgmoneta.conf file
+  -c, --config CONFIG_FILE                        Set the path to the pgmoneta_cli.conf file
   -h, --host HOST                                 Set the host name
   -p, --port PORT                                 Set the port number
   -U, --user USERNAME                             Set the user name

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,6 +11,8 @@ if (RST2MAN_FOUND)
   set(PGMONETA_ADMIN_DST_FILE "${CMAKE_CURRENT_BINARY_DIR}/pgmoneta-admin.1")
   set(PGMONETA_CONF_SRC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/man/pgmoneta.conf.5.rst")
   set(PGMONETA_CONF_DST_FILE "${CMAKE_CURRENT_BINARY_DIR}/pgmoneta.conf.5")
+  set(PGMONETA_CLI_CONF_SRC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/man/pgmoneta-cli.conf.5.rst")
+  set(PGMONETA_CLI_CONF_DST_FILE "${CMAKE_CURRENT_BINARY_DIR}/pgmoneta-cli.conf.5")
   set(PGMONETA_WALFILTER_SRC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/man/pgmoneta-walfilter.1.rst")
   set(PGMONETA_WALFILTER_DST_FILE "${CMAKE_CURRENT_BINARY_DIR}/pgmoneta-walfilter.1")
   set(PGMONETA_WALINFO_SRC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/man/pgmoneta-walinfo.1.rst")
@@ -45,6 +47,13 @@ if (RST2MAN_FOUND)
     DEPENDS ${PGMONETA_CONF_SRC_FILE}
     COMMENT "Generating man page: pgmoneta.conf.5"
   )
+  # pgmoneta-cli.conf.5
+  add_custom_command(
+    OUTPUT ${PGMONETA_CLI_CONF_DST_FILE}
+    COMMAND ${RST2MAN_EXECUTABLE} ${PGMONETA_CLI_CONF_SRC_FILE} ${PGMONETA_CLI_CONF_DST_FILE}
+    DEPENDS ${PGMONETA_CLI_CONF_SRC_FILE}
+    COMMENT "Generating man page: pgmoneta-cli.conf.5"
+  )
   # pgmoneta-walfilter.1
   add_custom_command(
     OUTPUT ${PGMONETA_WALFILTER_DST_FILE}
@@ -62,7 +71,7 @@ if (RST2MAN_FOUND)
 
   # Group man page outputs into a target
   add_custom_target(manpages ALL
-    DEPENDS ${PGMONETA_DST_FILE} ${PGMONETA_CLI_DST_FILE} ${PGMONETA_ADMIN_DST_FILE} ${PGMONETA_CONF_DST_FILE} ${PGMONETA_WALFILTER_DST_FILE} ${PGMONETA_WALINFO_DST_FILE}
+    DEPENDS ${PGMONETA_DST_FILE} ${PGMONETA_CLI_DST_FILE} ${PGMONETA_ADMIN_DST_FILE} ${PGMONETA_CONF_DST_FILE} ${PGMONETA_CLI_CONF_DST_FILE} ${PGMONETA_WALFILTER_DST_FILE} ${PGMONETA_WALINFO_DST_FILE}
   )
 
   # Make 'man' depend on 'manpages'
@@ -81,6 +90,7 @@ if (RST2MAN_FOUND)
   install(FILES ${PGMONETA_WALFILTER_DST_FILE} DESTINATION share/man/man1)
   install(FILES ${PGMONETA_WALINFO_DST_FILE} DESTINATION share/man/man1)
   install(FILES ${PGMONETA_CONF_DST_FILE} DESTINATION share/man/man5)
+  install(FILES ${PGMONETA_CLI_CONF_DST_FILE} DESTINATION share/man/man5)
 endif()
 
 #

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -156,6 +156,26 @@ If pgmoneta has both Transport Layer Security (TLS) and `management` enabled the
 connect with TLS using the files `~/.pgmoneta/pgmoneta.key` (must be 0600 permission),
 `~/.pgmoneta/pgmoneta.crt` and `~/.pgmoneta/root.crt`.
 
+# pgmoneta_cli configuration
+
+The `pgmoneta_cli` configuration defines defaults for the `pgmoneta-cli` client. It is loaded from the path passed with `-c` or from `/etc/pgmoneta/pgmoneta_cli.conf` if `-c` is not supplied. Command-line flags override values in this file.
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| host |  | String | No | Management host to connect to. If omitted, `unix_socket_dir` may be used for a local Unix socket connection. |
+| port | 0 | Int | No | Management port to connect to. Required for remote TCP connections unless a Unix socket is used. |
+| unix_socket_dir |  | String | No | Directory containing the pgmoneta Unix Domain Socket. Enables local management without host/port. Can interpolate environment variables (e.g., `$HOME`). |
+| compression | none | String | No | Wire-protocol compression (`none`, `gzip`, `zstd`, `lz4`, `bzip2`). Applies only to CLI<->server traffic. |
+| encryption | none | String | No | Wire-protocol encryption (`none`, `aes256`, `aes192`, `aes128`). Applies only to CLI<->server traffic. |
+| output | text | String | No | Default CLI output format (`text`, `json`, `raw`). |
+| log_type | console | String | No | Logging type for the CLI (`console`, `file`, `syslog`). |
+| log_level | info | String | No | Logging level (`fatal`, `error`, `warn`, `info`, `debug`/`debug1`-`debug5`). |
+| log_path | pgmoneta-cli.log | String | No | Log file path when `log_type = file`. Can interpolate environment variables (e.g., `$HOME`). |
+| log_mode | append | String | No | Log file mode (`append`, `create`). |
+| log_rotation_age | 0 | String | No | Time-based rotation. `0` disables. Supports `S`, `M`, `H`, `D`, `W` suffixes (seconds default). |
+| log_rotation_size | 0 | String | No | Size-based rotation. `0` disables. Supports `B` (default), `K/KB`, `M/MB`, `G/GB`. |
+| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | strftime(3) format prefix for log lines. |
+
 ## Configuration Directory
 
 You can specify a directory for all configuration files using the `-D` flag (or `--directory`).

--- a/doc/man/pgmoneta-cli.1.rst
+++ b/doc/man/pgmoneta-cli.1.rst
@@ -22,7 +22,7 @@ OPTIONS
 =======
 
 -c, --config CONFIG_FILE
-  Set the path to the pgmoneta.conf file
+  Set the path to the pgmoneta_cli.conf file
 
 -h, --host HOST
   Set the host name
@@ -139,4 +139,4 @@ pgmoneta is licensed under the 3-clause BSD License.
 SEE ALSO
 ========
 
-pgmoneta.conf(5), pgmoneta(1), pgmoneta-admin(1)
+pgmoneta-cli.conf(5), pgmoneta.conf(5), pgmoneta(1), pgmoneta-admin(1)

--- a/doc/man/pgmoneta-cli.conf.5.rst
+++ b/doc/man/pgmoneta-cli.conf.5.rst
@@ -1,0 +1,78 @@
+=================
+pgmoneta-cli.conf
+=================
+
+--------------------------------------------------------
+Configuration file for pgmoneta-cli command line utility
+--------------------------------------------------------
+
+:Manual section: 5
+
+DESCRIPTION
+===========
+
+pgmoneta-cli.conf is the configuration file for pgmoneta-cli.
+
+This file defines default settings for the pgmoneta-cli command line utility. It is loaded from the path specified with ``-c`` or from ``/etc/pgmoneta/pgmoneta_cli.conf`` if ``-c`` is not provided. Command-line flags always override values from the configuration file.
+
+All properties are in the format ``key = value``.
+
+The characters ``#`` and ``;`` can be used for comments; must be the first character on the line.
+The ``Bool`` data type supports the following values: ``on``, ``1``, ``true``, ``off``, ``0`` and ``false``.
+
+OPTIONS
+=======
+
+host
+  Management host to connect to. If omitted, ``unix_socket_dir`` may be used for a local Unix socket connection.
+
+port
+  Management port to connect to. Required for remote TCP connections unless a Unix socket is used. Default is 0 (disabled)
+
+unix_socket_dir
+  Directory containing the pgmoneta Unix Domain Socket. Enables local management without host/port. Supports environment variable interpolation (e.g., $HOME).
+
+compression
+  Wire-protocol compression. Available options: ``none``, ``gzip``, ``zstd``, ``lz4``, ``bzip2``. Applies only to CLI<->server traffic. Default is ``none``
+
+encryption
+  Wire-protocol encryption. Available options: ``none``, ``aes256``, ``aes192``, ``aes128``. Applies only to CLI<->server traffic. Default is ``none``
+
+output
+  Default CLI output format. Available options: ``text``, ``json``, ``raw``. Default is ``text``
+
+log_type
+  Logging type for the CLI. Available options: ``console``, ``file``, ``syslog``. Default is ``console``
+
+log_level
+  Logging level. Available options: ``fatal``, ``error``, ``warn``, ``info``, ``debug`` (and ``debug1``-``debug5``). Default is ``info``
+
+log_path
+  Log file path when ``log_type = file``. Supports environment variable interpolation (e.g., $HOME). Default is ``pgmoneta-cli.log``
+
+log_mode
+  Log file mode. Available options: ``append``, ``create``. Default is ``append``
+
+log_rotation_age
+  Time-based log rotation. If this value is specified without units, it is taken as seconds. Setting this parameter to 0 disables log rotation based on time. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. Default is 0 (disabled)
+
+log_rotation_size
+  Size-based log rotation. Supports suffixes: ``B`` (bytes), the default if omitted, ``K`` or ``KB`` (kilobytes), ``M`` or ``MB`` (megabytes), ``G`` or ``GB`` (gigabytes). A value of 0 (with or without suffix) disables. Default is 0 (disabled)
+
+log_line_prefix
+  A strftime(3) compatible string to use as prefix for every log line. Must be quoted if contains spaces. Default is ``%Y-%m-%d %H:%M:%S``
+
+REPORTING BUGS
+==============
+
+pgmoneta is maintained on GitHub at https://github.com/pgmoneta/pgmoneta
+
+COPYRIGHT
+=========
+
+pgmoneta is licensed under the 3-clause BSD License.
+
+SEE ALSO
+========
+
+pgmoneta-cli(1), pgmoneta.conf(5), pgmoneta(1), pgmoneta-admin(1)

--- a/doc/man/pgmoneta.conf.5.rst
+++ b/doc/man/pgmoneta.conf.5.rst
@@ -338,4 +338,4 @@ pgmoneta is licensed under the 3-clause BSD License.
 SEE ALSO
 ========
 
-pgmoneta(1), pgmoneta-cli(1), pgmoneta-admin(1)
+pgmoneta(1), pgmoneta-cli(1), pgmoneta-cli.conf(5), pgmoneta-admin(1)

--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -125,7 +125,7 @@ Usage:
   pgmoneta-cli [ -c CONFIG_FILE ] [ COMMAND ]
 
 Options:
-  -c, --config CONFIG_FILE                       Set the path to the pgmoneta.conf file
+  -c, --config CONFIG_FILE                       Set the path to the pgmoneta_cli.conf file
   -h, --host HOST                                Set the host name
   -p, --port PORT                                Set the port number
   -U, --user USERNAME                            Set the user name

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -275,6 +275,27 @@ If pgmoneta has both Transport Layer Security (TLS) and `management` enabled the
 connect with TLS using the files `~/.pgmoneta/pgmoneta.key` (must be 0600 permission),
 `~/.pgmoneta/pgmoneta.crt` and `~/.pgmoneta/root.crt`.
 
+## pgmoneta_cli.conf
+
+The `pgmoneta_cli` configuration defines defaults for the `pgmoneta-cli` client. It is loaded from the path passed with `-c` or from `/etc/pgmoneta/pgmoneta_cli.conf` if `-c` is not supplied. Command-line flags override values in this file.
+
+| Property | Default | Unit | Required | Description |
+| :------- | :------ | :--- | :------- | :---------- |
+| host |  | String | No | Management host to connect to. If omitted, `unix_socket_dir` may be used for a local Unix socket connection. |
+| port | 0 | Int | No | Management port to connect to. Required for remote TCP connections unless a Unix socket is used. |
+| unix_socket_dir |  | String | No | Directory containing the pgmoneta Unix Domain Socket. Enables local management without host/port. Can interpolate environment variables (e.g., `$HOME`). |
+| compression | none | String | No | Wire-protocol compression (`none`, `gzip`, `zstd`, `lz4`, `bzip2`). Applies only to CLI<->server traffic. |
+| encryption | none | String | No | Wire-protocol encryption (`none`, `aes256`, `aes192`, `aes128`). Applies only to CLI<->server traffic. |
+| output | text | String | No | Default CLI output format (`text`, `json`, `raw`). |
+| log_type | console | String | No | Logging type for the CLI (`console`, `file`, `syslog`). |
+| log_level | info | String | No | Logging level (`fatal`, `error`, `warn`, `info`, `debug`/`debug1`-`debug5`). |
+| log_path | pgmoneta-cli.log | String | No | Log file path when `log_type = file`. Can interpolate environment variables (e.g., `$HOME`). |
+| log_mode | append | String | No | Log file mode (`append`, `create`). |
+| log_rotation_age | 0 | String | No | Time-based rotation. `0` disables. Supports `S`, `M`, `H`, `D`, `W` suffixes (seconds default). |
+| log_rotation_size | 0 | String | No | Size-based rotation. `0` disables. Supports `B` (default), `K/KB`, `M/MB`, `G/GB`. |
+| log_line_prefix | %Y-%m-%d %H:%M:%S | String | No | strftime(3) format prefix for log lines. |
+
+
 ## Configuration Directory
 
 You can specify a directory for all configuration files using the `-D` flag (or `--directory`).
@@ -312,4 +333,3 @@ pgmoneta -d
 ```
 
 Refer to logs for details about which configuration files were loaded and from which locations.
-

--- a/doc/manual/en/05-cli.md
+++ b/doc/manual/en/05-cli.md
@@ -16,7 +16,7 @@ Usage:
   pgmoneta-cli [ -c CONFIG_FILE ] [ COMMAND ]
 
 Options:
-  -c, --config CONFIG_FILE                        Set the path to the pgmoneta.conf file
+  -c, --config CONFIG_FILE                        Set the path to the pgmoneta_cli.conf file
   -h, --host HOST                                 Set the host name
   -p, --port PORT                                 Set the port number
   -U, --user USERNAME                             Set the user name

--- a/pgmoneta.spec
+++ b/pgmoneta.spec
@@ -60,6 +60,7 @@ cmake -DCMAKE_BUILD_TYPE=Release -DDOCS=FALSE ..
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-admin.1 %{buildroot}%{_mandir}/man1/pgmoneta-admin.1
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-cli.1 %{buildroot}%{_mandir}/man1/pgmoneta-cli.1
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta.conf.5 %{buildroot}%{_mandir}/man5/pgmoneta.conf.5
+%{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-cli.conf.5 %{buildroot}%{_mandir}/man5/pgmoneta-cli.conf.5
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-walfilter.1 %{buildroot}%{_mandir}/man1/pgmoneta-walfilter.1
 %{__install} -m 644 %{_builddir}/%{name}-%{version}/build/doc/pgmoneta-walinfo.1 %{buildroot}%{_mandir}/man1/pgmoneta-walinfo.1
 
@@ -104,6 +105,7 @@ cd %{buildroot}%{_libdir}/
 %{_mandir}/man1/pgmoneta-admin.1*
 %{_mandir}/man1/pgmoneta-cli.1*
 %{_mandir}/man5/pgmoneta.conf.5*
+%{_mandir}/man5/pgmoneta-cli.conf.5*
 %{_mandir}/man1/pgmoneta-walfilter.1*
 %{_mandir}/man1/pgmoneta-walinfo.1*
 %config %{_sysconfdir}/pgmoneta/pgmoneta.conf

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -40,6 +40,7 @@ extern "C" {
 
 #define PGMONETA_MAIN_INI_SECTION                   "pgmoneta"
 #define PGMONETA_DEFAULT_CONFIG_FILE_PATH           "/etc/pgmoneta/pgmoneta.conf"
+#define PGMONETA_CLI_DEFAULT_CONFIG_FILE_PATH       "/etc/pgmoneta/pgmoneta_cli.conf"
 #define PGMONETA_WALINFO_DEFAULT_CONFIG_FILE_PATH   "/etc/pgmoneta/pgmoneta_walinfo.conf"
 #define PGMONETA_WALFILTER_DEFAULT_CONFIG_FILE_PATH "/etc/pgmoneta/pgmoneta_walfilter.conf"
 #define PGMONETA_DEFAULT_USERS_FILE_PATH            "/etc/pgmoneta/pgmoneta_users.conf"
@@ -191,6 +192,31 @@ pgmoneta_read_main_configuration(void* shmem, char* filename);
  */
 int
 pgmoneta_validate_main_configuration(void* shmem);
+
+/**
+ * Initialize the CLI configuration structure
+ * @param shmem The shared memory segment
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_init_cli_configuration(void* shmem);
+
+/**
+ * Read the CLI configuration from a file
+ * @param shmem The shared memory segment
+ * @param filename The file name
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_read_cli_configuration(void* shmem, char* filename);
+
+/**
+ * Validate the CLI configuration
+ * @param shmem The shared memory segment
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_validate_cli_configuration(void* shmem);
 
 /**
  * Initialize the WALINFO configuration structure

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -386,6 +386,8 @@ struct common_configuration
    bool nodelay;      /**< Use NODELAY */
    bool non_blocking; /**< Use non blocking */
 
+   char unix_socket_dir[MISC_LENGTH]; /**< The directory for the Unix Domain Socket */
+
    struct prometheus prometheus; /**< The Prometheus metrics */
 } __attribute__((aligned(64)));
 
@@ -458,8 +460,6 @@ struct main_configuration
    int backlog;             /**< The backlog for listen */
    unsigned char hugepage;  /**< Huge page support */
 
-   char unix_socket_dir[MISC_LENGTH]; /**< The directory for the Unix Domain Socket */
-
    int backup_max_rate;  /**< Number of tokens added to the bucket with each replenishment for backup. */
    int network_max_rate; /**< Number of bytes of tokens added every one second to limit the netowrk backup rate */
 
@@ -468,6 +468,23 @@ struct main_configuration
 #ifdef DEBUG
    bool link; /**< Do linking */
 #endif
+} __attribute__((aligned(64)));
+
+/** @struct cli_configuration
+ * Defines the CLI configuration list
+ */
+struct cli_configuration
+{
+   struct common_configuration common; /**< Common configurations shared with other tools */
+
+   char host[MISC_LENGTH]; /**< Host to connect to server */
+   int port;               /**< Port to connect to server */
+
+   int32_t output_format; /**< Default output format for CLI responses */
+
+   int compression; /**< Wire protocol compression */
+   int encryption;  /**< Wire protocol encryption */
+
 } __attribute__((aligned(64)));
 
 /** @struct walinfo_configuration

--- a/src/libpgmoneta/remote.c
+++ b/src/libpgmoneta/remote.c
@@ -65,7 +65,7 @@ pgmoneta_remote_management(int client_fd, char* address)
    auth_status = pgmoneta_remote_management_auth(client_fd, address, &client_ssl);
    if (auth_status == AUTH_SUCCESS)
    {
-      if (pgmoneta_connect_unix_socket(config->unix_socket_dir, MAIN_UDS, &server_fd))
+      if (pgmoneta_connect_unix_socket(config->common.unix_socket_dir, MAIN_UDS, &server_fd))
       {
          goto done;
       }

--- a/src/main.c
+++ b/src/main.c
@@ -149,7 +149,7 @@ shutdown_mgt(void)
    ev_io_stop(main_loop, (struct ev_io*)&io_mgt);
    pgmoneta_disconnect(unix_management_socket);
    errno = 0;
-   pgmoneta_remove_unix_socket(config->unix_socket_dir, MAIN_UDS);
+   pgmoneta_remove_unix_socket(config->common.unix_socket_dir, MAIN_UDS);
    errno = 0;
 }
 
@@ -719,11 +719,11 @@ main(int argc, char** argv)
    }
 
    /* Bind Unix Domain Socket */
-   if (pgmoneta_bind_unix_socket(config->unix_socket_dir, MAIN_UDS, &unix_management_socket))
+   if (pgmoneta_bind_unix_socket(config->common.unix_socket_dir, MAIN_UDS, &unix_management_socket))
    {
-      pgmoneta_log_fatal("Could not bind to %s/%s", config->unix_socket_dir, MAIN_UDS);
+      pgmoneta_log_fatal("Could not bind to %s/%s", config->common.unix_socket_dir, MAIN_UDS);
 #ifdef HAVE_SYSTEMD
-      sd_notifyf(0, "STATUS=Could not bind to %s/%s", config->unix_socket_dir, MAIN_UDS);
+      sd_notifyf(0, "STATUS=Could not bind to %s/%s", config->common.unix_socket_dir, MAIN_UDS);
 #endif
       goto error;
    }
@@ -1000,9 +1000,9 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
          shutdown_mgt();
 
-         if (pgmoneta_bind_unix_socket(config->unix_socket_dir, MAIN_UDS, &unix_management_socket))
+         if (pgmoneta_bind_unix_socket(config->common.unix_socket_dir, MAIN_UDS, &unix_management_socket))
          {
-            pgmoneta_log_fatal("Could not bind to %s", config->unix_socket_dir);
+            pgmoneta_log_fatal("Could not bind to %s", config->common.unix_socket_dir);
             exit(1);
          }
 
@@ -2818,16 +2818,16 @@ create_pidfile(void)
    if (strlen(config->pidfile) == 0)
    {
       // no pidfile set, use a default one
-      if (!pgmoneta_ends_with(config->unix_socket_dir, "/"))
+      if (!pgmoneta_ends_with(config->common.unix_socket_dir, "/"))
       {
          snprintf(config->pidfile, sizeof(config->pidfile), "%s/pgmoneta.%s.pid",
-                  config->unix_socket_dir,
+                  config->common.unix_socket_dir,
                   !strncmp(config->host, "*", sizeof(config->host)) ? "all" : config->host);
       }
       else
       {
          snprintf(config->pidfile, sizeof(config->pidfile), "%spgmoneta.%s.pid",
-                  config->unix_socket_dir,
+                  config->common.unix_socket_dir,
                   !strncmp(config->host, "*", sizeof(config->host)) ? "all" : config->host);
       }
       pgmoneta_log_debug("PID file automatically set to: [%s]", config->pidfile);

--- a/test/check.sh
+++ b/test/check.sh
@@ -83,7 +83,7 @@ cleanup() {
    set +e
    echo "Shutdown pgmoneta"
    if [[ -f "/tmp/pgmoneta.localhost.pid" ]]; then
-     $EXECUTABLE_DIRECTORY/pgmoneta-cli -c $CONFIGURATION_DIRECTORY/pgmoneta.conf shutdown
+     $EXECUTABLE_DIRECTORY/pgmoneta-cli -c $CONFIGURATION_DIRECTORY/pgmoneta_cli.conf shutdown
      sleep 5
      if [[ -f "/tmp/pgmoneta.localhost.pid" ]]; then
        echo "Force stop pgmoneta"
@@ -244,8 +244,15 @@ remove_postgresql_container() {
 }
 
 pgmoneta_initialize_configuration() {
-   touch $CONFIGURATION_DIRECTORY/pgmoneta.conf $CONFIGURATION_DIRECTORY/pgmoneta_users.conf
-   echo "Creating pgmoneta.conf and pgmoneta_users.conf inside $CONFIGURATION_DIRECTORY ... ok"
+  touch $CONFIGURATION_DIRECTORY/pgmoneta.conf $CONFIGURATION_DIRECTORY/pgmoneta_users.conf $CONFIGURATION_DIRECTORY/pgmoneta_cli.conf 
+  echo "Creating pgmoneta.conf, pgmoneta_users.conf and pgmoneta_cli.conf inside $CONFIGURATION_DIRECTORY ... ok"
+  cat <<EOF >$CONFIGURATION_DIRECTORY/pgmoneta_cli.conf
+# CLI configuration
+unix_socket_dir = /tmp/
+log_type = file
+log_level = info
+log_path = $LOG_DIR/pgmoneta-cli.log
+EOF
    cat <<EOF >$CONFIGURATION_DIRECTORY/pgmoneta.conf
 # Main configuration
 [pgmoneta]
@@ -329,7 +336,7 @@ execute_testcases() {
    $EXECUTABLE_DIRECTORY/pgmoneta -c $CONFIGURATION_DIRECTORY/pgmoneta.conf -u $CONFIGURATION_DIRECTORY/pgmoneta_users.conf -d
    echo "Wait for pgmoneta to be ready"
    sleep 10
-   $EXECUTABLE_DIRECTORY/pgmoneta-cli -c $CONFIGURATION_DIRECTORY/pgmoneta.conf status details
+   $EXECUTABLE_DIRECTORY/pgmoneta-cli -c $CONFIGURATION_DIRECTORY/pgmoneta_cli.conf status details
    if [[ $? -eq 0 ]]; then
       echo "pgmoneta server started ... ok"
    else

--- a/test/libpgmonetatest/tsclient.c
+++ b/test/libpgmonetatest/tsclient.c
@@ -237,11 +237,11 @@ get_connection()
    config = (struct main_configuration*)shmem;
    if (strlen(config->common.configuration_path))
    {
-      if (pgmoneta_connect_unix_socket(config->unix_socket_dir, MAIN_UDS, &socket))
+      if (pgmoneta_connect_unix_socket(config->common.unix_socket_dir, MAIN_UDS, &socket))
       {
          return -1;
       }
    }
-   pgmoneta_log_info("%s %s %d", config->common.configuration_path, config->unix_socket_dir, socket);
+   pgmoneta_log_info("%s %s %d", config->common.configuration_path, config->common.unix_socket_dir, socket);
    return socket;
 }


### PR DESCRIPTION
Relates #610 

## Changes

- Introduced `pgmoneta_cli.conf` for storing cli related configuration fields. Supports host, port, output_format, compression, encryption, logging settings
- Common fields are moved out from `main_configuration` and put inside `common_configuration` and a new `cli_configuration` is created.
- The flow of the parameters is `flags -> conf file -> defaults`
- `unix_socket_dir` is put in common configuration and the user will need to provide either host,port or unix socket dir for connection otherwise an error is raised. Also, this property must be same in both `pgmoneta.conf` and `pgmoneta_cli.conf` otherwise the connection fails and a useful error message is issued which directs user to check this fact.
- No changes are made to the `pgmoneta.conf` file