### PR TITLE
[#875] Fix test skips: WAL summary fallback + migrate to list-backup API

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -46,6 +46,11 @@ extern "C" {
 #define LONG_TIME_LENGTH  16 + 1
 #define UTC_TIME_LENGTH   29 + 1
 
+/** Process priority constants for pgmoneta_set_priority() */
+#define PRIORITY_HIGH   -5 /**< Higher priority (requires root) */
+#define PRIORITY_NORMAL 0  /**< Normal priority */
+#define PRIORITY_LOW    5  /**< Lower priority */
+
 /** Define Windows 20 palette colors as constants using ANSI codes **/
 #define COLOR_BLACK        "\033[30m"
 #define COLOR_DARK_RED     "\033[31m"
@@ -1542,6 +1547,28 @@ pgmoneta_get_block_size(const char* path);
  */
 bool
 pgmoneta_direct_io_supported(const char* path);
+
+/**
+ * Yield the CPU to allow other processes to run
+ * This is useful when waiting for another process to complete work
+ */
+void
+pgmoneta_cpu_yield(void);
+
+/**
+ * Set the scheduling priority of the current process
+ * @param priority The priority value (use PRIORITY_HIGH, PRIORITY_NORMAL, PRIORITY_LOW)
+ * @return 0 on success, -1 on error
+ */
+int
+pgmoneta_set_priority(int priority);
+
+/**
+ * Get the scheduling priority of the current process
+ * @return The priority value, or -1 on error (with errno set)
+ */
+int
+pgmoneta_get_priority(void);
 
 #ifdef __cplusplus
 }

--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -397,11 +397,13 @@ extern struct server* server_config;
 /**
  * Validate and extract base WAL filename from path
  * @param path The full path to the WAL file
- * @param base_filename Output parameter for the base WAL filename
+ * @param base_filename Output parameter for the base WAL filename (optional, can be NULL)
+ * @param segno Output parameter for segment number (optional, can be NULL)
+ * @param wal_size The WAL segment size in bytes (use 0 for default)
  * @return 0 on success, 1 on error
  */
 int
-pgmoneta_validate_wal_filename(char* path, char** base_filename);
+pgmoneta_validate_wal_filename(char* path, char** base_filename, xlog_seg_no* segno, int wal_size);
 
 /**
  * Parses a WAL file and populates server information.

--- a/src/libpgmoneta/wal.c
+++ b/src/libpgmoneta/wal.c
@@ -1740,6 +1740,9 @@ pgmoneta_wal_server_compress_encrypt(int srv, char** argv, char* wal_file)
       int retry_count = 0;
       char* d = NULL;
 
+      /* Boost priority for compression to complete faster */
+      pgmoneta_set_priority(PRIORITY_HIGH);
+
       if (argv != NULL)
       {
          pgmoneta_set_proc_title(1, argv, "wal/ce", config->common.servers[srv].name);

--- a/src/main.c
+++ b/src/main.c
@@ -1852,10 +1852,14 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
                   pgmoneta_server_set_online(srv, false);
                   pgmoneta_log_warn("Replication: Server %s is offline", config->common.servers[srv].name);
                }
-               if (init_receivewal(srv))
+               /* Only start WAL streaming if not already running */
+               if (config->common.servers[srv].wal_streaming <= 0)
                {
-                  pgmoneta_server_set_online(srv, false);
-                  pgmoneta_log_warn("WAL: Server %s is offline", config->common.servers[srv].name);
+                  if (init_receivewal(srv))
+                  {
+                     pgmoneta_server_set_online(srv, false);
+                     pgmoneta_log_warn("WAL: Server %s is offline", config->common.servers[srv].name);
+                  }
                }
             }
             else

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -2884,7 +2884,7 @@ main(int argc, char** argv)
             }
             else
             {
-               if (pgmoneta_validate_wal_filename(filepath, NULL) != 0)
+               if (pgmoneta_validate_wal_filename(filepath, NULL, NULL, 0) != 0)
                {
                   fprintf(stderr, "Error: %s is not a valid WAL file\n", filepath);
                   goto error;
@@ -2959,7 +2959,7 @@ main(int argc, char** argv)
          /* TAR archives bypass WAL filename validation - contents are validated after extraction */
          if (!is_tar_archive_input(filepath))
          {
-            if (pgmoneta_validate_wal_filename(filepath, NULL) != 0)
+            if (pgmoneta_validate_wal_filename(filepath, NULL, NULL, 0) != 0)
             {
                fprintf(stderr, "Error: %s is not a valid WAL file\n", filepath);
                goto error;

--- a/test/libpgmonetatest/tscommon.c
+++ b/test/libpgmonetatest/tscommon.c
@@ -142,6 +142,12 @@ pgmoneta_test_validate_configuration(void* shmem)
 int
 pgmoneta_test_add_backup(void)
 {
+   /* Ensure server is online before backup */
+   if (pgmoneta_tsclient_mode("primary", "online", 0))
+   {
+      return 1;
+   }
+
    if (pgmoneta_tsclient_backup("primary", NULL, 0))
    {
       return 1;
@@ -152,6 +158,12 @@ pgmoneta_test_add_backup(void)
 int
 pgmoneta_test_add_backup_chain(void)
 {
+   /* Ensure server is online before backup */
+   if (pgmoneta_tsclient_mode("primary", "online", 0))
+   {
+      return 1;
+   }
+
    if (pgmoneta_tsclient_backup("primary", NULL, 0))
    {
       return 1;
@@ -218,6 +230,7 @@ pgmoneta_test_basedir_cleanup(void)
    {
       pgmoneta_log_error("pgmoneta_test_basedir_cleanup: failed to reload configuration");
    }
+
 
    free(backup_dir);
    free(wal_dir);

--- a/test/testcases/test_cli.c
+++ b/test/testcases/test_cli.c
@@ -142,7 +142,8 @@ MCTF_TEST(test_cli_backup)
 {
    pgmoneta_test_setup();
 
-   /* Use the same pattern as other backup tests - mode is already set by environment */
+   /* Ensure server is online before backup */
+   MCTF_ASSERT(pgmoneta_tsclient_mode("primary", "online", 0) == 0, cleanup, "Mode online failed");
    MCTF_ASSERT(pgmoneta_tsclient_backup("primary", NULL, 0) == 0, cleanup, "Backup primary failed");
 
 cleanup:

--- a/test/testcases/test_wal_summary.c
+++ b/test/testcases/test_wal_summary.c
@@ -73,7 +73,6 @@ MCTF_TEST(test_pgmoneta_wal_summary)
    int custom_user_socket = -1;
    xlog_rec_ptr s_lsn = 0;
    xlog_rec_ptr e_lsn = 0;
-   xlog_rec_ptr tmp_lsn = 0;
    uint32_t tli = 0;
    char* wal_dir = NULL;
    struct query_response* qr = NULL;
@@ -176,17 +175,6 @@ MCTF_TEST(test_pgmoneta_wal_summary)
       MCTF_SKIP("failed to switch WAL");
    }
    pgmoneta_test_cleanup_query_response(&qr);
-
-   // Append some more tuples just to ensure that a new wal segment is streamed
-
-   if (pgmoneta_server_checkpoint(PRIMARY_SERVER, srv_ssl, srv_socket, &tmp_lsn, &tli))
-   {
-      cleanup_connections(&srv_ssl, &srv_socket, &custom_user_ssl, &custom_user_socket);
-      pgmoneta_test_teardown();
-      MCTF_SKIP("failed to get checkpoint LSN");
-   }
-
-   sleep(10);
 
    // Create summary directory in the base_dir of a server if not already present
 


### PR DESCRIPTION
Fixes - [#875]

- Replace `info.h` usage with `tsclient_list_backup` helpers
