### PR TITLE
[#876] test: enhance MCTF_SKIP() to show file, line, and message

### DIFF
--- a/test/testcases/test_backup.c
+++ b/test/testcases/test_backup.c
@@ -45,9 +45,8 @@ MCTF_TEST(test_pgmoneta_backup_full)
 
    if (pgmoneta_test_add_backup())
    {
-      fprintf(stderr, "test_pgmoneta_backup_full: backup failed during setup\n");
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
 cleanup:
@@ -65,9 +64,8 @@ MCTF_TEST(test_pgmoneta_backup_incremental_basic)
 
    if (pgmoneta_test_add_backup_chain())
    {
-      fprintf(stderr, "test_pgmoneta_backup_incremental_basic: backup chain failed during setup\n");
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup chain failed during setup");
    }
 
    d = pgmoneta_get_server_backup(PRIMARY_SERVER);

--- a/test/testcases/test_cli.c
+++ b/test/testcases/test_cli.c
@@ -157,7 +157,7 @@ MCTF_TEST(test_cli_list_backup)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(pgmoneta_tsclient_list_backup("primary", NULL, NULL, 0) == 0, cleanup, "List backup primary failed");
@@ -174,7 +174,7 @@ MCTF_TEST(test_cli_info)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(pgmoneta_tsclient_info("primary", "newest", 0) == 0, cleanup, "Info newest failed");
@@ -192,7 +192,7 @@ MCTF_TEST(test_cli_verify)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    snprintf(path, sizeof(path), "%s/verify_test", TEST_BASE_DIR);
@@ -215,7 +215,7 @@ MCTF_TEST(test_cli_archive)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    snprintf(path, sizeof(path), "%s/archive_test", TEST_BASE_DIR);
@@ -237,7 +237,7 @@ MCTF_TEST(test_cli_restore)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(pgmoneta_tsclient_restore("primary", "newest", "current", 0) == 0, cleanup, "Restore newest failed");
@@ -256,7 +256,7 @@ MCTF_TEST(test_cli_retain)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(pgmoneta_tsclient_retain("primary", "newest", false, 0) == 0, cleanup, "Retain newest failed");
@@ -273,7 +273,7 @@ MCTF_TEST(test_cli_expunge)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(pgmoneta_tsclient_expunge("primary", "newest", false, 0) == 0, cleanup, "Expunge newest failed");
@@ -290,7 +290,7 @@ MCTF_TEST(test_cli_annotate)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(pgmoneta_tsclient_annotate("primary", "newest", "add", "testkey", "testcomment", 0) == 0, cleanup,
@@ -308,7 +308,7 @@ MCTF_TEST(test_cli_delete)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(pgmoneta_tsclient_delete("primary", "oldest", 0) == 0, cleanup, "Delete oldest failed");

--- a/test/testcases/test_delete.c
+++ b/test/testcases/test_delete.c
@@ -44,13 +44,13 @@ MCTF_TEST(test_pgmoneta_delete_full)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    if (pgmoneta_tsclient_delete("primary", "oldest", 0))
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
 cleanup:
@@ -69,7 +69,7 @@ MCTF_TEST(test_pgmoneta_delete_retained_backup)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    d = pgmoneta_get_server_backup(PRIMARY_SERVER);
@@ -135,7 +135,7 @@ MCTF_TEST(test_pgmoneta_delete_force_retained_backup)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    d = pgmoneta_get_server_backup(PRIMARY_SERVER);
@@ -200,7 +200,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_last)
    if (pgmoneta_test_add_backup_chain())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    d = pgmoneta_get_server_backup(PRIMARY_SERVER);
@@ -226,7 +226,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_last)
          bcks_before = NULL;
       }
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_bck_after, &bcks_after), cleanup, "failed to load backup infos after deletion");
@@ -272,7 +272,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_middle)
    if (pgmoneta_test_add_backup_chain())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    d = pgmoneta_get_server_backup(PRIMARY_SERVER);
@@ -300,7 +300,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_middle)
          bcks_before = NULL;
       }
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_bck_after, &bcks_after), cleanup, "failed to load backup infos after deletion");
@@ -353,7 +353,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_root)
    if (pgmoneta_test_add_backup_chain())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    d = pgmoneta_get_server_backup(PRIMARY_SERVER);
@@ -381,7 +381,7 @@ MCTF_TEST(test_pgmoneta_delete_chain_root)
          bcks_before = NULL;
       }
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    MCTF_ASSERT(!pgmoneta_load_infos(d, &num_bck_after, &bcks_after), cleanup, "failed to load backup infos after deletion");

--- a/test/testcases/test_restore.c
+++ b/test/testcases/test_restore.c
@@ -41,13 +41,13 @@ MCTF_TEST(test_pgmoneta_restore_full)
    if (pgmoneta_test_add_backup())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup failed during setup");
    }
 
    if (pgmoneta_tsclient_restore("primary", "newest", "current", 0))
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("restore failed");
    }
 
 cleanup:
