### PR TITLE
[#830]refactor: S3 configuration to be overwritten by the server config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,4 +36,4 @@ Bassam Adnan <mailbassam@gmail.com>
 Sara Nabih <nabihsara8@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
-Amr Shams <amr.shams2015.a@gmail.com>
+Amr Shams (NightBird) <amr.shams2015.a@gmail.com>

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -97,6 +97,15 @@ See a [sample](./etc/pgmoneta.conf) configuration for running `pgmoneta` on `loc
 | retention | | Array | No | The retention for the server in days, weeks, months, years |
 | wal_shipping | | String | No | The WAL shipping directory |
 | workspace | /tmp/pgmoneta-workspace/ | String | No | The directory for the workspace that incremental backup can use for its work. Can interpolate environment variables (e.g., `$HOME`) |
+| s3_storage_class | | String | No | The S3 storage class. Overrides global setting. |
+| s3_port   | | Int | No | The port number for the S3 endpoint. Overrides global setting. |
+| s3_use_tls | | Bool | No | Use TLS for S3 connections. Overrides global setting. |
+| s3_endpoint | | String | No | S3 endpoint URL. Overrides global setting. |
+| s3_region | | String | No | The AWS region. Overrides global setting. |
+| s3_access_key_id | | String | No | The IAM access key ID. Overrides global setting. |
+| s3_secret_access_key | | String | No | The IAM secret access key. Overrides global setting. |
+| s3_bucket | | String | No | The AWS S3 bucket name. Overrides global setting. |
+| s3_base_dir | | String | No | The base directory for the S3 bucket. Overrides global setting. |
 | hot_standby | | String | No | Hot standby directories. Single directory or comma separated directories up to 8 (e.g., /path/to/hot/standby1,/path/to/hot/standby2) |
 | hot_standby_overrides | | String | No | Files to override in the hot standby directory. If multiple hot standbys are specified then this setting is separated by a \| |
 | hot_standby_tablespaces | | String | No | Tablespace mappings for the hot standby. Syntax is [from -> to,?]+. If multiple hot standbys are specified then this setting is separated by a \| |

--- a/doc/S3.md
+++ b/doc/S3.md
@@ -92,3 +92,45 @@ s3_endpoint = <endpoint_url>
 s3_port = <port>
 s3_region = <region>
 ```
+## Per-Server Configuration
+
+All S3 configuration settings can be specified within a server's configuration section. This allows you to use different S3 buckets, credentials, or even regions for different PostgreSQL servers.
+
+When a server section has S3 settings, they override the global settings found in the `[pgmoneta]` section. If a server section does not specify a particular S3 setting, it will fall back to the value in the `[pgmoneta]` section.
+
+If the `[pgmoneta]` section has no S3 configuration, then all required S3 settings must be specified in each server section that uses the S3 storage engine.
+
+### Example with Per-Server Override
+
+In this example, `server1` uses the global S3 bucket, but `server2` overrides it with its own bucket and credentials.
+
+```ini
+[pgmoneta]
+host = localhost
+unix_socket_dir = /tmp/
+storage_engine = s3
+
+# Global S3 configuration
+s3_access_key_id = <global_access_key>
+s3_secret_access_key = <global_secret_key>
+s3_bucket = global-backup-bucket
+s3_base_dir = pgmoneta
+s3_region = us-east-1
+
+[server1]
+host = pg1.example.com
+port = 5432
+user = repl
+
+# server1 uses the global S3 configuration.
+
+[server2]
+host = pg2.example.com
+port = 5432
+user = repl
+
+# server2 overrides some S3 settings.
+s3_access_key_id = <server2_access_key>
+s3_secret_access_key = <server2_secret_key>
+s3_bucket = server2-backup-bucket
+```

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -233,6 +233,22 @@ struct extension_info
    struct version installed_version; /**< The installed version */
 } __attribute__((aligned(64)));
 
+/** @struct s3_configuration
+ * Defines the S3 configuration
+ */
+struct s3_configuration
+{
+   int port;                            /**< The S3 port */
+   bool use_tls;                        /**< Use TLS for S3 */
+   char storage_class[MISC_LENGTH];     /**< The S3 storage class */
+   char endpoint[MISC_LENGTH];          /**< The S3 endpoint */
+   char region[MISC_LENGTH];            /**< The AWS region */
+   char access_key_id[MISC_LENGTH];     /**< The IAM Access Key ID */
+   char secret_access_key[MISC_LENGTH]; /**< The IAM Secret Access Key */
+   char bucket[MISC_LENGTH];            /**< The S3 bucket */
+   char base_dir[MAX_PATH];             /**< The S3 base directory */
+} __attribute__((aligned(64)));
+
 /** @struct server
  * Defines a server
  */
