### PR TITLE
[#738] Interaction mode for pgmoneta_walinfo using ncurses

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,7 @@ else()
     ${LIBSSH_INCLUDE_DIRS}
     ${LibArchive_INCLUDE_DIRS}
     ${THREAD_INCLUDE_DIRS}
+    ${CURSES_INCLUDE_DIRS}
   )
 
   #
@@ -144,6 +145,7 @@ else()
     ${LIBSSH_LIBRARIES}
     ${LibArchive_LIBRARIES}
     ${THREAD_LIBRARIES}
+    ${CURSES_LIBRARIES}
   )
 
   if (${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
@@ -353,7 +355,7 @@ endif()
 add_library(pgmoneta SHARED ${SOURCES})
 set_target_properties(pgmoneta PROPERTIES LINKER_LANGUAGE C VERSION ${VERSION_STRING}
                                SOVERSION ${VERSION_MAJOR})
-target_link_libraries(pgmoneta PUBLIC)
+target_link_libraries(pgmoneta PUBLIC ncurses)
 install(TARGETS pgmoneta DESTINATION ${CMAKE_INSTALL_LIBDIR}/)
 
 #

--- a/src/include/walfile/rmgr.h
+++ b/src/include/walfile/rmgr.h
@@ -140,6 +140,14 @@ extern struct rmgr_data rmgr_table[RM_MAX_ID + 1];
 extern struct rmgr_summary rmgr_summary_table[RM_MAX_ID + 1];
 extern struct rmgr_stats rmgr_stats_table[RM_MAX_ID + 1];
 
+/**
+ * Get the name of a resource manager by its ID
+ * @param rmid The resource manager ID
+ * @return The name of the resource manager, or NULL if invalid
+ */
+char*
+pgmoneta_rmgr_get_name(uint8_t rmid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -417,6 +417,33 @@ char*
 pgmoneta_wal_get_record_block_data(struct decoded_xlog_record* record, uint8_t block_id, size_t* len);
 
 /**
+ * Get block reference information for a WAL record
+ * 
+ * @param buf Buffer to append to (can be NULL)
+ * @param record The decoded WAL record
+ * @param pretty Whether to format prettily
+ * @param detailed_format Whether to use detailed format
+ * @param fpi_len Pointer to store FPI length
+ * @param magic_value WAL magic value
+ * @return Updated buffer with block reference info
+ */
+char*
+get_record_block_ref_info(char* buf, struct decoded_xlog_record* record,
+                          bool pretty, bool detailed_format,
+                          uint32_t* fpi_len, uint8_t magic_value);
+
+/**
+ * Enhance WAL record description with operation context
+ * 
+ * @param record_desc Base record description
+ * @param rmid Resource manager ID
+ * @param info xl_info flags
+ * @return Enhanced description string
+ */
+char*
+enhance_description(char* record_desc, uint8_t rmid, uint8_t info);
+
+/**
  * Checks if the backup image is compressed.
  *
  * @param server_info The server structure for context.

--- a/src/libpgmoneta/walfile/rmgr.c
+++ b/src/libpgmoneta/walfile/rmgr.c
@@ -102,3 +102,13 @@ struct rmgr_stats rmgr_stats_table[RM_MAX_ID + 1] = {
    PG_RMGR_STATS(RM_GENERIC_ID, "Generic"),
    PG_RMGR_STATS(RM_LOGICALMSG_ID, "LogicalMessage"),
 };
+
+char*
+pgmoneta_rmgr_get_name(uint8_t rmid)
+{
+   if (rmgr_table[rmid].name != NULL)
+   {
+      return rmgr_table[rmid].name;
+   }
+   return NULL;
+}

--- a/test/testcases/test_wal_summary.c
+++ b/test/testcases/test_wal_summary.c
@@ -143,6 +143,16 @@ START_TEST(test_pgmoneta_wal_summary)
    pgmoneta_brt_destroy(brt);
    pgmoneta_disconnect(srv_socket);
    pgmoneta_disconnect(custom_user_socket);
+
+   if (srv_ssl != NULL)
+   {
+      SSL_free(srv_ssl);
+   }
+   if (custom_user_ssl != NULL)
+   {
+      SSL_free(custom_user_ssl);
+   }
+
    free(summary_dir);
    free(wal_dir);
 }


### PR DESCRIPTION
Implements an interactive ncurses-based WAL file viewer that allows users to navigate, search, and inspect PostgreSQL WAL records in real-time. This addresses issue [#738] by providing a visual debugging tool for WAL file analysis.
Features

Interactive Navigation: Use arrow keys to browse through WAL records
Multiple Display Modes:
- Text mode: Human-readable record information
- Binary mode: Hexadecimal dump of record data
- Detail view: Expanded information for individual records


Search Functionality: Search through WAL records by LSN, RMGR, type, or description
Record Verification: Integration point for pg_waldump verification (placeholder for future implementation)
Color-coded Display: Visual feedback with color-coded status indicators
Keyboard Controls:
- Up/Down: Navigate between records
- PgUp/PgDn: Page scrolling
- Home/End: Jump to first/last record
- T/B: Toggle text/binary view
- Enter: Show detailed record view
- S: Search records
- V: Verify records
- ?: Show help
- Q: Quit