### PR TITLE
[#954] Cross-porting Optimization of salted password generation by reusing HMAC context from pgagroal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ Bishoy Wadea Fathy <bishoyw.fathy@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
+Zeyad Daowd <zeyaddaowd@yahoo.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -52,6 +52,7 @@ Bishoy Wadea Fathy <bishoyw.fathy@gmail.com>
 Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
+Zeyad Daowd <zeyaddaowd@yahoo.com>
 ```
 
 ## Committers

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -2246,12 +2246,8 @@ salted_password(char* password, char* salt, int salt_length, int iterations, uns
 
    for (int i = 2; i <= iterations; i++)
    {
-      if (HMAC_CTX_reset(ctx) != 1)
-      {
-         goto error;
-      }
-
-      if (HMAC_Init_ex(ctx, password, password_length, EVP_sha256(), NULL) != 1)
+      /* passing nulls cause function to reuse the same key / password in the context */
+      if (HMAC_Init_ex(ctx, NULL, 0, NULL, NULL) != 1)
       {
          goto error;
       }


### PR DESCRIPTION
This PR is a cross-port of the performance optimization merged in pgagroal # 738.
Link of the PR: https://github.com/pgagroal/pgagroal/pull/738
I have isolated pgmoneta's salting function in a separate file to replicate the testing and achieved the same ~5 speedup.
before:
<img width="880" height="102" alt="image" src="https://github.com/user-attachments/assets/a470bccb-cd71-4e78-bcbc-34d3171b7e90" />
after:
<img width="926" height="99" alt="image" src="https://github.com/user-attachments/assets/947b79c8-88f0-41d5-900d-632d316e9acb" />
closes #954