@@ -292,6 +308,7 @@ struct server
    bool has_extension;                                            /**< Does this have pgmoneta_ext */
    char ext_version[MISC_LENGTH];                                 /**< The major version of the extension*/
    struct extension_info extensions[NUMBER_OF_EXTENSIONS];        /**< The extensions */
+   struct s3_configuration s3;                                    /**< The S3 configuration */
 } __attribute__((aligned(64)));
 
 /** @struct user
@@ -404,15 +421,7 @@ struct main_configuration
    char ssh_public_key_file[MAX_PATH];  /**< The SSH public key path */
    char ssh_private_key_file[MAX_PATH]; /**< The SSH private key path */
 
-   int s3_port;                            /**< The S3 port */
-   bool s3_use_tls;                        /**< Use TLS  for S3 */
-   char s3_storage_class[MISC_LENGTH];     /**< The S3 storage class */
-   char s3_endpoint[MISC_LENGTH];          /**< The S3 endpoint */
-   char s3_region[MISC_LENGTH];            /**< The AWS region */
-   char s3_access_key_id[MISC_LENGTH];     /**< The IAM Access Key ID */
-   char s3_secret_access_key[MISC_LENGTH]; /**< The IAM Secret Access Key */
-   char s3_bucket[MISC_LENGTH];            /**< The S3 bucket */
-   char s3_base_dir[MAX_PATH];             /**< The S3 base directory */
+   struct s3_configuration s3; /**< The S3 configuration */
 
    char azure_storage_account[MISC_LENGTH]; /**< The Azure storage account name */
    char azure_container[MISC_LENGTH];       /**< The Azure container name */

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -1232,7 +1232,14 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                {
                   if (!strcmp(section, "pgmoneta"))
                   {
-                     if (as_bool(value, &config->s3_use_tls))
+                     if (as_bool(value, &config->s3.use_tls))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     if (as_bool(value, &srv.s3.use_tls))
                      {
                         unknown = true;
                      }
@@ -1251,7 +1258,16 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      {
                         max = MISC_LENGTH - 1;
                      }
-                     memcpy(config->s3_storage_class, value, max);
+                     memcpy(config->s3.storage_class, value, max);
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(srv.s3.storage_class, value, max);
                   }
                   else
                   {
@@ -1262,7 +1278,14 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                {
                   if (!strcmp(section, "pgmoneta"))
                   {
-                     if (as_int(value, &config->s3_port))
+                     if (as_int(value, &config->s3.port))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     if (as_int(value, &srv.s3.port))
                      {
                         unknown = true;
                      }
@@ -1281,7 +1304,16 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      {
                         max = MISC_LENGTH - 1;
                      }
-                     memcpy(config->s3_endpoint, value, max);
+                     memcpy(config->s3.endpoint, value, max);
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(srv.s3.endpoint, value, max);
                   }
                   else
                   {
@@ -1297,7 +1329,16 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      {
                         max = MISC_LENGTH - 1;
                      }
-                     memcpy(config->s3_region, value, max);
+                     memcpy(config->s3.region, value, max);
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(srv.s3.region, value, max);
                   }
                   else
                   {
@@ -1313,7 +1354,16 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      {
                         max = MISC_LENGTH - 1;
                      }
-                     memcpy(config->s3_access_key_id, value, max);
+                     memcpy(config->s3.access_key_id, value, max);
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(srv.s3.access_key_id, value, max);
                   }
                   else
                   {
@@ -1329,7 +1379,16 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      {
                         max = MISC_LENGTH - 1;
                      }
-                     memcpy(config->s3_secret_access_key, value, max);
+                     memcpy(config->s3.secret_access_key, value, max);
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(srv.s3.secret_access_key, value, max);
                   }
                   else
                   {
@@ -1345,7 +1404,16 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      {
                         max = MISC_LENGTH - 1;
                      }
-                     memcpy(config->s3_bucket, value, max);
+                     memcpy(config->s3.bucket, value, max);
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(srv.s3.bucket, value, max);
                   }
                   else
                   {
@@ -1361,7 +1429,16 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      {
                         max = MAX_PATH - 1;
                      }
-                     memcpy(config->s3_base_dir, value, max);
+                     memcpy(config->s3.base_dir, value, max);
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     max = strlen(value);
+                     if (max > MAX_PATH - 1)
+                     {
+                        max = MAX_PATH - 1;
+                     }
+                     memcpy(srv.s3.base_dir, value, max);
                   }
                   else
                   {
@@ -3026,15 +3103,15 @@ add_configuration_response(struct json* res)
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_SSH_CIPHERS, (uintptr_t)config->ssh_ciphers, ValueString);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_SSH_PUBLIC_KEY_FILE, (uintptr_t)config->ssh_public_key_file, ValueString);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_SSH_PRIVATE_KEY_FILE, (uintptr_t)config->ssh_private_key_file, ValueString);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_USE_TLS, (uintptr_t)config->s3_use_tls, ValueInt32);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_STORAGE_CLASS, (uintptr_t)config->s3_storage_class, ValueString);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_ENDPOINT, (uintptr_t)config->s3_endpoint, ValueString);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_PORT, (uintptr_t)config->s3_port, ValueInt32);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_REGION, (uintptr_t)config->s3_region, ValueString);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_ACCESS_KEY_ID, (uintptr_t)config->s3_access_key_id, ValueString);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_SECRET_ACCESS_KEY, (uintptr_t)config->s3_secret_access_key, ValueString);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_BUCKET, (uintptr_t)config->s3_bucket, ValueString);
-   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_BASE_DIR, (uintptr_t)config->s3_base_dir, ValueString);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_USE_TLS, (uintptr_t)config->s3.use_tls, ValueInt32);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_STORAGE_CLASS, (uintptr_t)config->s3.storage_class, ValueString);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_ENDPOINT, (uintptr_t)config->s3.endpoint, ValueString);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_PORT, (uintptr_t)config->s3.port, ValueInt32);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_REGION, (uintptr_t)config->s3.region, ValueString);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_ACCESS_KEY_ID, (uintptr_t)config->s3.access_key_id, ValueString);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_SECRET_ACCESS_KEY, (uintptr_t)config->s3.secret_access_key, ValueString);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_BUCKET, (uintptr_t)config->s3.bucket, ValueString);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_BASE_DIR, (uintptr_t)config->s3.base_dir, ValueString);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_AZURE_BASE_DIR, (uintptr_t)config->azure_base_dir, ValueString);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_AZURE_STORAGE_ACCOUNT, (uintptr_t)config->azure_storage_account, ValueString);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_AZURE_CONTAINER, (uintptr_t)config->azure_container, ValueString);
@@ -3133,7 +3210,15 @@ add_servers_configuration_response(struct json* res)
       }
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_HOT_STANDBY, (uintptr_t)hot_standby, ValueString);
       free(hot_standby);
