### PR TITLE
[#934] fix double free of log_file inside pgmoneta_stop_logging

### DIFF
--- a/src/libpgmoneta/logging.c
+++ b/src/libpgmoneta/logging.c
@@ -129,7 +129,9 @@ pgmoneta_stop_logging(void)
    {
       if (log_file != NULL)
       {
-         return fclose(log_file);
+         int rc = fclose(log_file);
+         log_file = NULL;
+         return rc;
       }
       else
       {


### PR DESCRIPTION
fixes #934 