@@ -62,13 +62,13 @@ MCTF_TEST(test_pgmoneta_restore_incremental_chain)
    if (pgmoneta_test_add_backup_chain())
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("backup chain failed during setup");
    }
 
    if (pgmoneta_tsclient_restore("primary", "newest", "current", 0))
    {
       pgmoneta_test_basedir_cleanup();
-      MCTF_SKIP();
+      MCTF_SKIP("restore failed");
    }
 
 cleanup:

--- a/test/testcases/test_server_api.c
+++ b/test/testcases/test_server_api.c
@@ -53,7 +53,7 @@ MCTF_TEST(test_server_api_info)
    if (setup_server_connection())
    {
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to setup server connection");
    }
 
    config = (struct main_configuration*)shmem;
@@ -86,13 +86,13 @@ MCTF_TEST(test_server_api_checkpoint)
    if (setup_server_connection())
    {
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to setup server connection");
    }
 
    if (pgmoneta_server_checkpoint(PRIMARY_SERVER, srv_ssl, srv_socket, &chkt, &tli))
    {
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to get checkpoint");
    }
 
 cleanup:
@@ -109,7 +109,7 @@ MCTF_TEST(test_server_api_read_file)
    if (setup_server_connection())
    {
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to setup server connection");
    }
 
    if (pgmoneta_server_read_binary_file(PRIMARY_SERVER, srv_ssl, file_path, 0, 100, srv_socket, &data, &data_length))
@@ -131,7 +131,7 @@ MCTF_TEST(test_server_api_read_file_metadata)
    if (setup_server_connection())
    {
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to setup server connection");
    }
 
    if (pgmoneta_server_file_stat(PRIMARY_SERVER, srv_ssl, srv_socket, file_path, &stat))
@@ -154,20 +154,20 @@ MCTF_TEST(test_server_api_backup)
    if (setup_server_connection())
    {
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to setup server connection");
    }
 
    if (pgmoneta_server_start_backup(PRIMARY_SERVER, srv_ssl, srv_socket, "test_backup", &start_lsn))
    {
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to start backup");
    }
 
    if (pgmoneta_server_stop_backup(PRIMARY_SERVER, srv_ssl, srv_socket, NULL, &stop_lsn, &lf))
    {
       free(start_lsn);
       teardown_server_connection();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to stop backup");
    }
 
 cleanup:

--- a/test/testcases/test_wal_summary.c
+++ b/test/testcases/test_wal_summary.c
@@ -104,7 +104,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
    {
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to authenticate with primary server");
    }
 
    // establish a connection to custom myuser
@@ -113,7 +113,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
    {
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to authenticate with custom user");
    }
 
    // Get server info - this returns void, so we check validity after
@@ -123,7 +123,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
    {
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("server info check failed");
    }
 
    // get the starting lsn for summary
@@ -132,7 +132,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
    {
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to get starting LSN");
    }
 
    // Create a table
@@ -142,7 +142,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       pgmoneta_test_cleanup_query_response(&qr);
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to create table");
    }
    pgmoneta_test_cleanup_query_response(&qr);
 
@@ -153,7 +153,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       pgmoneta_test_cleanup_query_response(&qr);
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to insert data");
    }
    pgmoneta_test_cleanup_query_response(&qr);
 
@@ -163,7 +163,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
    {
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to get ending LSN");
    }
 
    // Switch the wal segment so that records won't appear in partial segments
@@ -173,7 +173,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       pgmoneta_test_cleanup_query_response(&qr);
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to switch WAL");
    }
    pgmoneta_test_cleanup_query_response(&qr);
 
@@ -183,7 +183,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
    {
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to get checkpoint LSN");
    }
 
    sleep(10);
@@ -198,7 +198,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       summary_dir = NULL;
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to create summary directory");
    }
 
    wal_dir = pgmoneta_get_server_wal(PRIMARY_SERVER);
@@ -213,7 +213,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       wal_dir = NULL;
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to summarize WAL");
    }
 
    // Verify BRT was created and contains data
@@ -237,7 +237,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       wal_dir = NULL;
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to save WAL summary");
    }
 
    // Verify the summary file was actually created on disk
@@ -275,7 +275,7 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       wal_dir = NULL;
       cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
       pgmoneta_test_teardown();
-      MCTF_SKIP();
+      MCTF_SKIP("failed to read BRT from summary file");
    }
 
    // Verify the read BRT is valid and matches what we wrote


### PR DESCRIPTION
Skip follows the same pattern as fail, in giving info

`MCTF_SKIP()` displays file, line number, and optional message.

fixes  :  #876 

Flow output format:
 ` test_name (00:00:00,000) [SKIP] (file.c:line)`

Summary output format:
`  - test_name (file.c:line) [SKIP] - message`