### PR TITLE
[#851] CI: Tests for PostgreSQL 14/15 fails

### DIFF
--- a/src/libpgmoneta/walfile.c
+++ b/src/libpgmoneta/walfile.c
@@ -692,12 +692,6 @@ pgmoneta_summarize_walfiles(char* dir_path, uint64_t start_lsn, uint64_t end_lsn
          snprintf(file_path, MAX_PATH, "%s%s", dir_path, file);
       }
 
-      if (!pgmoneta_is_file(file_path))
-      {
-         pgmoneta_log_error("WAL file at %s does not exist", file_path);
-         goto error;
-      }
-
       if (pgmoneta_summarize_walfile(file_path, start_lsn, end_lsn, brt))
       {
          goto error;

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -1747,12 +1747,6 @@ copy_wal_from_archive(char* start_wal_file, char* wal_dir, char* backup_data)
          src_file = pgmoneta_append(src_file, wal_dir);
          src_file = pgmoneta_append(src_file, file_name);
 
-         if (!pgmoneta_is_file(src_file))
-         {
-            pgmoneta_log_warn("WAL segment %s does not exist in source", file_name);
-            goto error;
-         }
-
          // copy and extract
          if (pgmoneta_copy_and_extract_file(src_file, &dst_file))
          {


### PR DESCRIPTION
Fix: #851 

`pgmoneta_is_file` checks if a wal file is present in the directory or not but the issue is `pgmoneta_get_wal_files` captures both full and partial segments, and t a partial segment may convert to a full segment by the time we check the file existence.

Not to worry this has already been taken care of in the file copy logic, refer [this](https://github.com/pgmoneta/pgmoneta/pull/788/files#diff-28572a36916d0a56312f651385efdd568b28dbdf872f3a6ee940f1a9599c7818R1972)