### PR TITLE
[#860] fix:Prevent null pointer crash in verify command when files parameter is omitted

### DIFF
--- a/src/libpgmoneta/verify.c
+++ b/src/libpgmoneta/verify.c
@@ -100,6 +100,11 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
       goto error;
    }
 
+   if (files == NULL || strlen(files) == 0)
+   {
+      files = MANAGEMENT_ARGUMENT_FAILED;
+   }
+
    if (pgmoneta_art_insert(nodes, USER_FILES, (uintptr_t)files, ValueString))
    {
       goto error;
@@ -195,7 +200,7 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
       pgmoneta_json_append(failed, (uintptr_t)j, ValueJSON);
    }
 
-   if (!strcasecmp(files, "all"))
+   if (files != NULL && !strcasecmp(files, "all"))
    {
       pgmoneta_json_create(&all);
 

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -121,7 +121,8 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
       goto error;
    }
 
-   if (!strcasecmp((char*)pgmoneta_art_search(nodes, USER_FILES), NODE_ALL))
+   char* user_files = (char*)pgmoneta_art_search(nodes, USER_FILES);
+   if (user_files != NULL && !strcasecmp(user_files, NODE_ALL))
    {
       if (pgmoneta_deque_create(true, &all_deque))
       {


### PR DESCRIPTION
## Fixes -  [#860]

Add null checks before calling strcasecmp() in verify workflow:
- `wf_verify.c` - Check `USER_FILES` art node before comparison
- `verify.c` - Check files parameter before comparison