-
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_USE_TLS, (uintptr_t)config->common.servers[i].s3.use_tls, ValueInt32);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_STORAGE_CLASS, (uintptr_t)config->common.servers[i].s3.storage_class, ValueString);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_ENDPOINT, (uintptr_t)config->common.servers[i].s3.endpoint, ValueString);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_PORT, (uintptr_t)config->common.servers[i].s3.port, ValueInt32);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_REGION, (uintptr_t)config->common.servers[i].s3.region, ValueString);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_ACCESS_KEY_ID, (uintptr_t)config->common.servers[i].s3.access_key_id, ValueString);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_SECRET_ACCESS_KEY, (uintptr_t)config->common.servers[i].s3.secret_access_key, ValueString);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_BUCKET, (uintptr_t)config->common.servers[i].s3.bucket, ValueString);
+      pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_S3_BASE_DIR, (uintptr_t)config->common.servers[i].s3.base_dir, ValueString);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_HOT_STANDBY_OVERRIDES, (uintptr_t)config->common.servers[i].hot_standby_overrides, ValueString);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_HOT_STANDBY_TABLESPACES, (uintptr_t)config->common.servers[i].hot_standby_tablespaces, ValueString);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_WORKERS, (uintptr_t)config->common.servers[i].workers, ValueInt64);
@@ -3348,14 +3433,13 @@ pgmoneta_conf_set(SSL* ssl, int client_fd, uint8_t compression, uint8_t encrypti
    }
    else
    {
-      // Success - configuration applied
+      //Success - configuration applied
       pgmoneta_json_put(response, CONFIGURATION_RESPONSE_STATUS, (uintptr_t)CONFIGURATION_STATUS_SUCCESS, ValueString);
       pgmoneta_json_put(response, CONFIGURATION_RESPONSE_MESSAGE, (uintptr_t)CONFIGURATION_MESSAGE_SUCCESS, ValueString);
       pgmoneta_json_put(response, CONFIGURATION_RESPONSE_CONFIG_KEY, (uintptr_t)config_key, ValueString);
       pgmoneta_json_put(response, CONFIGURATION_RESPONSE_OLD_VALUE, (uintptr_t)old_value, ValueString);
       pgmoneta_json_put(response, CONFIGURATION_RESPONSE_NEW_VALUE, (uintptr_t)new_value, ValueString);
       pgmoneta_json_put(response, CONFIGURATION_RESPONSE_RESTART_REQUIRED, (uintptr_t)false, ValueBool);
-
       pgmoneta_log_info("Conf Set: Successfully applied %s: %s -> %s", config_key, old_value, new_value);
    }
 
