### PR TITLE
[#890] CI: Add coverage summary display to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,15 @@ jobs:
           fi
         working-directory: /home/runner/work/pgmoneta/pgmoneta/
 
+      - name: Report coverage summary
+        if: matrix.compiler == 'clang' && matrix.build_type == 'Debug'
+        run: |
+          echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/pgmoneta-test/coverage/coverage-report-*.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
       - name: Upload All Coverage Reports as Artifact
         if: always()
         uses: actions/upload-artifact@v5

--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Somye Mahajan <mahajan.somye@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Seongjun Shin <shinsj4653@gmail.com>
 Bishoy Wadea Fathy <bishoyw.fathy@gmail.com>
+Mazen Kamal <mazenkamal212@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -49,6 +49,7 @@ Somye Mahajan <mahajan.somye@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Seongjun Shin <shinseongjun@gmail.com>
 Bishoy Wadea Fathy <bishoyw.fathy@gmail.com>
+Mazen Kamal <mazenkamal212@gmail.com>
 ```
 
 ## Committers


### PR DESCRIPTION
Closes #890 

Add a step to display code coverage summary in CI workflow.

This change prints coverage information into the GitHub Actions job summary so users can view results directly from CI without
downloading artifacts.

Existing artifact uploads are kept unchanged.
