### PR TITLE
[#858] Fixed walinfo build error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Sara Nabih <nabihsara8@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
+Somye Mahajan <mahajan.somye@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -45,6 +45,7 @@ Sara Nabih <nabihsara8@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Amr Shams <amr.shams2015.a@gmail.com>
+Somye Mahajan <mahajan.somye@gmail.com>
 ```
 
 ## Committers

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -45,6 +45,7 @@
 #include <err.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Resolves #858 

### Changes
Added `#include <libgen.h>` header to `walinfo.c` for resolving the `basename()` function.