### PR TITLE
[#884] feat:add TAR archive support and file type bitmask detection to walinfo

### DIFF
--- a/doc/man/pgmoneta-walinfo.1.rst
+++ b/doc/man/pgmoneta-walinfo.1.rst
@@ -2,21 +2,26 @@
 pgmoneta-walinfo
 =====================
 
-----------------------------------------------------------------------
 Command line utility to read and display Write-Ahead Log (WAL) files
-----------------------------------------------------------------------
 
 :Manual section: 1
 
 SYNOPSIS
 ========
 
-pgmoneta-walinfo <file>
+pgmoneta-walinfo <file|directory|tar_archive>
 
 DESCRIPTION
 ===========
 
-pgmoneta-walinfo is a command line utility to read and display information about PostgreSQL Write-Ahead Log (WAL) files. It provides details of the WAL file in either raw or JSON format.
+pgmoneta-walinfo is a command line utility to read and display information about PostgreSQL Write-Ahead Log (WAL) files. It supports individual WAL files, directories containing WAL files, TAR archives (optionally compressed with .gz, .lz4, .zstd, or .bz2), and encrypted files (.aes). It provides details of the WAL file in either raw or JSON format.
+
+In addition to standard WAL files, pgmoneta-walinfo also supports:
+
+- Encrypted WAL files (**.aes**)
+- Compressed WAL files: **.zstd**, **.gz**, **.lz4**, and **.bz2**
+- TAR archives containing WAL files (**.tar**)
+- Directories containing WAL files
 
 OPTIONS
 =======
@@ -75,8 +80,8 @@ OPTIONS
 ARGUMENTS
 =========
 
-<file>
-  The path to the WAL file to be analyzed.
+<file|directory|tar_archive>
+  The path to the WAL file, directory containing WAL files, or TAR archive to be analyzed.
 
 USAGE
 =====
@@ -88,6 +93,10 @@ To display information about a WAL file in raw format:
 To display information in JSON format:
 
     pgmoneta-walinfo -F json /path/to/walfile
+
+To analyze WAL files from a TAR archive:
+
+    pgmoneta-walinfo /path/to/wal_backup.tar.gz
 
 To display information and translate the OIDs to the corresponding object names:
 

--- a/doc/manual/en/17-wal-tools.md
+++ b/doc/manual/en/17-wal-tools.md
@@ -11,7 +11,12 @@ pgmoneta provides two powerful command-line utilities for working with PostgreSQ
 
 `pgmoneta-walinfo` is a command-line utility designed to read and display information about PostgreSQL Write-Ahead Log (WAL) files. The tool provides output in either raw or JSON format, making it easy to analyze WAL files for debugging, auditing, or general information purposes.
 
-In addition to standard WAL files, `pgmoneta-walinfo` also supports encrypted (**aes**) and compressed WAL files in the following formats: **zstd**, **gz**, **lz4**, and **bz2**.
+In addition to standard WAL files, `pgmoneta-walinfo` also supports:
+
+- Encrypted WAL files (**.aes**)
+- Compressed WAL files: **.zstd**, **.gz**, **.lz4**, and **.bz2**
+- TAR archives containing WAL files (**.tar**)
+- Directories containing WAL files
 
 ### Usage
 
@@ -20,7 +25,7 @@ pgmoneta-walinfo 0.20.0
   Command line utility to read and display Write-Ahead Log (WAL) files
 
 Usage:
-  pgmoneta-walinfo <file>
+  pgmoneta-walinfo <file|directory|tar_archive>
 
 Options:
   -c,  --config      Set the path to the pgmoneta_walinfo.conf file
@@ -103,6 +108,18 @@ pgmoneta-walinfo -S /path/to/walfile
 
 ```bash
 pgmoneta-walinfo -r Heap -l 10 /path/to/walfile
+```
+
+6. **Analyze a directory containing WAL files:**
+
+```bash
+pgmoneta-walinfo /path/to/wal_directory/
+```
+
+7. **Analyze WAL files from a TAR archive:**
+
+```bash
+pgmoneta-walinfo /path/to/wal_backup.tar.gz
 ```
 
 ### OID Translation

--- a/src/include/achv.h
+++ b/src/include/achv.h
@@ -53,15 +53,6 @@ void
 pgmoneta_archive(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_t encryption, struct json* request);
 
 /**
- * Extract from a tar file to a given directory
- * @param file_path The tar file path
- * @param destination The destination to extract to
- * @return 0 upon success, otherwise 1
- */
-int
-pgmoneta_extract_tar_file(char* file_path, char* destination);
-
-/**
  * Create a tar archive of the given directory
  * @param src The source directory
  * @param dst The destination tar file path


### PR DESCRIPTION
## Fixes- [#884]

## Description
This PR adds support for TAR archives (including compressed variants) to the walinfo tool and introduces a general file type detection function that returns a bitmask.

## Add TAR archive support and file type bitmask detection to walinfo

Add support for reading WAL files from TAR archives (including compressed variants) and introduces a general file type bitmask detection function.

- [`pgmoneta_get_file_type()`](cci:1://file:///home/shashank-singh/pgmoneta/src/libpgmoneta/utils.c:4427:0-4502:1) - Returns bitmask for WAL/compressed/encrypted/TAR/partial detection
- [`pgmoneta_is_tar_archive()`](cci:1://file:///home/shashank-singh/pgmoneta/src/libpgmoneta/utils.c:4406:0-4425:1) - TAR archive detection
- [`pgmoneta_extract_wal_from_tar()`](cci:1://file:///home/shashank-singh/pgmoneta/src/libpgmoneta/utils.c:4504:0-4635:1) - Extract WAL files from TAR archives

### Supported TAR formats

`.tar`, `.tar.gz`, `.tgz`, `.tar.zstd`, `.tar.lz4`, `.tar.bz2`

### Usage

```bash
pgmoneta-walinfo /path/to/wal_backup.tar.gz
