### PR TITLE
[#881] Add persistent logging support for test runs

### DIFF
--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -3681,8 +3681,8 @@ pgmoneta_conf_set(SSL* ssl, int client_fd, uint8_t compression, uint8_t encrypti
 
    pgmoneta_json_destroy(payload);
    pgmoneta_disconnect(client_fd);
-   pgmoneta_stop_logging();
    pgmoneta_log_info("Configuration set operation completed successfully");
+   pgmoneta_stop_logging();
    return 0;
 
 error:

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -150,6 +150,22 @@ void
 mctf_print_summary(void);
 
 /**
+ * Open a log file for MCTF output
+ * All subsequent test runner output will be duplicated to this file.
+ *
+ * @param path Filesystem path of the log file
+ * @return 0 on success, non-zero on failure
+ */
+int
+mctf_open_log(const char* path);
+
+/**
+ * Close the MCTF log file if it is open
+ */
+void
+mctf_close_log(void);
+
+/**
  * Get test results
  * @param count [out] Number of results
  * @return Array of test results


### PR DESCRIPTION

- Closes #881


Adds persistent logging for test runs: all test execution output (progress, results, summaries) is mirrored to a dedicated log file in addition to standard console output

Log file location: `/tmp/pgmoneta-test/log/pgmoneta-test.log`