@@ -4006,10 +4090,46 @@ write_config_value(char* buffer, char* config_key, size_t buffer_size)
                   snprintf(buffer, buffer_size, "%s", ret ? ret : "");
                   free(ret);
                }
+               else if (!strcmp(key_info.key, "s3_use_tls"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.use_tls ? "true" : "false");
+               }
+               else if (!strcmp(key_info.key, "s3_storage_class"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.storage_class);
+               }
+               else if (!strcmp(key_info.key, "s3_endpoint"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.endpoint);
+               }
+               else if (!strcmp(key_info.key, "s3_port"))
+               {
+                  snprintf(buffer, buffer_size, "%d", srv->s3.port);
+               }
+               else if (!strcmp(key_info.key, "s3_region"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.region);
+               }
+               else if (!strcmp(key_info.key, "s3_access_key_id"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.access_key_id);
+               }
+               else if (!strcmp(key_info.key, "s3_secret_access_key"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.secret_access_key);
+               }
+               else if (!strcmp(key_info.key, "s3_bucket"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.bucket);
+               }
+               else if (!strcmp(key_info.key, "s3_base_dir"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->s3.base_dir);
+               }
                else
                {
                   pgmoneta_log_debug("Unknown server configuration key: %s", key_info.key);
-                  return 1; // Unknown key
+                  return 1;
                }
                break;
             }
@@ -5381,6 +5501,21 @@ copy_server(struct server* dst, struct server* src)
       changed = true;
    }
    if (restart_string("wal_shipping", &dst->wal_shipping[0], &src->wal_shipping[0]))
+   {
+      changed = true;
+   }
+   if (restart_int("s3_port", dst->s3.port, src->s3.port) ||
+       restart_bool("s3_use_tls", dst->s3.use_tls, src->s3.use_tls) ||
+       restart_string("s3_storage_class", dst->s3.storage_class,
+                      src->s3.storage_class) ||
+       restart_string("s3_endpoint", dst->s3.endpoint, src->s3.endpoint) ||
+       restart_string("s3_region", dst->s3.region, src->s3.region) ||
+       restart_string("s3_access_key_id", dst->s3.access_key_id,
+                      src->s3.access_key_id) ||
+       restart_string("s3_secret_access_key", dst->s3.secret_access_key,
+                      src->s3.secret_access_key) ||
+       restart_string("s3_bucket", dst->s3.bucket, src->s3.bucket) ||
+       restart_string("s3_base_dir", dst->s3.base_dir, src->s3.base_dir))
    {
       changed = true;
    }

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -2560,6 +2560,15 @@ pgmoneta_create_ssl_ctx(bool client, SSL_CTX** ctx)
       goto error;
    }
 
+   if (client)
+   {
+      if (!SSL_CTX_set_default_verify_paths(c))
+      {
+         pgmoneta_log_warn("Failed to set default SSL verify paths");
+      }
+      SSL_CTX_set_verify(c, SSL_VERIFY_PEER, NULL);
+   }
+
    if (SSL_CTX_set_min_proto_version(c, TLS1_2_VERSION) == 0)
    {
       goto error;


### PR DESCRIPTION
       - Added per-server S3 configuration overrides entirely.
       - Added the now-redundant `s3_configuration` struct.
       - Revised documentation (CONFIGURATION.md, S3.md) to reflect the addition of per-server S3 options.