### PR TITLE
[#897] Fix Prometheus metrics to export integers instead of boolean s…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
+Seongjun Shin <shinsj4653@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -47,6 +47,7 @@ Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Amr Shams <amr.shams2015.a@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
+Seongjun Shin <shinseongjun@gmail.com>
 ```
 
 ## Committers

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -4253,7 +4253,7 @@ size_information(SSL* client_ssl, int client_fd, int* number_of_backups, struct 
                data = pgmoneta_append(data, backups[i][j]->label);
                data = pgmoneta_append(data, "\"} ");
 
-               data = pgmoneta_append_bool(data, backups[i][j]->keep);
+               data = pgmoneta_append_int(data, backups[i][j]->keep ? 1 : 0);
 
                data = pgmoneta_append(data, "\n");
             }
@@ -4509,7 +4509,7 @@ size_information(SSL* client_ssl, int client_fd, int* number_of_backups, struct 
       data = pgmoneta_append(data, config->common.servers[i].current_wal_filename);
       data = pgmoneta_append(data, "\"} ");
 
-      data = pgmoneta_append_bool(data, config->common.servers[i].wal_streaming > 0);
+      data = pgmoneta_append_int(data, config->common.servers[i].wal_streaming > 0 ? 1 : 0);
 
       data = pgmoneta_append(data, "\n");
    }
@@ -4537,7 +4537,7 @@ size_information(SSL* client_ssl, int client_fd, int* number_of_backups, struct 
       }
       data = pgmoneta_append(data, "\"} ");
 
-      data = pgmoneta_append_bool(data, config->common.servers[i].wal_streaming > 0);
+      data = pgmoneta_append_int(data, config->common.servers[i].wal_streaming > 0 ? 1 : 0);
 
       data = pgmoneta_append(data, "\n");
    }


### PR DESCRIPTION
**Description**
Fixes #897

This PR ensures that `pgmoneta` exports metrics compliant with the Prometheus exposition format.
Previously, boolean metrics (`pgmoneta_backup_retain`, `pgmoneta_current_wal_file`, `pgmoneta_current_wal_lsn`) were exported as strings (`"true"`/`"false"`), causing parsing errors (`invalid syntax`) in Prometheus.
This change converts these values to integers (`1` for true, `0` for false).

**Changes**
- Modified `src/libpgmoneta/prometheus.c`:
  - Replaced `pgmoneta_append_bool` with `pgmoneta_append_int` using a ternary operator (`val ? 1 : 0`).
- Updated `AUTHORS` and `acknowledgement` files.

**Testing**
- Verified build passed on macOS (Apple Silicon).
- Manually verified the metrics output using `curl`.

**Verification Output**
```text
(base) shinseongjun@sinseongjun-ui-noteubug build % curl [http://127.0.0.1:5001/metrics](http://127.0.0.1:5001/metrics) | grep pgmoneta_backup_retain
#HELP pgmoneta_backup_retain Retain backup for a server
#TYPE pgmoneta_backup_retain gauge
pgmoneta_backup_retain{name="main_db", label="20260201170633"} 0