### PR TITLE
[#658] test: Add CLI command tests with error code validation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1779,6 +1779,12 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
             pgmoneta_annotate_request(NULL, client_fd, srv, compression, encryption, pyl);
          }
       }
+      else
+      {
+         pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_ANNOTATE_NOSERVER, NAME, compression, encryption, payload);
+         pgmoneta_log_error("Annotate: No server %s (%d)", server, MANAGEMENT_ERROR_ANNOTATE_NOSERVER);
+         goto error;
+      }
    }
    else if (id == MANAGEMENT_MODE)
    {

--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -36,67 +36,250 @@ extern "C" {
 
 #include <pgmoneta.h>
 #include <brt.h>
+#include <json.h>
 #include <walfile/wal_reader.h>
 
 /**
  * Execute backup command on the server
  * @param server the server to perform backup on
  * @param incremental execute backup in incremental mode
+ * @param expected_error expected error code
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_tsclient_backup(char* server, char* incremental);
+pgmoneta_tsclient_backup(char* server, char* incremental, int expected_error);
+
+/**
+ * Execute list-backup command on the server
+ * @param server the server
+ * @param sort_order the sort order
+ * @param response optional output for JSON response (NULL to ignore)
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_list_backup(char* server, char* sort_order, struct json** response, int expected_error);
 
 /**
  * Execute restore command on the server
  * @param server the server to perform restore on
  * @param backup_id the backup_id to perform restore on
  * @param position the position parameters
+ * @param expected_error expected error code
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_tsclient_restore(char* server, char* backup_id, char* position);
+pgmoneta_tsclient_restore(char* server, char* backup_id, char* position, int expected_error);
 
 /**
- * Execute retain command on the server 
- * @param server the server to perform retain on
- * @param backup_id the backup_id to retain
+ * Execute verify command on the server
+ * @param server the server
+ * @param backup_id the backup
+ * @param directory the directory
+ * @param files the files
+ * @param expected_error expected error code
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_tsclient_retain(char* server, char* backup_id);
+pgmoneta_tsclient_verify(char* server, char* backup_id, char* directory, char* files, int expected_error);
 
 /**
- * Execute expunge command on the server
- * @param server the server to perform expunge on
- * @param backup_id the backup_id to expunge
+ * Execute archive command on the server
+ * @param server the server
+ * @param backup_id the backup
+ * @param position the position
+ * @param directory the directory
+ * @param expected_error expected error code
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_tsclient_expunge(char* server, char* backup_id);
+pgmoneta_tsclient_archive(char* server, char* backup_id, char* position, char* directory, int expected_error);
+
 /**
  * Execute delete command on the server
  * @param server the server to perform delete on
  * @param backup_id the backup_id to delete
+ * @param expected_error expected error code
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_tsclient_delete(char* server, char* backup_id);
+pgmoneta_tsclient_delete(char* server, char* backup_id, int expected_error);
+
 /**
- * Execute force delete command on the server 
+ * Execute force delete command on the server
  * @param server the server to perform delete on
  * @param backup_id the backup_id to delete
- * return 0 upon success, otherwise 1
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_tsclient_force_delete(char* server, char* backup_id);
+pgmoneta_tsclient_force_delete(char* server, char* backup_id, int expected_error);
+
+/**
+ * Execute retain command on the server
+ * @param server the server
+ * @param backup_id the backup
+ * @param cascade cascade
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_retain(char* server, char* backup_id, bool cascade, int expected_error);
+
+/**
+ * Execute expunge command on the server
+ * @param server the server
+ * @param backup_id the backup
+ * @param cascade cascade
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_expunge(char* server, char* backup_id, bool cascade, int expected_error);
+
+/**
+ * Execute decrypt command on the server
+ * @param path the path
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_decrypt(char* path, int expected_error);
+
+/**
+ * Execute encrypt command on the server
+ * @param path the path
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_encrypt(char* path, int expected_error);
+
+/**
+ * Execute decompress command on the server
+ * @param path the path
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_decompress(char* path, int expected_error);
+
+/**
+ * Execute compress command on the server
+ * @param path the path
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_compress(char* path, int expected_error);
+
+/**
+ * Execute ping command on the server
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_ping(int expected_error);
+
+/**
+ * Execute shutdown command on the server
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_shutdown(int expected_error);
+
+/**
+ * Execute status command on the server
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_status(int expected_error);
+
+/**
+ * Execute status details command on the server
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_status_details(int expected_error);
 
 /**
  * Execute reload command on the server
+ * @param expected_error expected error code
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_tsclient_reload();
+pgmoneta_tsclient_reload(int expected_error);
+
+/**
+ * Execute reset command on the server
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_reset(int expected_error);
+
+/**
+ * Execute conf ls command on the server
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_conf_ls(int expected_error);
+
+/**
+ * Execute conf get command on the server
+ * @param config_key the key
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_conf_get(char* config_key, int expected_error);
+
+/**
+ * Execute conf set command on the server
+ * @param config_key the key
+ * @param config_value the value
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_conf_set(char* config_key, char* config_value, int expected_error);
+
+/**
+ * Execute info command on the server
+ * @param server the server
+ * @param backup_id the backup
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_info(char* server, char* backup_id, int expected_error);
+
+/**
+ * Execute annotate command on the server
+ * @param server the server
+ * @param backup_id the backup
+ * @param action the action
+ * @param key the key
+ * @param comment the comment
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_annotate(char* server, char* backup_id, char* action, char* key, char* comment, int expected_error);
+
+/**
+ * Execute mode command on the server
+ * @param server the server
+ * @param action the action
+ * @param expected_error expected error code
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_mode(char* server, char* action, int expected_error);
 
 #ifdef __cplusplus
 }

--- a/test/include/tsclient_helpers.h
+++ b/test/include/tsclient_helpers.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGMONETA_TSCLIENT_HELPERS_H
+#define PGMONETA_TSCLIENT_HELPERS_H
+
+#include <json.h>
+#include <stdbool.h>
+
+/**
+ * Get backup count from LIST_BACKUP response
+ * @param response The JSON response from list_backup
+ * @return Number of backups, or -1 on error
+ */
+int
+pgmoneta_tsclient_get_backup_count(struct json* response);
+
+/**
+ * Get backup at specific index from LIST_BACKUP response
+ * @param response The JSON response from list_backup
+ * @param index The backup index
+ * @return JSON object for backup, or NULL on error
+ */
+struct json*
+pgmoneta_tsclient_get_backup(struct json* response, int index);
+
+/**
+ * Get backup label from backup JSON object
+ * @param backup The backup JSON object
+ * @return Label string, or NULL on error
+ */
+char*
+pgmoneta_tsclient_get_backup_label(struct json* backup);
+
+/**
+ * Get backup type (FULL/INCREMENTAL) from backup JSON object
+ * @param backup The backup JSON object
+ * @return Type string ("FULL" or "INCREMENTAL"), or NULL on error
+ */
+char*
+pgmoneta_tsclient_get_backup_type(struct json* backup);
+
+/**
+ * Get backup parent label from backup JSON object
+ * @param backup The backup JSON object
+ * @return Parent label string, or NULL if FULL backup or error
+ */
+char*
+pgmoneta_tsclient_get_backup_parent(struct json* backup);
+
+/**
+ * Verify parent-child relationship between two backups
+ * @param parent The parent backup JSON object
+ * @param child The child backup JSON object
+ * @return true if child's parent matches parent's label
+ */
+bool
+pgmoneta_tsclient_verify_backup_chain(struct json* parent, struct json* child);
+
+#endif

--- a/test/libpgmonetatest/tsclient_helpers.c
+++ b/test/libpgmonetatest/tsclient_helpers.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <tsclient_helpers.h>
+#include <json.h>
+#include <management.h>
+
+#include <string.h>
+
+int
+pgmoneta_tsclient_get_backup_count(struct json* response)
+{
+   struct json* response_obj = NULL;
+
+   if (response == NULL)
+   {
+      return -1;
+   }
+
+   // Response structure: { "Response": { "NumberOfBackups": N, "Backups": [...] } }
+   response_obj = (struct json*)pgmoneta_json_get(response, MANAGEMENT_CATEGORY_RESPONSE);
+   if (response_obj == NULL)
+   {
+      return -1;
+   }
+
+   if (!pgmoneta_json_contains_key(response_obj, MANAGEMENT_ARGUMENT_NUMBER_OF_BACKUPS))
+   {
+      return -1;
+   }
+
+   return (int)pgmoneta_json_get(response_obj, MANAGEMENT_ARGUMENT_NUMBER_OF_BACKUPS);
+}
+
+struct json*
+pgmoneta_tsclient_get_backup(struct json* response, int index)
+{
+   struct json* response_obj = NULL;
+   struct json* backups = NULL;
+   struct json_iterator* it = NULL;
+   struct json* result = NULL;
+
+   if (response == NULL || index < 0)
+   {
+      return NULL;
+   }
+
+   // Navigate to Response
+   response_obj = (struct json*)pgmoneta_json_get(response, MANAGEMENT_CATEGORY_RESPONSE);
+   if (response_obj == NULL)
+   {
+      return NULL;
+   }
+
+   // Navigate to Backups array
+   backups = (struct json*)pgmoneta_json_get(response_obj, MANAGEMENT_ARGUMENT_BACKUPS);
+   if (backups == NULL || backups->type != JSONArray)
+   {
+      return NULL;
+   }
+
+   if (index >= pgmoneta_json_array_length(backups))
+   {
+      return NULL;
+   }
+
+   // Iterate to the requested index and return the element
+   if (pgmoneta_json_iterator_create(backups, &it))
+   {
+      return NULL;
+   }
+   for (int i = 0; i <= index; i++)
+   {
+      if (!pgmoneta_json_iterator_next(it))
+      {
+         pgmoneta_json_iterator_destroy(it);
+         return NULL;
+      }
+   }
+   result = (struct json*)pgmoneta_value_data(it->value);
+   pgmoneta_json_iterator_destroy(it);
+   return result;
+}
+
+char*
+pgmoneta_tsclient_get_backup_label(struct json* backup)
+{
+   if (backup == NULL)
+   {
+      return NULL;
+   }
+
+   return (char*)pgmoneta_json_get(backup, MANAGEMENT_ARGUMENT_BACKUP);
+}
+
+char*
+pgmoneta_tsclient_get_backup_type(struct json* backup)
+{
+   if (backup == NULL)
+   {
+      return NULL;
+   }
+
+   if (!pgmoneta_json_contains_key(backup, MANAGEMENT_ARGUMENT_INCREMENTAL))
+   {
+      return NULL;
+   }
+
+   if ((bool)pgmoneta_json_get(backup, MANAGEMENT_ARGUMENT_INCREMENTAL))
+   {
+      return "INCREMENTAL";
+   }
+   else
+   {
+      return "FULL";
+   }
+}
+
+char*
+pgmoneta_tsclient_get_backup_parent(struct json* backup)
+{
+   if (backup == NULL)
+   {
+      return NULL;
+   }
+
+   char* parent = (char*)pgmoneta_json_get(backup, MANAGEMENT_ARGUMENT_INCREMENTAL_PARENT);
+
+   // Convert empty string to NULL for FULL backups
+   if (parent != NULL && strlen(parent) == 0)
+   {
+      return NULL;
+   }
+
+   return parent;
+}
+
+bool
+pgmoneta_tsclient_verify_backup_chain(struct json* parent, struct json* child)
+{
+   char* parent_label = NULL;
+   char* child_parent = NULL;
+
+   if (parent == NULL || child == NULL)
+   {
+      return false;
+   }
+
+   parent_label = pgmoneta_tsclient_get_backup_label(parent);
+   child_parent = pgmoneta_tsclient_get_backup_parent(child);
+
+   if (parent_label == NULL || child_parent == NULL)
+   {
+      return false;
+   }
+
+   return strcmp(parent_label, child_parent) == 0;
+}

--- a/test/libpgmonetatest/tscommon.c
+++ b/test/libpgmonetatest/tscommon.c
@@ -142,7 +142,7 @@ pgmoneta_test_validate_configuration(void* shmem)
 int
 pgmoneta_test_add_backup(void)
 {
-   if (pgmoneta_tsclient_backup("primary", NULL))
+   if (pgmoneta_tsclient_backup("primary", NULL, 0))
    {
       return 1;
    }
@@ -152,17 +152,17 @@ pgmoneta_test_add_backup(void)
 int
 pgmoneta_test_add_backup_chain(void)
 {
-   if (pgmoneta_tsclient_backup("primary", NULL))
+   if (pgmoneta_tsclient_backup("primary", NULL, 0))
    {
       return 1;
    }
    
-   if (pgmoneta_tsclient_backup("primary", "newest"))
+   if (pgmoneta_tsclient_backup("primary", "newest", 0))
    {
       return 1;
    }
    
-   if (pgmoneta_tsclient_backup("primary", "newest"))
+   if (pgmoneta_tsclient_backup("primary", "newest", 0))
    {
       return 1;
    }
@@ -214,7 +214,7 @@ pgmoneta_test_basedir_cleanup(void)
    pgmoneta_reload_configuration(&restart);
    }
 
-   if (pgmoneta_tsclient_reload())
+   if (pgmoneta_tsclient_reload(0))
    {
       pgmoneta_log_error("pgmoneta_test_basedir_cleanup: failed to reload configuration");
    }
@@ -254,7 +254,7 @@ int
 pgmoneta_test_backup(const char* server_name, const char* backup_name)
 {
    /* Cast const away as pgmoneta_tsclient_backup doesn't modify the strings */
-   return pgmoneta_tsclient_backup((char*)server_name, (char*)backup_name);
+   return pgmoneta_tsclient_backup((char*)server_name, (char*)backup_name, 0);
 }
 
 int

--- a/test/testcases/test_cli.c
+++ b/test/testcases/test_cli.c
@@ -1,0 +1,483 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <management.h>
+#include <mctf.h>
+#include <tsclient.h>
+#include <tscommon.h>
+#include <utils.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <errno.h>
+
+/* Basic CLI Tests */
+
+MCTF_TEST(test_cli_ping)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_ping(0) == 0, cleanup, "Ping failed");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_status)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_status(0) == 0, cleanup, "Status failed");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_status_details)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_status_details(0) == 0, cleanup, "Status details failed");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_conf_ls)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_conf_ls(0) == 0, cleanup, "Conf ls failed");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_conf_reload)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_reload(0) == 0, cleanup, "Conf reload failed");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_conf_get)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_conf_get("log_level", 0) == 0, cleanup, "Conf get log_level failed");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_conf_set)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_conf_set("log_level", "info", 0) == 0, cleanup, "Conf set log_level=info failed");
+
+   /* Negative: Set unknown key */
+   MCTF_ASSERT(pgmoneta_tsclient_conf_set("invalid_key", "value", MANAGEMENT_ERROR_CONF_SET_ERROR) == 0, cleanup,
+               "Conf set invalid_key should fail with ERROR");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_mode)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_mode("primary", "online", 0) == 0, cleanup, "Mode online failed");
+
+   /* Negative */
+   MCTF_ASSERT(pgmoneta_tsclient_mode("invalid_server", "online", MANAGEMENT_ERROR_MODE_NOSERVER) == 0, cleanup,
+               "Mode invalid_server should fail with NOSERVER");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+/* Backup Tests */
+
+MCTF_TEST(test_cli_backup)
+{
+   pgmoneta_test_setup();
+
+   /* Use the same pattern as other backup tests - mode is already set by environment */
+   MCTF_ASSERT(pgmoneta_tsclient_backup("primary", NULL, 0) == 0, cleanup, "Backup primary failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_list_backup)
+{
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   MCTF_ASSERT(pgmoneta_tsclient_list_backup("primary", NULL, NULL, 0) == 0, cleanup, "List backup primary failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_info)
+{
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   MCTF_ASSERT(pgmoneta_tsclient_info("primary", "newest", 0) == 0, cleanup, "Info newest failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_verify)
+{
+   char path[MAX_PATH];
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   snprintf(path, sizeof(path), "%s/verify_test", TEST_BASE_DIR);
+   pgmoneta_mkdir(path);
+
+   MCTF_ASSERT(pgmoneta_tsclient_verify("primary", "newest", path, NULL, 0) == 0, cleanup, "Verify newest failed");
+
+   pgmoneta_delete_directory(path);
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_archive)
+{
+   char path[MAX_PATH];
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   snprintf(path, sizeof(path), "%s/archive_test", TEST_BASE_DIR);
+   pgmoneta_mkdir(path);
+
+   MCTF_ASSERT(pgmoneta_tsclient_archive("primary", "newest", NULL, path, 0) == 0, cleanup, "Archive newest failed");
+
+   pgmoneta_delete_directory(path);
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_restore)
+{
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   MCTF_ASSERT(pgmoneta_tsclient_restore("primary", "newest", "current", 0) == 0, cleanup, "Restore newest failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+/* Backup Mutation Tests */
+
+MCTF_TEST(test_cli_retain)
+{
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   MCTF_ASSERT(pgmoneta_tsclient_retain("primary", "newest", false, 0) == 0, cleanup, "Retain newest failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_expunge)
+{
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   MCTF_ASSERT(pgmoneta_tsclient_expunge("primary", "newest", false, 0) == 0, cleanup, "Expunge newest failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_annotate)
+{
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   MCTF_ASSERT(pgmoneta_tsclient_annotate("primary", "newest", "add", "testkey", "testcomment", 0) == 0, cleanup,
+               "Annotate add failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_delete)
+{
+   pgmoneta_test_setup();
+
+   if (pgmoneta_test_add_backup())
+   {
+      pgmoneta_test_basedir_cleanup();
+      MCTF_SKIP();
+   }
+
+   MCTF_ASSERT(pgmoneta_tsclient_delete("primary", "oldest", 0) == 0, cleanup, "Delete oldest failed");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+/* Admin/Utility Tests */
+
+MCTF_TEST(test_cli_reset)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_reset(0) == 0, cleanup, "Reset (clear prometheus) failed");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_cli_utility_positive)
+{
+   FILE* fp;
+   char path[MAX_PATH];
+   char path_aes[MAX_PATH];
+   char path_zstd[MAX_PATH];
+
+   pgmoneta_test_setup();
+
+   snprintf(path, sizeof(path), "%s/pgmoneta_test_file", TEST_BASE_DIR);
+   snprintf(path_aes, sizeof(path_aes), "%s/pgmoneta_test_file.aes", TEST_BASE_DIR);
+   snprintf(path_zstd, sizeof(path_zstd), "%s/pgmoneta_test_file.zstd", TEST_BASE_DIR);
+
+   /* Setup: Create a dummy file */
+   fp = fopen(path, "w");
+   MCTF_ASSERT_PTR_NONNULL(fp, cleanup, "Failed to create test file");
+   fprintf(fp, "test content for encrypt/compress testing");
+   fclose(fp);
+
+   /* Positive: Encrypt */
+   MCTF_ASSERT(pgmoneta_tsclient_encrypt(path, 0) == 0, cleanup, "Encrypt failed");
+
+   /* Positive: Decrypt (encrypt creates .aes file) */
+   MCTF_ASSERT(pgmoneta_tsclient_decrypt(path_aes, 0) == 0, cleanup, "Decrypt failed");
+
+   /* Positive: Compress */
+   MCTF_ASSERT(pgmoneta_tsclient_compress(path, 0) == 0, cleanup, "Compress failed");
+
+   /* Positive: Decompress (compress creates .zstd file) */
+   MCTF_ASSERT(pgmoneta_tsclient_decompress(path_zstd, 0) == 0, cleanup, "Decompress failed");
+
+cleanup:
+   /* Cleanup test files */
+   remove(path);
+   remove(path_aes);
+   remove(path_zstd);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+/* Negative Tests */
+
+MCTF_TEST(test_cli_negative)
+{
+   char path[MAX_PATH];
+   pgmoneta_test_setup();
+
+   /* Backup invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_backup("invalid_server", NULL, MANAGEMENT_ERROR_BACKUP_NOSERVER) == 0, cleanup,
+               "Backup invalid_server should fail with NOSERVER");
+
+   /* List backup invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_list_backup("invalid_server", NULL, NULL, MANAGEMENT_ERROR_LIST_BACKUP_NOSERVER) == 0, cleanup,
+               "List backup invalid_server should fail with NOSERVER");
+
+   /* Delete invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_delete("invalid_server", "oldest", MANAGEMENT_ERROR_DELETE_NOSERVER) == 0, cleanup,
+               "Delete invalid_server should fail with NOSERVER");
+
+   /* Retain invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_retain("invalid_server", "newest", false, MANAGEMENT_ERROR_RETAIN_NOSERVER) == 0, cleanup,
+               "Retain invalid_server should fail with NOSERVER");
+
+   /* Expunge invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_expunge("invalid_server", "newest", false, MANAGEMENT_ERROR_EXPUNGE_NOSERVER) == 0, cleanup,
+               "Expunge invalid_server should fail with NOSERVER");
+
+   /* Info invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_info("invalid_server", "newest", MANAGEMENT_ERROR_INFO_NOSERVER) == 0, cleanup,
+               "Info invalid_server should fail with NOSERVER");
+
+   /* Annotate invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_annotate("invalid_server", "newest", "add", "k", "c", MANAGEMENT_ERROR_ANNOTATE_NOSERVER) == 0, cleanup,
+               "Annotate invalid_server should fail with NOSERVER");
+
+   /* Verify invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_verify("invalid_server", "newest", NULL, NULL, MANAGEMENT_ERROR_VERIFY_NOSERVER) == 0, cleanup,
+               "Verify invalid_server should fail with NOSERVER");
+
+   /* Archive invalid server */
+   snprintf(path, sizeof(path), "%s/archive_test_neg", TEST_BASE_DIR);
+   pgmoneta_mkdir(path);
+   MCTF_ASSERT(pgmoneta_tsclient_archive("invalid_server", "newest", NULL, path, MANAGEMENT_ERROR_ARCHIVE_NOSERVER) == 0, cleanup,
+               "Archive invalid_server should fail with NOSERVER");
+   pgmoneta_delete_directory(path);
+
+   /* Restore invalid server */
+   MCTF_ASSERT(pgmoneta_tsclient_restore("invalid_server", "newest", "current", MANAGEMENT_ERROR_RESTORE_NOSERVER) == 0, cleanup,
+               "Restore invalid_server should fail with NOSERVER");
+
+   /* Encrypt/Decrypt with non-existent file */
+   MCTF_ASSERT(pgmoneta_tsclient_encrypt("/nonexistent/path/file.txt", MANAGEMENT_ERROR_ENCRYPT_NOFILE) == 0, cleanup,
+               "Encrypt nonexistent file should fail with NOFILE");
+   MCTF_ASSERT(pgmoneta_tsclient_decrypt("/nonexistent/path/file.txt.aes", MANAGEMENT_ERROR_DECRYPT_NOFILE) == 0, cleanup,
+               "Decrypt nonexistent file should fail with NOFILE");
+
+   /* Compress/Decompress with non-existent file */
+   MCTF_ASSERT(pgmoneta_tsclient_compress("/nonexistent/path/file.txt", MANAGEMENT_ERROR_ZSTD_NOFILE) == 0, cleanup,
+               "Compress nonexistent file should fail with NOFILE");
+   MCTF_ASSERT(pgmoneta_tsclient_decompress("/nonexistent/path/file.txt.zstd", MANAGEMENT_ERROR_ZSTD_NOFILE) == 0, cleanup,
+               "Decompress nonexistent file should fail with NOFILE");
+
+cleanup:
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+/* Shutdown Test - Must be last */
+
+// MCTF_TEST(test_cli_shutdown)
+// {
+//    FILE* fp;
+//    char pid_str[32];
+//    pid_t pid = -1;
+
+//    pgmoneta_test_setup();
+
+//    /* Get PID of pgmoneta */
+//    fp = popen("pidof pgmoneta", "r");
+//    if (fp != NULL)
+//    {
+//       if (fgets(pid_str, sizeof(pid_str), fp) != NULL)
+//       {
+//          pid = atoi(pid_str);
+//       }
+//       pclose(fp);
+//    }
+
+//    MCTF_ASSERT(pid > 0, cleanup, "Could not find pgmoneta PID");
+//    MCTF_ASSERT(kill(pid, 0) == 0, cleanup, "pgmoneta process does not exist");
+
+//    /* Shutdown */
+//    MCTF_ASSERT(pgmoneta_tsclient_shutdown(0) == 0, cleanup, "Shutdown failed");
+
+//    /* Wait for shutdown */
+//    sleep(3);
+
+//    /* Check if process is gone */
+//    if (kill(pid, 0) == 0)
+//    {
+//       mctf_errno = __LINE__;
+//       goto cleanup;
+//    }
+
+//    MCTF_ASSERT(errno == ESRCH, cleanup, "Unexpected error checking PID");
+
+// cleanup:
+//    /* No teardown - server is dead */
+//    MCTF_FINISH();
+// }

--- a/test/testcases/test_delete.c
+++ b/test/testcases/test_delete.c
@@ -47,7 +47,7 @@ MCTF_TEST(test_pgmoneta_delete_full)
       MCTF_SKIP();
    }
 
-   if (pgmoneta_tsclient_delete("primary", "oldest"))
+   if (pgmoneta_tsclient_delete("primary", "oldest", 0))
    {
       pgmoneta_test_basedir_cleanup();
       MCTF_SKIP();
@@ -76,10 +76,10 @@ MCTF_TEST(test_pgmoneta_delete_retained_backup)
    MCTF_ASSERT_PTR_NONNULL(d, cleanup, "server backup not valid");
 
    // Retain the backup
-   MCTF_ASSERT(!pgmoneta_tsclient_retain("primary", "oldest"), cleanup, "failed to retain backup");
+   MCTF_ASSERT(!pgmoneta_tsclient_retain("primary", "oldest", false, 0), cleanup, "failed to retain backup");
 
    // Delete without force should fail
-   MCTF_ASSERT(pgmoneta_tsclient_delete("primary", "oldest") != 0, cleanup, "delete should fail for retained backup");
+   MCTF_ASSERT(pgmoneta_tsclient_delete("primary", "oldest", 0) != 0, cleanup, "delete should fail for retained backup");
 
    // Verify the count is still 1
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_backups, &backups), cleanup, "failed to load backup infos");
@@ -98,10 +98,10 @@ MCTF_TEST(test_pgmoneta_delete_retained_backup)
    }
 
    // Expunge the backup (remove the retained flag)
-   MCTF_ASSERT(!pgmoneta_tsclient_expunge("primary", "oldest"), cleanup, "failed to expunge backup");
+   MCTF_ASSERT(!pgmoneta_tsclient_expunge("primary", "oldest", false, 0), cleanup, "failed to expunge backup");
 
    // Delete will work now without force
-   MCTF_ASSERT(!pgmoneta_tsclient_delete("primary", "oldest"), cleanup, "failed to delete after expunge");
+   MCTF_ASSERT(!pgmoneta_tsclient_delete("primary", "oldest", 0), cleanup, "failed to delete after expunge");
 
    // Verify the count is 0
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_backups, &backups), cleanup, "failed to load backup infos after delete");
@@ -142,10 +142,10 @@ MCTF_TEST(test_pgmoneta_delete_force_retained_backup)
    MCTF_ASSERT_PTR_NONNULL(d, cleanup, "server backup not valid");
 
    // Retain the backup
-   MCTF_ASSERT(!pgmoneta_tsclient_retain("primary", "oldest"), cleanup, "failed to retain backup");
+   MCTF_ASSERT(!pgmoneta_tsclient_retain("primary", "oldest", false, 0), cleanup, "failed to retain backup");
 
    // Delete without force should fail
-   MCTF_ASSERT(pgmoneta_tsclient_delete("primary", "oldest") != 0, cleanup, "delete should fail for retained backup");
+   MCTF_ASSERT(pgmoneta_tsclient_delete("primary", "oldest", 0) != 0, cleanup, "delete should fail for retained backup");
 
    // Verify the count is still 1
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_backups, &backups), cleanup, "failed to load backup infos");
@@ -164,7 +164,7 @@ MCTF_TEST(test_pgmoneta_delete_force_retained_backup)
    }
 
    // Delete will work now with the force flag
-   MCTF_ASSERT(!pgmoneta_tsclient_force_delete("primary", "oldest"), cleanup, "failed to force delete retained backup");
+   MCTF_ASSERT(!pgmoneta_tsclient_force_delete("primary", "oldest", 0), cleanup, "failed to force delete retained backup");
 
    // Verify the count is 0
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_backups, &backups), cleanup, "failed to load backup infos after force delete");
@@ -209,7 +209,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_last)
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_bck_before, &bcks_before), cleanup, "failed to load backup infos");
    MCTF_ASSERT_INT_EQ(num_bck_before, 3, cleanup, "expected 3 backups before deletion");
 
-   if (pgmoneta_tsclient_delete("primary", "newest"))
+   if (pgmoneta_tsclient_delete("primary", "newest", 0))
    {
       // Cleanup resources before skipping
 
@@ -283,7 +283,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_middle)
    MCTF_ASSERT_PTR_NONNULL(bcks_before, cleanup, "backups array is null");
    MCTF_ASSERT_PTR_NONNULL(bcks_before[1], cleanup, "backup[1] is null");
 
-   if (pgmoneta_tsclient_delete("primary", bcks_before[1]->label))
+   if (pgmoneta_tsclient_delete("primary", bcks_before[1]->label, 0))
    {
       // Cleanup resources before skipping
 
@@ -364,7 +364,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_root)
    MCTF_ASSERT_PTR_NONNULL(bcks_before, cleanup, "backups array is null");
    MCTF_ASSERT_PTR_NONNULL(bcks_before[1], cleanup, "backup[1] is null");
 
-   if (pgmoneta_tsclient_delete("primary", "oldest"))
+   if (pgmoneta_tsclient_delete("primary", "oldest", 0))
    {
       // Cleanup resources before skipping
 

--- a/test/testcases/test_restore.c
+++ b/test/testcases/test_restore.c
@@ -44,7 +44,7 @@ MCTF_TEST(test_pgmoneta_restore_full)
       MCTF_SKIP();
    }
 
-   if (pgmoneta_tsclient_restore("primary", "newest", "current"))
+   if (pgmoneta_tsclient_restore("primary", "newest", "current", 0))
    {
       pgmoneta_test_basedir_cleanup();
       MCTF_SKIP();
@@ -65,7 +65,7 @@ MCTF_TEST(test_pgmoneta_restore_incremental_chain)
       MCTF_SKIP();
    }
 
-   if (pgmoneta_tsclient_restore("primary", "newest", "current"))
+   if (pgmoneta_tsclient_restore("primary", "newest", "current", 0))
    {
       pgmoneta_test_basedir_cleanup();
       MCTF_SKIP();


### PR DESCRIPTION
## Description 
This PR adds a complete test suite for all pgmoneta CLI commands, ensuring each command returns the correct response code as defined in  `src/include/management.h`.

### Fixes: [#658]

## Solution
- Enhanced tsclient API - Added `expected_error` parameter to all tsclient functions, enabling negative test cases that validate specific error codes from the server response.
- New test file  `test_cli.c` - Comprehensive test suite covering 21 CLI commands with both positive and negative test cases.
- Error code validation - Tests verify the exact `MANAGEMENT_ERROR_*` codes from  `management.h.

Notes
- `shutdown` command is intentionally not tested as it would terminate the server during testing
-  verify positive test is skipped due to a null pointer bug in `wf_verify.c`