### PR TITLE
[#878] Log environment variables before running test suite

### DIFF
--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -150,6 +150,15 @@ void
 mctf_print_summary(void);
 
 /**
+ * Log all available environment variables
+ *
+ * This is typically called by the test runner before the test suite starts,
+ * so that the execution context is captured in the test output and log.
+ */
+void
+mctf_log_environment(void);
+
+/**
  * Open a log file for MCTF output
  * All subsequent test runner output will be duplicated to this file.
  *

--- a/test/libpgmonetatest/mctf.c
+++ b/test/libpgmonetatest/mctf.c
@@ -34,6 +34,9 @@
 #include <stdbool.h>
 #include <time.h>
 #include <sys/time.h>
+#include <unistd.h>
+
+extern char** environ;
 
 /* Global error number */
 int mctf_errno = 0;
@@ -94,6 +97,27 @@ mctf_log_errorf(const char* fmt, ...)
       mctf_vlogf(mctf_log_file, fmt, ap);
       va_end(ap);
    }
+}
+
+void
+mctf_log_environment(void)
+{
+   char** env;
+
+   mctf_logf("=== Test Environment Variables ===\n");
+
+   if (environ == NULL)
+   {
+      mctf_logf("  (no environment variables available)\n\n");
+      return;
+   }
+
+   for (env = environ; *env != NULL; env++)
+   {
+      mctf_logf("  %s\n", *env);
+   }
+
+   mctf_logf("=== End Environment Variables ===\n\n");
 }
 
 int

--- a/test/runner.c
+++ b/test/runner.c
@@ -283,6 +283,11 @@ main(int argc, char* argv[])
       }
    }
 
+   /* Log all environment variables before starting the test suite so that
+    * the execution context is captured alongside the test output.
+    */
+   mctf_log_environment();
+
    number_failed = mctf_run_tests(filter_type, filter);
    mctf_print_summary();
    mctf_cleanup();


### PR DESCRIPTION
PR adds logging of all environment variables at pgmoneta-test startup.

sample output: 
```
. . .
Starting pgmoneta server in daemon mode
Wait for pgmoneta to be ready
pgmoneta server started ... ok
Start running MCTF tests
=== Test Environment Variables ===
  SHELL=/bin/bash
  SESSION_MANAGER=local/shashidhar:@/tmp/.ICE-unix/2717,unix/shashidhar:/tmp/.ICE-unix/2717
     .  .  .
  _=/home/shashidhar/project/pgmoneta/build/test/pgmoneta-test
  __LLVM_PROFILE_RT_INIT_ONCE=__LLVM_PROFILE_RT_INIT_ONCE
=== End Environment Variables ===

=== Running MCTF Tests ===
Total tests to run: 115
. . . 
```
