### PR TITLE
[#883] Replace WAL parser assertion with validation for compressed/encrypted file detection

### DIFF
--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -395,6 +395,15 @@ extern struct server* server_config;
 /* Function definitions */
 
 /**
+ * Validate and extract base WAL filename from path
+ * @param path The full path to the WAL file
+ * @param base_filename Output parameter for the base WAL filename
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_validate_wal_filename(char* path, char** base_filename);
+
+/**
  * Parses a WAL file and populates server information.
  *
  * @param path The file path of the WAL file.


### PR DESCRIPTION
Replace assertion with validation in WAL parser
- Replace assert() with proper magic number validation
- Add file extension checks for compressed/encrypted files (.gz, .zst, .tar, .aes, etc.)
- Detect file type from magic bytes (gzip, zstd, tar)
- Provide helpful error messages with decompression commands
- Use cached pg_version instead of recalculating

Fixes [#883]