### PR TITLE
[#603] Exclude WAL size from incremental backup restore_size

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -673,6 +673,15 @@ unsigned long
 pgmoneta_directory_size(char* directory);
 
 /**
+ * Calculate the size of WAL files starting from a specific WAL segment
+ * @param directory The directory containing WAL files
+ * @param start The starting WAL segment
+ * @return The size in bytes
+ */
+unsigned long
+pgmoneta_calculate_wal_size(char* directory, char* start);
+
+/**
  * Get directories
  * @param base The base directory
  * @param number_of_directories The number of directories

--- a/src/include/walfile/rmgr.h
+++ b/src/include/walfile/rmgr.h
@@ -57,33 +57,39 @@ extern "C" {
 
 #include <stdint.h>
 
-#define RM_XLOG_ID                                        0
-#define RM_XACT_ID                                        1
-#define RM_SMGR_ID                                        2
-#define RM_CLOG_ID                                        3
-#define RM_DBASE_ID                                       4
-#define RM_TBLSPC_ID                                      5
-#define RM_MULTIXACT_ID                                   6
-#define RM_RELMAP_ID                                      7
-#define RM_STANDBY_ID                                     8
-#define RM_HEAP2_ID                                       9
-#define RM_HEAP_ID                                        10
-#define RM_BTREE_ID                                       11
-#define RM_HASH_ID                                        12
-#define RM_GIN_ID                                         13
-#define RM_GIST_ID                                        14
-#define RM_SEQ_ID                                         15
-#define RM_SPGIST_ID                                      16
-#define RM_BRIN_ID                                        17
-#define RM_COMMIT_TS_ID                                   18
-#define RM_REPLORIGIN_ID                                  19
-#define RM_GENERIC_ID                                     20
-#define RM_LOGICALMSG_ID                                  21
+#define RM_XLOG_ID       0
+#define RM_XACT_ID       1
+#define RM_SMGR_ID       2
+#define RM_CLOG_ID       3
+#define RM_DBASE_ID      4
+#define RM_TBLSPC_ID     5
+#define RM_MULTIXACT_ID  6
+#define RM_RELMAP_ID     7
+#define RM_STANDBY_ID    8
+#define RM_HEAP2_ID      9
+#define RM_HEAP_ID       10
+#define RM_BTREE_ID      11
+#define RM_HASH_ID       12
+#define RM_GIN_ID        13
+#define RM_GIST_ID       14
+#define RM_SEQ_ID        15
+#define RM_SPGIST_ID     16
+#define RM_BRIN_ID       17
+#define RM_COMMIT_TS_ID  18
+#define RM_REPLORIGIN_ID 19
+#define RM_GENERIC_ID    20
+#define RM_LOGICALMSG_ID 21
 
-#define PG_RMGR(symname, name, desc)                      {name, desc}
-#define PG_RMGR_SUMMARY(symname, name, number_of_records) {name, number_of_records}
-#define PG_RMGR_STATS(symname, name)                      {name, 0, 0, 0, 0}
-#define RM_MAX_ID                                         UINT8_MAX
+#define PG_RMGR(symname, name, desc) \
+   {                                 \
+      name, desc}
+#define PG_RMGR_SUMMARY(symname, name, number_of_records) \
+   {                                                      \
+      name, number_of_records}
+#define PG_RMGR_STATS(symname, name) \
+   {                                 \
+      name, 0, 0, 0, 0}
+#define RM_MAX_ID UINT8_MAX
 
 /**
  * @struct rmgr_data

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -58,7 +58,36 @@ START_TEST(test_resolve_path_trailing_env_var)
    ck_assert_str_eq(resolved, expected);
 
    unsetenv(env_key);
+   unsetenv(env_key);
    free(resolved);
+}
+END_TEST
+
+START_TEST(test_calculate_wal_size)
+{
+   char wal_dir[] = "test_wal_size";
+   char w1[] = "test_wal_size/000000010000000000000001";
+   char w2_real[] = "test_wal_size/000000010000000000000002";
+   char w3[] = "test_wal_size/000000010000000000000003";
+
+   pgmoneta_mkdir(wal_dir);
+
+   FILE* f1 = fopen(w1, "w");
+   fprintf(f1, "1234567890");
+   fclose(f1); // 10 bytes
+   FILE* f2 = fopen(w2_real, "w");
+   fprintf(f2, "12345678901234567890");
+   fclose(f2); // 20 bytes
+   FILE* f3 = fopen(w3, "w");
+   fprintf(f3, "123456789012345678901234567890");
+   fclose(f3); // 30 bytes
+
+   unsigned long size = pgmoneta_calculate_wal_size(wal_dir, "000000010000000000000002");
+
+   // Should include w2 and w3. 20 + 30 = 50.
+   ck_assert_int_eq(size, 50);
+
+   pgmoneta_delete_directory(wal_dir);
 }
 END_TEST
 
@@ -1267,6 +1296,7 @@ pgmoneta_test_utils_suite()
    tcase_set_timeout(tc_utils, 60);
    tcase_add_checked_fixture(tc_utils, pgmoneta_test_setup, pgmoneta_test_teardown);
    tcase_add_test(tc_utils, test_resolve_path_trailing_env_var);
+   tcase_add_test(tc_utils, test_calculate_wal_size);
    tcase_add_test(tc_utils, test_utils_starts_with);
    tcase_add_test(tc_utils, test_utils_ends_with);
    tcase_add_test(tc_utils, test_utils_contains);


### PR DESCRIPTION
## Problem
The `restore_size` in backup.info for incremental backups incorrectly included the size of WAL segments `(pg_wal)`. This caused inconsistency because the restore process (`restore.c`) dynamically calculates and adds the WAL size at runtime, leading to double-counting and inaccurate disk space checks.

## Solution
Updated `incr_backup_execute_14_to_16` in `src/libpgmoneta/wf_backup_incremental.c` to use `pgmoneta_directory_size_excludes`
with {"pg_wal", NULL} when calculating the backup size. This ensures `restore_size` reflects only the data directory size, allowing the restore logic to correctly add the dynamic WAL size when required.

### Fixes- #603