### PR TITLE
[#608] Restore: resolve backup via target LSN, time, or timeline

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -138,6 +138,21 @@ Example
 pgmoneta-cli restore primary newest name=MyLabel,primary /tmp
 ```
 
+### Automatic Backup Selection
+
+When using recovery targets (`lsn=X`, `time=X`, or `timeline=X`), pgmoneta automatically selects the appropriate backup:
+
+```sh
+# Restore to a specific LSN (backup auto-selected)
+pgmoneta-cli restore primary newest lsn=0/16B0938 /tmp
+
+# Restore to a specific time (backup auto-selected)
+pgmoneta-cli restore primary newest time=2025-01-15\ 10:30:00 /tmp
+
+# Restore from a specific timeline (backup auto-selected)
+pgmoneta-cli restore primary newest timeline=2 /tmp
+```
+
 ## verify
 
 Verify a backup from a server

--- a/doc/manual/en/05-cli.md
+++ b/doc/manual/en/05-cli.md
@@ -154,6 +154,21 @@ Example
 pgmoneta-cli restore primary newest name=MyLabel,primary /tmp
 ```
 
+### Automatic Backup Selection
+
+When using recovery targets (`lsn=X`, `time=X`, or `timeline=X`), pgmoneta automatically selects the appropriate backup:
+
+```sh
+# Restore to a specific LSN (backup auto-selected)
+pgmoneta-cli restore primary newest lsn=0/16B0938 /tmp
+
+# Restore to a specific time (backup auto-selected)
+pgmoneta-cli restore primary newest time=2025-01-15\ 10:30:00 /tmp
+
+# Restore from a specific timeline (backup auto-selected)
+pgmoneta-cli restore primary newest timeline=2 /tmp
+```
+
 ## verify
 
 Verify a backup from a server

--- a/doc/manual/en/09-restore.md
+++ b/doc/manual/en/09-restore.md
@@ -25,6 +25,43 @@ where
 
 [More information](https://www.postgresql.org/docs/current/runtime-config-wal.html#RUNTIME-CONFIG-WAL-RECOVERY-TARGET)
 
+## Automatic Backup Selection
+
+When specifying a recovery target (`lsn=X`, `time=X`, or `timeline=X`), pgmoneta can automatically
+select the appropriate backup that contains the target. Instead of specifying a backup timestamp,
+use `newest` and pgmoneta will find the latest backup that can be used for recovery to the specified target.
+
+### Target LSN
+
+Restore to a specific LSN, with automatic backup selection:
+
+```
+pgmoneta-cli restore primary newest lsn=0/16B0938 /tmp
+```
+
+pgmoneta will select the latest valid backup whose start LSN is less than or equal to `0/16B0938`.
+
+### Target Time
+
+Restore to a specific point in time:
+
+```
+pgmoneta-cli restore primary newest time=2025-01-15\ 10:30:00 /tmp
+```
+
+pgmoneta will select the latest valid backup that started before or at the specified timestamp.
+The timestamp format is `YYYY-MM-DD HH:MM:SS`.
+
+### Target Timeline
+
+Restore from a specific timeline:
+
+```
+pgmoneta-cli restore primary newest timeline=2 /tmp
+```
+
+pgmoneta will select the latest valid backup from the specified timeline.
+
 And, you will get output like
 
 ```

--- a/src/include/backup.h
+++ b/src/include/backup.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 #include <pgmoneta.h>
+#include <art.h>
 #include <json.h>
 #include <info.h>
 
@@ -105,6 +106,17 @@ pgmoneta_is_backup_valid(int server, char* identifier);
  */
 bool
 pgmoneta_is_backup_struct_valid(int server, struct backup* backup);
+
+/**
+ * Get the backup identifier for a restore operation
+ * @param server The server
+ * @param identifier The identifier (e.g., target-lsn:X, target-time:X, target-tli:X, or label)
+ * @param nodes The art nodes structure (unused, reserved)
+ * @param label The output buffer for the actual backup label
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_get_backup_identifier(int server, char* identifier, struct art* nodes, char* label);
 
 #ifdef __cplusplus
 }

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -839,6 +839,31 @@ bool
 pgmoneta_is_file(char* file);
 
 /**
+ * Parse an LSN string
+ * @param lsn The LSN string (e.g., "0/16B0938")
+ * @return The LSN, or 0 on error
+ */
+uint64_t
+pgmoneta_lsn_from_string(char* lsn);
+
+/**
+ * Parse a timestamp string
+ * @param ts The timestamp string (e.g., "2025-12-23 15:30:00")
+ * @return The timestamp, or 0 on error
+ */
+time_t
+pgmoneta_timestamp_from_string(char* ts);
+
+/**
+ * Get LSN from high and low 32-bit values
+ * @param hi The high 32 bits
+ * @param lo The low 32 bits
+ * @return The 64-bit LSN
+ */
+uint64_t
+pgmoneta_get_lsn(uint32_t hi, uint32_t lo);
+
+/**
  * Compare files
  * @param f1 The first file path
  * @param f2 The second file path

--- a/src/libpgmoneta/backup.c
+++ b/src/libpgmoneta/backup.c
@@ -862,3 +862,165 @@ pgmoneta_is_backup_struct_valid(int server, struct backup* backup)
 
    return result;
 }
+
+static int
+resolve_backup_for_target(int server, uint64_t lsn, time_t time_val, unsigned int timeline, char* label)
+{
+   char* backup_dir = NULL;
+   int number_of_backups = 0;
+   struct backup** backups = NULL;
+   struct backup* bck = NULL;
+   int idx = -1;
+   char* l = NULL;
+
+   backup_dir = pgmoneta_get_server_backup(server);
+
+   if (pgmoneta_load_infos(backup_dir, &number_of_backups, &backups))
+   {
+      pgmoneta_log_error("Unable to get backups for server %d", server);
+      goto error;
+   }
+
+   /* Sort newest first so the first match is the latest backup containing the target */
+   pgmoneta_sort_backups(backups, number_of_backups, true);
+
+   for (int i = 0; i < number_of_backups; i++)
+   {
+      bck = backups[i];
+
+      if (bck->valid == VALID_TRUE)
+      {
+         if (lsn > 0)
+         {
+            uint64_t start_lsn = pgmoneta_get_lsn(bck->start_lsn_hi32, bck->start_lsn_lo32);
+            if (start_lsn <= lsn)
+            {
+               idx = i;
+               break;
+            }
+         }
+         else if (time_val > 0)
+         {
+            struct tm tm_val;
+            time_t bck_time;
+
+            memset(&tm_val, 0, sizeof(struct tm));
+            if (strptime(bck->label, "%Y%m%d%H%M%S", &tm_val) != NULL)
+            {
+               tm_val.tm_isdst = -1;
+               bck_time = mktime(&tm_val);
+               if (bck_time <= time_val)
+               {
+                  idx = i;
+                  break;
+               }
+            }
+         }
+         else if (timeline > 0)
+         {
+            if (bck->start_timeline == timeline)
+            {
+               idx = i;
+               break;
+            }
+         }
+      }
+   }
+
+   if (idx == -1)
+   {
+      pgmoneta_log_error("No backup found for requested target");
+      goto error;
+   }
+
+   l = pgmoneta_append(l, backups[idx]->label);
+   memcpy(label, l, strlen(l) + 1);
+   free(l);
+   l = NULL;
+
+   for (int i = 0; i < number_of_backups; i++)
+   {
+      free(backups[i]);
+   }
+   free(backups);
+   free(backup_dir);
+
+   return 0;
+
+error:
+
+   free(l);
+
+   for (int i = 0; i < number_of_backups; i++)
+   {
+      free(backups[i]);
+   }
+   free(backups);
+   free(backup_dir);
+
+   return 1;
+}
+
+int
+pgmoneta_get_backup_identifier(int server, char* identifier, struct art* nodes __attribute__((unused)), char* label)
+{
+   uint64_t lsn = 0;
+   time_t time_val = 0;
+   unsigned int timeline = 0;
+   char* value = NULL;
+   char* l = NULL;
+
+   if (identifier == NULL || strlen(identifier) == 0)
+   {
+      goto error;
+   }
+
+   if (pgmoneta_starts_with(identifier, "target-lsn:"))
+   {
+      value = identifier + 11;
+      lsn = pgmoneta_lsn_from_string(value);
+
+      if (lsn == 0)
+      {
+         pgmoneta_log_error("Invalid LSN: %s", value);
+         goto error;
+      }
+   }
+   else if (pgmoneta_starts_with(identifier, "target-time:"))
+   {
+      value = identifier + 12;
+      time_val = pgmoneta_timestamp_from_string(value);
+
+      if (time_val == 0)
+      {
+         pgmoneta_log_error("Invalid timestamp: %s", value);
+         goto error;
+      }
+   }
+   else if (pgmoneta_starts_with(identifier, "target-tli:"))
+   {
+      value = identifier + 11;
+      timeline = atoi(value);
+
+      if (timeline == 0)
+      {
+         pgmoneta_log_error("Invalid timeline: %s", value);
+         goto error;
+      }
+   }
+   else
+   {
+      l = pgmoneta_append(l, identifier);
+      memcpy(label, l, strlen(l) + 1);
+      free(l);
+      l = NULL;
+
+      return 0;
+   }
+
+   return resolve_backup_for_target(server, lsn, time_val, timeline, label);
+
+error:
+
+   return 1;
+}

--- a/src/libpgmoneta/manifest.c
+++ b/src/libpgmoneta/manifest.c
@@ -29,12 +29,12 @@
 /* pgmoneta */
 #include <pgmoneta.h>
 #include <art.h>
+#include <utils.h>
 #include <csv.h>
 #include <json.h>
 #include <logging.h>
 #include <manifest.h>
 #include <security.h>
-#include <utils.h>
 
 /* system */
 #include <dirent.h>
@@ -463,8 +463,8 @@ pgmoneta_generate_manifest(int version, uint64_t system_id, char* backup_data, s
    /* put wal ranges */
    pgmoneta_json_create(&wal_ranges);
    pgmoneta_json_create(&range);
-   start_lsn = pgmoneta_lsn_to_string((uint64_t)((uint64_t)bck->start_lsn_hi32 << 32) + (uint64_t)bck->start_lsn_lo32);
-   end_lsn = pgmoneta_lsn_to_string((uint64_t)((uint64_t)bck->end_lsn_hi32 << 32) + (uint64_t)bck->end_lsn_lo32);
+   start_lsn = pgmoneta_lsn_to_string(pgmoneta_get_lsn(bck->start_lsn_hi32, bck->start_lsn_lo32));
+   end_lsn = pgmoneta_lsn_to_string(pgmoneta_get_lsn(bck->end_lsn_hi32, bck->end_lsn_lo32));
 
    pgmoneta_json_put(range, "Timeline", (uintptr_t)bck->start_timeline, ValueInt32);
    pgmoneta_json_put(range, "Start-LSN", (uintptr_t)start_lsn, ValueString);

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -328,6 +328,7 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
 {
    bool active = false;
    bool locked = false;
+   bool explicit_label = false;
    int ret = RESTORE_OK;
    char* identifier = NULL;
    char* position = NULL;
@@ -339,6 +340,9 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
    char* output = NULL;
    char* en = NULL;
    int ec = -1;
+   char label[MISC_LENGTH];
+   char* target_identifier = NULL;
+   char* timeline_value = NULL;
    struct backup* backup = NULL;
    struct art* nodes = NULL;
    struct json* req = NULL;
@@ -387,7 +391,186 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
       goto error;
    }
 
-   if (pgmoneta_workflow_nodes(server, identifier, nodes, &backup))
+   memset(&label[0], 0, sizeof(label));
+
+   /* Check if identifier is an explicit backup label (not oldest/newest) */
+   if (identifier != NULL &&
+       strcmp(identifier, "oldest") != 0 &&
+       strcmp(identifier, "newest") != 0 &&
+       strcmp(identifier, "latest") != 0)
+   {
+      explicit_label = true;
+   }
+
+   /* If lsn=X or time=X is in position, automatically select the
+    * latest backup containing that target. timeline=X is a modifier,
+    * not a primary recovery target. */
+   if (position != NULL && strlen(position) > 0)
+   {
+      char tokens[512];
+      char* ptr = NULL;
+      int target_count = 0;
+      size_t len = 0;
+
+      memset(&tokens[0], 0, sizeof(tokens));
+      len = strlen(position);
+      if (len >= sizeof(tokens))
+      {
+         len = sizeof(tokens) - 1;
+      }
+      memcpy(&tokens[0], position, len);
+
+      ptr = strtok(&tokens[0], ",");
+
+      while (ptr != NULL)
+      {
+         char key[256];
+         char value[256];
+         char* equal = NULL;
+         size_t key_len = 0;
+         size_t val_len = 0;
+
+         memset(&key[0], 0, sizeof(key));
+         memset(&value[0], 0, sizeof(value));
+
+         equal = strchr(ptr, '=');
+
+         if (equal == NULL)
+         {
+            key_len = strlen(ptr);
+            if (key_len >= sizeof(key))
+            {
+               key_len = sizeof(key) - 1;
+            }
+            memcpy(&key[0], ptr, key_len);
+         }
+         else
+         {
+            key_len = strlen(ptr) - strlen(equal);
+            if (key_len >= sizeof(key))
+            {
+               key_len = sizeof(key) - 1;
+            }
+            memcpy(&key[0], ptr, key_len);
+
+            val_len = strlen(equal) - 1;
+            if (val_len >= sizeof(value))
+            {
+               val_len = sizeof(value) - 1;
+            }
+            memcpy(&value[0], equal + 1, val_len);
+         }
+
+         if (!strcmp(&key[0], "lsn"))
+         {
+            if (target_identifier != NULL)
+            {
+               free(target_identifier);
+               target_identifier = NULL;
+            }
+            target_identifier = pgmoneta_append(target_identifier, "target-lsn:");
+            target_identifier = pgmoneta_append(target_identifier, &value[0]);
+            target_count++;
+         }
+         else if (!strcmp(&key[0], "time"))
+         {
+            if (target_identifier != NULL)
+            {
+               free(target_identifier);
+               target_identifier = NULL;
+            }
+            target_identifier = pgmoneta_append(target_identifier, "target-time:");
+            target_identifier = pgmoneta_append(target_identifier, &value[0]);
+            target_count++;
+         }
+         else if (!strcmp(&key[0], "current") || !strcmp(&key[0], "immediate"))
+         {
+            target_count++;
+         }
+         else if (!strcmp(&key[0], "name"))
+         {
+            target_count++;
+         }
+         else if (!strcmp(&key[0], "xid"))
+         {
+            target_count++;
+         }
+         else if (!strcmp(&key[0], "timeline"))
+         {
+            /* timeline is a modifier, not a primary target.
+             * Save the value for potential backup selection below. */
+            if (timeline_value != NULL)
+            {
+               free(timeline_value);
+               timeline_value = NULL;
+            }
+            timeline_value = pgmoneta_append(timeline_value, &value[0]);
+         }
+
+         ptr = strtok(NULL, ",");
+      }
+
+      /* Use timeline for backup auto-selection only when no primary
+       * target was specified and the identifier is not explicit. */
+      if (target_count == 0 && !explicit_label && timeline_value != NULL)
+      {
+         target_identifier = pgmoneta_append(target_identifier, "target-tli:");
+         target_identifier = pgmoneta_append(target_identifier, timeline_value);
+      }
+      free(timeline_value);
+      timeline_value = NULL;
+
+      if (target_count > 1)
+      {
+         ec = MANAGEMENT_ERROR_RESTORE_NOBACKUP;
+         pgmoneta_log_error("Restore: Multiple recovery target options specified. Only one primary target (lsn, time, name, xid, current) is allowed.");
+         goto error;
+      }
+
+      if (explicit_label)
+      {
+         /* Explicit backup label takes precedence over position-based selection */
+         if (pgmoneta_get_backup_identifier(server, identifier, nodes, &label[0]))
+         {
+            ec = MANAGEMENT_ERROR_RESTORE_NOBACKUP;
+            pgmoneta_log_error("Restore: Unable to find backup for %s/%s", config->common.servers[server].name, identifier);
+            goto error;
+         }
+      }
+      else if (target_identifier != NULL)
+      {
+         /* target-* is an internal identifier used only for backup-label
+          * resolution. Recovery target configuration (recovery_target_lsn,
+          * etc.) is derived from USER_POSITION by wf_restore.c. */
+         if (pgmoneta_get_backup_identifier(server, target_identifier, nodes, &label[0]))
+         {
+            ec = MANAGEMENT_ERROR_RESTORE_NOBACKUP;
+            pgmoneta_log_error("Restore: Unable to find backup for %s using recovery target '%s'",
+                               config->common.servers[server].name, target_identifier);
+            goto error;
+         }
+      }
+      else
+      {
+         if (pgmoneta_get_backup_identifier(server, identifier, nodes, &label[0]))
+         {
+            ec = MANAGEMENT_ERROR_RESTORE_NOBACKUP;
+            pgmoneta_log_error("Restore: Unable to find backup for %s/%s", config->common.servers[server].name, identifier);
+            goto error;
+         }
+      }
+   }
+   else
+   {
+      if (pgmoneta_get_backup_identifier(server, identifier, nodes, &label[0]))
+      {
+         ec = MANAGEMENT_ERROR_RESTORE_NOBACKUP;
+         pgmoneta_log_error("Restore: Unable to find backup for %s/%s", config->common.servers[server].name, identifier);
+         goto error;
+      }
+   }
+
+   if (pgmoneta_workflow_nodes(server, label, nodes, &backup))
    {
       ec = MANAGEMENT_ERROR_RESTORE_NOBACKUP;
       goto error;
@@ -465,6 +648,8 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
    free(backup);
    free(elapsed);
    free(output);
+   free(target_identifier);
+   free(timeline_value);
 
    exit(0);
 
@@ -489,6 +674,8 @@ error:
    free(backup);
    free(elapsed);
    free(output);
+   free(target_identifier);
+   free(timeline_value);
 
    exit(1);
 }

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -6043,3 +6043,69 @@ pgmoneta_time_format(pgmoneta_time_t t, enum pgmoneta_time_format_t fmt, char** 
    *output = str;
    return 0;
 }
+
+uint64_t
+pgmoneta_lsn_from_string(char* lsn)
+{
+   uint32_t id = 0;
+   uint32_t off = 0;
+   uint64_t v = 0;
+
+   if (lsn == NULL || strlen(lsn) == 0)
+   {
+      goto error;
+   }
+
+   if (sscanf(lsn, "%X/%X", &id, &off) != 2)
+   {
+      goto error;
+   }
+
+   v = ((uint64_t)id << 32) | off;
+
+   return v;
+
+error:
+
+   return 0;
+}
+
+time_t
+pgmoneta_timestamp_from_string(char* ts)
+{
+   struct tm tm_val;
+   time_t time_val;
+
+   if (ts == NULL || strlen(ts) == 0)
+   {
+      goto error;
+   }
+
+   memset(&tm_val, 0, sizeof(struct tm));
+
+   if (strptime(ts, "%Y-%m-%d %H:%M:%S", &tm_val) == NULL)
+   {
+      goto error;
+   }
+
+   tm_val.tm_isdst = -1;
+
+   time_val = mktime(&tm_val);
+
+   if (time_val == -1)
+   {
+      goto error;
+   }
+
+   return time_val;
+
+error:
+
+   return 0;
+}
+
+uint64_t
+pgmoneta_get_lsn(uint32_t hi, uint32_t lo)
+{
+   return ((uint64_t)hi << 32) | lo;
+}

--- a/test/testcases/test_backup_identifier.c
+++ b/test/testcases/test_backup_identifier.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgmoneta.h>
+#include <art.h>
+#include <backup.h>
+#include <info.h>
+#include <utils.h>
+#include <mctf.h>
+#include <tsclient.h>
+#include <tscommon.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+static void
+create_mock_backup(char* label, char* lsn, int timeline, int status)
+{
+   char* server_path = pgmoneta_get_server_backup(PRIMARY_SERVER);
+   char* path = NULL;
+   char* info_path = NULL;
+   FILE* file = NULL;
+
+   path = pgmoneta_append(path, server_path);
+   path = pgmoneta_append(path, "/");
+   path = pgmoneta_append(path, label);
+   pgmoneta_mkdir(path);
+
+   info_path = pgmoneta_append(info_path, path);
+   info_path = pgmoneta_append(info_path, "/backup.info");
+   file = fopen(info_path, "w");
+   if (file)
+   {
+      fprintf(file, "LABEL=%s\n", label);
+      fprintf(file, "STATUS=%d\n", status);
+      fprintf(file, "START_WALPOS=%s\n", lsn);
+      fprintf(file, "START_TIMELINE=%d\n", timeline);
+      fprintf(file, "PGMONETA_VERSION=0.21.0\n");
+      fflush(file);
+      fclose(file);
+   }
+   free(info_path);
+   free(path);
+   free(server_path);
+}
+
+static void
+cleanup_mock_backups(void)
+{
+   char* backup_dir = pgmoneta_get_server_backup(PRIMARY_SERVER);
+   if (backup_dir != NULL)
+   {
+      pgmoneta_delete_directory(backup_dir);
+      pgmoneta_mkdir(backup_dir);
+      free(backup_dir);
+   }
+}
+
+MCTF_TEST_SETUP(backup_identifier)
+{
+   pgmoneta_test_setup();
+   cleanup_mock_backups();
+}
+
+MCTF_TEST_TEARDOWN(backup_identifier)
+{
+   cleanup_mock_backups();
+   pgmoneta_test_teardown();
+}
+
+MCTF_TEST(test_backup_identifier_lsn)
+{
+   struct art* nodes = NULL;
+   char label[MAX_PATH];
+   char identifier[MAX_PATH];
+   int ret = 0;
+
+   pgmoneta_art_create(&nodes);
+
+   // Setup: Create 2 backups
+   // Backup 1: 20250101000000, LSN 0/1000
+   create_mock_backup("20250101000000", "0/1000", 1, 1);
+   // Backup 2: 20250101010000, LSN 0/2000
+   create_mock_backup("20250101010000", "0/2000", 1, 1);
+
+   // Test 1: Target LSN between backups (0/1500) -> Should pick Backup 1 (0/1000)
+   snprintf(identifier, sizeof(identifier), "target-lsn:0/1500");
+   memset(label, 0, MAX_PATH);
+   ret = pgmoneta_get_backup_identifier(PRIMARY_SERVER, identifier, nodes, label);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "ret mismatch 1");
+   MCTF_ASSERT_STR_EQ(label, "20250101000000", cleanup, "label mismatch 1");
+
+   // Test 2: Target LSN after Backup 2 (0/3000) -> Should pick Backup 2 (0/2000)
+   snprintf(identifier, sizeof(identifier), "target-lsn:0/3000");
+   memset(label, 0, MAX_PATH);
+   ret = pgmoneta_get_backup_identifier(PRIMARY_SERVER, identifier, nodes, label);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "ret mismatch 2");
+   MCTF_ASSERT_STR_EQ(label, "20250101010000", cleanup, "label mismatch 2");
+
+   // Test 3: Target LSN before Backup 1 (0/500) -> Should fail
+   snprintf(identifier, sizeof(identifier), "target-lsn:0/500");
+   memset(label, 0, MAX_PATH);
+   ret = pgmoneta_get_backup_identifier(PRIMARY_SERVER, identifier, nodes, label);
+   MCTF_ASSERT(ret != 0, cleanup, "ret should adhere to logic");
+
+cleanup:
+   if (nodes != NULL)
+   {
+      pgmoneta_art_destroy(nodes);
+   }
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_backup_identifier_time)
+{
+   struct art* nodes = NULL;
+   char label[MAX_PATH];
+   char identifier[MAX_PATH];
+   int ret = 0;
+
+   pgmoneta_art_create(&nodes);
+
+   // Backup 1: 20230101000000
+   create_mock_backup("20230101000000", "0/1000", 1, 1);
+   // Backup 2: 20230101020000
+   create_mock_backup("20230101020000", "0/2000", 1, 1);
+
+   // Target Time: 2023-01-01 01:00:00 -> Should pick Backup 1
+   snprintf(identifier, sizeof(identifier), "target-time:2023-01-01 01:00:00");
+   memset(label, 0, MAX_PATH);
+   ret = pgmoneta_get_backup_identifier(PRIMARY_SERVER, identifier, nodes, label);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "ret mismatch");
+   MCTF_ASSERT_STR_EQ(label, "20230101000000", cleanup, "label mismatch");
+
+cleanup:
+   if (nodes != NULL)
+   {
+      pgmoneta_art_destroy(nodes);
+   }
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_backup_identifier_tli)
+{
+   struct art* nodes = NULL;
+   char label[MAX_PATH];
+   char identifier[MAX_PATH];
+   int ret = 0;
+
+   pgmoneta_art_create(&nodes);
+
+   // Backup 1: TLI 1
+   create_mock_backup("20230101000000", "0/1000", 1, 1);
+   // Backup 2: TLI 2
+   create_mock_backup("20230101010000", "0/2000", 2, 1);
+
+   // Target TLI: 1
+   snprintf(identifier, sizeof(identifier), "target-tli:1");
+   memset(label, 0, MAX_PATH);
+   ret = pgmoneta_get_backup_identifier(PRIMARY_SERVER, identifier, nodes, label);
+   MCTF_ASSERT_INT_EQ(ret, 0, cleanup, "ret mismatch");
+   MCTF_ASSERT_STR_EQ(label, "20230101000000", cleanup, "label mismatch");
+
+cleanup:
+   if (nodes != NULL)
+   {
+      pgmoneta_art_destroy(nodes);
+   }
+   MCTF_FINISH();
+}

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -2325,3 +2325,47 @@ MCTF_TEST(test_utils_cleanse)
 cleanup:
    MCTF_FINISH();
 }
+
+MCTF_TEST(test_parse_lsn)
+{
+   uint64_t lsn = 0;
+
+   lsn = pgmoneta_lsn_from_string("0/16B0938");
+   MCTF_ASSERT_INT_EQ(lsn, 23791928, cleanup, "lsn mismatch 1");
+
+   lsn = pgmoneta_lsn_from_string("1/0");
+   MCTF_ASSERT_INT_EQ(lsn, 4294967296, cleanup, "lsn mismatch 2");
+
+   lsn = pgmoneta_lsn_from_string("0/0");
+   MCTF_ASSERT_INT_EQ(lsn, 0, cleanup, "lsn mismatch 3");
+
+   lsn = pgmoneta_lsn_from_string("invalid");
+   MCTF_ASSERT_INT_EQ(lsn, 0, cleanup, "lsn mismatch 4");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_parse_timestamp)
+{
+   time_t ts = 0;
+   struct tm tm_val;
+
+   ts = pgmoneta_timestamp_from_string("2025-12-23 02:00:00");
+   MCTF_ASSERT(ts != 0, cleanup, "timestamp parsing failed");
+   MCTF_ASSERT(ts != -1, cleanup, "timestamp parsing error");
+
+   localtime_r(&ts, &tm_val);
+   MCTF_ASSERT_INT_EQ(tm_val.tm_year + 1900, 2025, cleanup, "year mismatch");
+   MCTF_ASSERT_INT_EQ(tm_val.tm_mon + 1, 12, cleanup, "month mismatch");
+   MCTF_ASSERT_INT_EQ(tm_val.tm_mday, 23, cleanup, "day mismatch");
+   MCTF_ASSERT_INT_EQ(tm_val.tm_hour, 2, cleanup, "hour mismatch");
+   MCTF_ASSERT_INT_EQ(tm_val.tm_min, 0, cleanup, "minute mismatch");
+   MCTF_ASSERT_INT_EQ(tm_val.tm_sec, 0, cleanup, "second mismatch");
+
+   ts = pgmoneta_timestamp_from_string("invalid");
+   MCTF_ASSERT_INT_EQ(ts, 0, cleanup, "invalid timestamp should return 0");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
## Problem
Currently, the restore command requires users to explicitly specify a backup label when performing a restore.
This makes point-in-time recovery (PITR) and LSN-based restores cumbersome, as users must manually inspect available backups to determine which label is appropriate for a given target.

There is no native support for restoring based on:
- a target LSN,
- a target timestamp, or
- a target timeline (TLI).

This limits usability and increases the risk of selecting an incorrect backup.
 ## Fixes - #608
## Solution Overview

### Identifier Resolution Logic (`src/libpgmoneta/backup.c`)

Implemented `pgmoneta_get_backup_identifier` to parse and map special identifiers to specific backup labels.

**Logic:**
- **`target-lsn`**: Selects the latest backup where `start_lsn <= target LSN`.
- **`target-time`**: Selects the latest backup that started before or at the target timestamp.
- **`target-tli`**: Selects the latest backup belonging to the specified timeline.

---

### Restore Integration (`src/libpgmoneta/restore.c`)

Updated the `pgmoneta_restore` workflow to invoke the new resolution logic. It now automatically translates an identifier like `target-lsn:0/1500` into a concrete backup label (e.g., `20250101000000`) before proceeding.

---

### Utilities (`src/libpgmoneta/utils.c`)

Added robust helper functions:
- `pgmoneta_parse_lsn` — parses LSN strings into `uint64_t`
- `pgmoneta_parse_timestamp` — parses timestamp strings into `time_t`

---

### Verification (`test/testcases/test_backup_identifier.c`)

Created a new dedicated test suite `pgmoneta_test_backup_identifier` covering all three scenarios.

**Validated that:**
- LSN lookups correctly pick the nearest preceding backup.
- Time-based lookups correctly respect backup timestamps.
- Timeline selection accurately filters by the requested TLI.
