### PR TITLE
feat(walfile): Support dynamic block size in WAL decoding

### DIFF
--- a/src/include/walfile/rm_btree.h
+++ b/src/include/walfile/rm_btree.h
@@ -39,9 +39,10 @@ extern "C" {
 
 #include <stdint.h>
 
-#define INVALID_OFFSET_NUMBER         ((offset_number)0)
-#define FIRST_OFFSET_NUMBER           ((offset_number)1)
-#define MAX_OFFSET_NUMBER             ((offset_number)(8192 / sizeof(struct item_id_data))) // TODO: Replace 8192 with block size from pg_control
+#define INVALID_OFFSET_NUMBER ((offset_number)0)
+#define FIRST_OFFSET_NUMBER   ((offset_number)1)
+#define MAX_OFFSET_NUMBER(block_size) \
+   ((block_size) / sizeof(struct item_id_data))
 
 #define XLOG_BTREE_INSERT_LEAF        0x00 /**< Add index tuple without split */
 #define XLOG_BTREE_INSERT_UPPER       0x10 /**< Same, on a non-leaf page */
@@ -61,10 +62,9 @@ extern "C" {
 
 #define SIZE_OF_BTREE_UPDATE          (offsetof(struct xl_btree_update, ndeletedtids) + sizeof(uint16_t))
 
-#define OFFSET_NUMBER_IS_VALID(offsetNumber)          \
-   ((bool)((offsetNumber != INVALID_OFFSET_NUMBER) && \
-           (offsetNumber <= MAX_OFFSET_NUMBER)))
-
+#define OFFSET_NUMBER_IS_VALID(offset, block_size) \
+   ((bool)(((offset) >= FIRST_OFFSET_NUMBER) &&    \
+           ((offset) <= MAX_OFFSET_NUMBER(block_size))))
 /**
  * @struct item_id_data
  * @brief Describes a line pointer on a page in a B-tree.

--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -342,6 +342,7 @@ struct decoded_xlog_record
    transaction_id toplevel_xid;                           /**< Top-level transaction ID. */
    char* main_data;                                       /**< Main data portion of the record. */
    uint32_t main_data_len;                                /**< Length of the main data portion. */
+   uint32_t block_size;                                   /**< Block size. */
    int max_block_id;                                      /**< Highest block ID in use (-1 if none). */
    struct decoded_bkp_block blocks[XLR_MAX_BLOCK_ID + 1]; /**< Array of decoded backup blocks. */
    bool partial;                                          /**< Indicates if the record is partial. */

--- a/src/libpgmoneta/walfile/rm_btree.c
+++ b/src/libpgmoneta/walfile/rm_btree.c
@@ -444,7 +444,7 @@ pgmoneta_wal_format_xl_btree_unlink_page_v14(struct xl_btree_unlink_page* wrappe
 }
 
 static char*
-pgmoneta_wal_delvacuum_desc(char* buf, char* block_data, uint16_t ndeleted, uint16_t nupdated)
+pgmoneta_wal_delvacuum_desc(char* buf, char* block_data, uint16_t ndeleted, uint16_t nupdated, uint32_t block_size)
 {
    offset_number* deletedoffsets;
    offset_number* updatedoffsets;
@@ -471,7 +471,7 @@ pgmoneta_wal_delvacuum_desc(char* buf, char* block_data, uint16_t ndeleted, uint
    {
       offset_number off = updatedoffsets[i];
 
-      assert(OFFSET_NUMBER_IS_VALID(off));
+      assert(OFFSET_NUMBER_IS_VALID(off, block_size));
       assert(updates->ndeletedtids > 0);
 
       /*
@@ -551,7 +551,7 @@ pgmoneta_wal_btree_desc(char* buf, struct decoded_xlog_record* record)
          if (XLogRecHasBlockData(record, 0))
          {
             buf = pgmoneta_wal_delvacuum_desc(buf, pgmoneta_wal_get_record_block_data(record, 0, NULL),
-                                              xlrec->ndeleted, xlrec->nupdated);
+                                              xlrec->ndeleted, xlrec->nupdated, record->block_size);
          }
          break;
       }

--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -598,6 +598,7 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
    decoded->toplevel_xid = INVALID_TRANSACTION_ID;
    decoded->main_data = NULL;
    decoded->main_data_len = 0;
+   decoded->block_size = block_size;
    decoded->max_block_id = -1;
 
    //read id
@@ -983,7 +984,7 @@ get_record_block_ref_info(char* buf, struct decoded_xlog_record* record, bool pr
                                                 record->blocks[block_id].apply_image ? "" : " for WAL verification",
                                                 record->blocks[block_id].hole_offset,
                                                 record->blocks[block_id].hole_length,
-                                                8192 -
+                                                record->block_size -
                                                    record->blocks[block_id].hole_length -
                                                    record->blocks[block_id].bimg_len,
                                                 method);


### PR DESCRIPTION
refactor the wal decoding logic to use replace hard coded 8192-byte constants to the wal file header format
[#841] 
enabling PostgreSQL instances running with non-standard block sizes.