### PR TITLE
fix(docker)[#741]: restore alpine build and improve run instructions

### DIFF
--- a/contrib/docker/Dockerfile.alpine
+++ b/contrib/docker/Dockerfile.alpine
@@ -27,7 +27,8 @@
 
 FROM alpine:latest AS builder
 
-RUN apk add --no-cache \
+RUN apk update && \
+    apk add --no-cache \
     git \
     gcc \
     cmake \
@@ -54,7 +55,8 @@ RUN apk add --no-cache \
     libarchive \
     libarchive-dev \
     libssh \
-    libssh-dev 
+    libssh-dev \
+    ncurses-dev
 
 WORKDIR /src
 
@@ -69,12 +71,10 @@ RUN cd build && \
 
 FROM alpine:latest
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk update && \
+RUN apk update && \
     apk add --no-cache \
-    postgresql17 \
-    postgresql17-client \
+    postgresql18 \
+    postgresql18-client \
     bash \
     ca-certificates \
     libev \
@@ -86,7 +86,8 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
     zstd \
     lz4-libs \
     libarchive \
-    libssh
+    libssh \
+    ncurses-libs
 
 RUN adduser -D -s /bin/sh pgmoneta
 

--- a/contrib/docker/Dockerfile.rocky10
+++ b/contrib/docker/Dockerfile.rocky10
@@ -25,9 +25,9 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM rockylinux:9 AS builder
+FROM rockylinux/rockylinux:10 AS builder
 
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm && \
     dnf -y upgrade && \
     dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
@@ -61,8 +61,8 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.
         libarchive-devel \
         libssh-devel \
         libasan \
-        libasan-static \
-        yaml-cpp-devel && \
+        yaml-cpp-devel \
+        ncurses-devel && \
     dnf clean all
 
 WORKDIR /src
@@ -76,16 +76,17 @@ RUN cd build && \
     make && \
     make install
 
-FROM rockylinux:9
+FROM rockylinux/rockylinux:10 
 
-RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm && \
+RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-10-x86_64/pgdg-redhat-repo-latest.noarch.rpm && \
     dnf -y update && \
-    dnf install -y postgresql17-server \
-        postgresql17-contrib \
+    dnf install -y postgresql18-server \
+        postgresql18-contrib \
         libpq5 \
         libev \
         libatomic \
-        libssh && \
+        libssh \
+        ncurses-libs && \
     dnf clean all
 
 RUN useradd --create-home --shell /bin/bash pgmoneta

--- a/doc/manual/en/13-docker.md
+++ b/doc/manual/en/13-docker.md
@@ -70,7 +70,7 @@ Once the image is built, run the container using:
 Using Docker
 
 ```sh
-docker run -d --name pgmoneta --network host pgmoneta:latest
+docker run -d --name pgmoneta -p 5001:5001 pgmoneta:latest
 ```
 
 Using Podman


### PR DESCRIPTION
	- pg18 is now supported
   	- Add support for Rocky Linux 10 via new Dockerfile.
	- Update documentation to recommend explicit port mapping (`-p 5001:5001`)