### PR TITLE
doc: fix broken manual links in README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Amr Shams (NightBird) <amr.shams2015.a@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Seongjun Shin <shinsj4653@gmail.com>
+Bishoy Wadea Fathy <bishoyw.fathy@gmail.com>

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 ## Documentation
 
-* [User guide](https://raw.githubusercontent.com/pgmoneta/pgmoneta.github.io/main/doc/pgmoneta-user-guide.pdf)
-* [Developer guide](https://raw.githubusercontent.com/pgmoneta/pgmoneta.github.io/main/doc/pgmoneta-dev-guide.pdf)
+* [User guide](https://pgmoneta.github.io/documentation.html)
+* [Developer guide](./doc/DEVELOPERS.md)
 * [Getting Started](./doc/GETTING_STARTED.md)
 * [Configuration](./doc/CONFIGURATION.md)
 

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -48,6 +48,7 @@ Amr Shams <amr.shams2015.a@gmail.com>
 Somye Mahajan <mahajan.somye@gmail.com>
 Shashidhar B M <shashidhar.i.0119@gmail.com>
 Seongjun Shin <shinseongjun@gmail.com>
+Bishoy Wadea Fathy <bishoyw.fathy@gmail.com>
 ```
 
 ## Committers


### PR DESCRIPTION
This PR updates the documentation links in the README that were returning 404 errors.

- User Guide: Pointed to the documentation landing page to ensure stability and prevent future breaks if PDF filenames are changed.

- Developer Guide: Pointed to doc/DEVELOPERS.md as requested by the maintainer.

I have also added my name to AUTHORS and doc/manual/en/97-acknowledgement.md per the project's contribution guidelines.

Fixes #905