### PR TITLE
[#946] Add support for PROGRESS in the BASE_BACKUP command

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -54,6 +54,7 @@ Commands:
   list-backup              List the backups for a server
   mode                     Switch the mode for a server
   ping                     Check if pgmoneta is alive
+  progress                 Get progress for a command
   restore                  Restore a backup from a server
   retain                   Retain a backup from a server
   shutdown                 Shutdown pgmoneta
@@ -291,6 +292,22 @@ Example
 
 ```sh
 pgmoneta-cli ping
+```
+
+## progress
+
+Get progress for a command.
+
+Command
+
+```sh
+pgmoneta-cli progress <server> backup
+```
+
+Example
+
+```sh
+pgmoneta-cli progress primary backup
 ```
 
 ## mode

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -76,6 +76,7 @@ See a [sample](./etc/pgmoneta.conf) configuration for running `pgmoneta` on `loc
 | libev | `auto` | String | No | Select the [libev](http://software.schmorp.de/pkg/libev.html) backend to use. Valid options: `auto`, `select`, `poll`, `epoll`, `iouring`, `devpoll` and `port` |
 | backup_max_rate | 0 | Int | No | The number of bytes of tokens added every one second to limit the backup rate|
 | network_max_rate | 0 | Int | No | The number of bytes of tokens added every one second to limit the netowrk backup rate|
+| progress | off | Bool | No | Enable backup progress tracking |
 | verification | 0 | String | No | The time between verification of a backup. Setting this parameter to 0 disables verification. Supports suffixes: 's' (seconds, default), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). |
 | keep_alive | on | Bool | No | Have `SO_KEEPALIVE` on sockets |
 | nodelay | on | Bool | No | Have `TCP_NODELAY` on sockets |
@@ -114,6 +115,7 @@ See a [sample](./etc/pgmoneta.conf) configuration for running `pgmoneta` on `loc
 | workers | -1 | Int | No | The number of workers that each process can use for its work. Use 0 to disable, -1 means use the global settting. Maximum is CPU count |
 | backup_max_rate | -1 | Int | No | The number of bytes of tokens added every one second to limit the backup rate. Use 0 to disable, -1 means use the global settting|
 | network_max_rate | -1 | Int | No | The number of bytes of tokens added every one second to limit the netowrk backup rate. Use 0 to disable, -1 means use the global settting|
+| progress | -1 | Int | No | Enable backup progress tracking. Use 1 to enable, 0 to disable, -1 means use the global setting |
 | tls_cert_file | | String | No | Certificate file for TLS. This file must be owned by either the user running pgmoneta or root. Can interpolate environment variables (e.g., `$HOME`) |
 | tls_key_file | | String | No | Private key file for TLS. This file must be owned by either the user running pgmoneta or root. Additionally permissions must be at least `0640` when owned by root or `0600` otherwise. Can interpolate environment variables (e.g., `$HOME`) |
 | tls_ca_file | | String | No | Certificate Authority (CA) file for TLS. This file must be owned by either the user running pgmoneta or root. Can interpolate environment variables (e.g., `$HOME`) |

--- a/doc/man/pgmoneta-cli.1.rst
+++ b/doc/man/pgmoneta-cli.1.rst
@@ -111,6 +111,9 @@ mode
 ping
   Check if pgmoneta is alive
 
+progress
+  Get progress for a command
+
 restore
   Restore a backup from a server
 

--- a/doc/man/pgmoneta.conf.5.rst
+++ b/doc/man/pgmoneta.conf.5.rst
@@ -205,6 +205,9 @@ backup_max_rate
 network_max_rate
   The number of bytes of tokens added every one second to limit the netowrk backup rate. Use 0 to disable. Default is 0
 
+progress
+  Enable backup progress tracking. Default is off
+
 tls
   Enable Transport Layer Security (TLS). Default is false
 
@@ -315,6 +318,9 @@ backup_max_rate
 
 network_max_rate
   The number of bytes of tokens added every one second to limit the netowrk backup rate. Use 0 to disable, -1 means use the global settting. Default is -1
+
+progress
+  Enable backup progress tracking. Use on to enable, off to disable, -1 means use the global setting. Default is -1
 
 verification
   The time between verification of a backup. If this value is specified without units,

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -163,6 +163,7 @@ Note, that if `host` starts with a `/` it represents a path and `pgmoneta` will 
 | :------- | :------ | :--- | :------- | :---------- |
 | backup_max_rate | 0 | Int | No | The number of bytes of tokens added every one second to limit the backup rate|
 | network_max_rate | 0 | Int | No | The number of bytes of tokens added every one second to limit the netowrk backup rate|
+| progress | off | Bool | No | Enable backup progress tracking |
 | blocking_timeout | 30 | String | No | The number of seconds the process will be blocking for a connection. If this value is specified without units, it is taken as seconds. Setting this parameter to 0 disables it. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
 | keep_alive | on | Bool | No | Have `SO_KEEPALIVE` on sockets |
 | nodelay | on | Bool | No | Have `TCP_NODELAY` on sockets |
@@ -239,6 +240,7 @@ have access to the `postgres` database in order to get the necessary configurati
 | :------- | :------ | :--- | :------- | :---------- |
 | backup_max_rate | -1 | Int | No | The number of bytes of tokens added every one second to limit the backup rate. Use 0 to disable, -1 means use the global settting|
 | network_max_rate | -1 | Int | No | The number of bytes of tokens added every one second to limit the netowrk backup rate. Use 0 to disable, -1 means use the global settting|
+| progress | -1 | Int | No | Enable backup progress tracking. Use 1 to enable, 0 to disable, -1 means use the global setting |
 
 **Extra**
 

--- a/doc/manual/en/05-cli.md
+++ b/doc/manual/en/05-cli.md
@@ -58,6 +58,7 @@ Commands:
   list-backup              List the backups for a server
   mode                     Switch the mode for a server
   ping                     Check if pgmoneta is alive
+  progress                 Get progress for a command
   restore                  Restore a backup from a server
   retain                   Retain a backup from a server
   shutdown                 Shutdown pgmoneta
@@ -298,6 +299,23 @@ Example
 ``` sh
 pgmoneta-cli ping
 ```
+
+## progress
+
+Get progress for a command.
+
+Command
+
+``` sh
+pgmoneta-cli progress <server> backup
+```
+
+Example
+
+``` sh
+pgmoneta-cli progress primary backup
+```
+
 ## mode
 
 [**pgmoneta**][pgmoneta] detects when a server is down. You can bring a server online or offline

--- a/src/cli.c
+++ b/src/cli.c
@@ -79,6 +79,7 @@
 #define COMMAND_LIST_BACKUP    "list-backup"
 #define COMMAND_MODE           "mode"
 #define COMMAND_PING           "ping"
+#define COMMAND_PROGRESS       "progress"
 #define COMMAND_RELOAD         "reload"
 #define COMMAND_RESET          "reset"
 #define COMMAND_RESTORE        "restore"
@@ -115,6 +116,7 @@ static void help_clear(void);
 static void help_info(void);
 static void help_annotate(void);
 static void help_mode(void);
+static void help_progress(void);
 static void display_helper(char* command);
 
 static int backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, char* incremental, int32_t output_format);
@@ -143,6 +145,7 @@ static int compress_data_server(SSL* ssl, int socket, char* path, uint8_t compre
 static int info(SSL* ssl, int socket, char* server, char* backup, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int annotate(SSL* ssl, int socket, char* server, char* backup, char* command, char* key, char* comment, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int mode(SSL* ssl, int socket, char* server, char* action, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int progress(SSL* ssl, int socket, char* server, char* command, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int conf_ls(SSL* ssl, int socket, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int conf_get(SSL* ssl, int socket, char* config_key, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int conf_set(SSL* ssl, int socket, char* config_key, char* config_value, uint8_t compression, uint8_t encryption, int32_t output_format);
@@ -228,6 +231,7 @@ usage(void)
    printf("  list-backup              List the backups for a server\n");
    printf("  mode                     Switch the mode for a server\n");
    printf("  ping                     Check if pgmoneta is alive\n");
+   printf("  progress                 Get progress for a command\n");
    printf("  restore                  Restore a backup from a server\n");
    printf("  retain                   Retain a backup from a server\n");
    printf("  shutdown                 Shutdown pgmoneta\n");
@@ -398,7 +402,13 @@ struct pgmoneta_command command_table[] = {
     .accepted_argument_count = {2},
     .action = MANAGEMENT_MODE,
     .deprecated = false,
-    .log_message = "<mode> [%s]"}};
+    .log_message = "<mode> [%s]"},
+   {.command = "progress",
+    .subcommand = "",
+    .accepted_argument_count = {2},
+    .action = MANAGEMENT_PROGRESS,
+    .deprecated = false,
+    .log_message = "<progress> [%s] [%s]"}};
 
 int
 main(int argc, char** argv)
@@ -1032,6 +1042,10 @@ execute:
    {
       exit_code = mode(s_ssl, socket, parsed.args[0], parsed.args[1], compression, encryption, output_format);
    }
+   else if (parsed.cmd->action == MANAGEMENT_PROGRESS)
+   {
+      exit_code = progress(s_ssl, socket, parsed.args[0], parsed.args[1], compression, encryption, output_format);
+   }
    else if (parsed.cmd->action == MANAGEMENT_CONF_LS)
    {
       exit_code = conf_ls(s_ssl, socket, compression, encryption, output_format);
@@ -1241,6 +1255,13 @@ help_mode(void)
 }
 
 static void
+help_progress(void)
+{
+   printf("Get progress for a command\n");
+   printf("  pgmoneta-cli progress <server> backup\n");
+}
+
+static void
 display_helper(char* command)
 {
    if (!strcmp(command, COMMAND_BACKUP))
@@ -1326,6 +1347,10 @@ display_helper(char* command)
    else if (!strcmp(command, COMMAND_MODE))
    {
       help_mode();
+   }
+   else if (!strcmp(command, COMMAND_PROGRESS))
+   {
+      help_progress();
    }
    else
    {
@@ -1936,6 +1961,26 @@ static int
 mode(SSL* ssl, int socket, char* server, char* action, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    if (pgmoneta_management_request_mode(ssl, socket, server, action, compression, encryption, output_format))
+   {
+      goto error;
+   }
+
+   if (process_result(ssl, socket, output_format))
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+
+   return 1;
+}
+
+static int
+progress(SSL* ssl, int socket, char* server, char* command, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   if (pgmoneta_management_request_progress(ssl, socket, server, command, compression, encryption, output_format))
    {
       goto error;
    }
@@ -2593,6 +2638,9 @@ translate_command(int32_t cmd_code)
       case MANAGEMENT_MODE:
          command_output = pgmoneta_append(command_output, COMMAND_MODE);
          break;
+      case MANAGEMENT_PROGRESS:
+         command_output = pgmoneta_append(command_output, COMMAND_PROGRESS);
+         break;
       case MANAGEMENT_CONF_LS:
          command_output = pgmoneta_append(command_output, COMMAND_CONF);
          command_output = pgmoneta_append_char(command_output, ' ');
@@ -3243,6 +3291,8 @@ translate_json_object(struct json* j)
                translate_configuration(response);
                break;
             case MANAGEMENT_MODE:
+               break;
+            case MANAGEMENT_PROGRESS:
                break;
             default:
                break;

--- a/src/include/backup.h
+++ b/src/include/backup.h
@@ -81,6 +81,14 @@ int
 pgmoneta_get_backup_max_rate(int server);
 
 /**
+ * Is progress enabled for a server
+ * @param server The server
+ * @return True if enabled, otherwise false
+ */
+bool
+pgmoneta_is_progress_enabled(int server);
+
+/**
  * Is the backup valid ?
  * @param server The server
  * @param identifier The identifier

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -92,6 +92,7 @@ extern "C" {
 #define CONFIGURATION_ARGUMENT_ONLINE                  "online"
 #define CONFIGURATION_ARGUMENT_PIDFILE                 "pidfile"
 #define CONFIGURATION_ARGUMENT_PORT                    "port"
+#define CONFIGURATION_ARGUMENT_PROGRESS                "progress"
 #define CONFIGURATION_ARGUMENT_RETENTION               "retention"
 #define CONFIGURATION_ARGUMENT_S3_USE_TLS              "s3_use_tls"
 #define CONFIGURATION_ARGUMENT_S3_ENDPOINT             "s3_endpoint"

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -86,6 +86,7 @@ extern "C" {
 #define MANAGEMENT_CONF_GET       22
 #define MANAGEMENT_CONF_SET       23
 #define MANAGEMENT_MODE           24
+#define MANAGEMENT_PROGRESS       25
 
 #define MANAGEMENT_MASTER_KEY     100
 #define MANAGEMENT_ADD_USER       101
@@ -117,6 +118,8 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_BACKUPS               "Backups"
 #define MANAGEMENT_ARGUMENT_BACKUP_SIZE           "BackupSize"
 #define MANAGEMENT_ARGUMENT_BIGGEST_FILE_SIZE     "BiggestFileSize"
+#define MANAGEMENT_ARGUMENT_BYTES_DONE            "BytesDone"
+#define MANAGEMENT_ARGUMENT_BYTES_TOTAL           "BytesTotal"
 #define MANAGEMENT_ARGUMENT_CALCULATED            "Calculated"
 #define MANAGEMENT_ARGUMENT_CASCADE               "Cascade"
 #define MANAGEMENT_ARGUMENT_CHECKPOINT_HILSN      "CheckpointHiLSN"
@@ -127,14 +130,12 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_COMMENT               "Comment"
 #define MANAGEMENT_ARGUMENT_COMMENTS              "Comments"
 #define MANAGEMENT_ARGUMENT_COMPRESSION           "Compression"
-#define MANAGEMENT_ARGUMENT_COMPRESSION           "Compression"
 #define MANAGEMENT_ARGUMENT_CONFIG_KEY            "ConfigKey"
 #define MANAGEMENT_ARGUMENT_CONFIG_VALUE          "ConfigValue"
 #define MANAGEMENT_ARGUMENT_DELTA                 "Delta"
 #define MANAGEMENT_ARGUMENT_DESTINATION_FILE      "DestinationFile"
 #define MANAGEMENT_ARGUMENT_DIRECTORY             "Directory"
 #define MANAGEMENT_ARGUMENT_ELAPSED               "Elapsed"
-#define MANAGEMENT_ARGUMENT_ENCRYPTION            "Encryption"
 #define MANAGEMENT_ARGUMENT_ENCRYPTION            "Encryption"
 #define MANAGEMENT_ARGUMENT_END_HILSN             "EndHiLSN"
 #define MANAGEMENT_ARGUMENT_END_LOLSN             "EndLoLSN"
@@ -161,14 +162,15 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_OUTPUT                "Output"
 #define MANAGEMENT_ARGUMENT_POSITION              "Position"
 #define MANAGEMENT_ARGUMENT_PRIMARY               "Primary"
+#define MANAGEMENT_ARGUMENT_PROGRESS_STATE        "BackupProgressState"
 #define MANAGEMENT_ARGUMENT_RESTART               "Restart"
 #define MANAGEMENT_ARGUMENT_RESTORE_SIZE          "RestoreSize"
 #define MANAGEMENT_ARGUMENT_RETENTION_DAYS        "RetentionDays"
 #define MANAGEMENT_ARGUMENT_RETENTION_MONTHS      "RetentionMonths"
 #define MANAGEMENT_ARGUMENT_RETENTION_WEEKS       "RetentionWeeks"
 #define MANAGEMENT_ARGUMENT_RETENTION_YEARS       "RetentionYears"
-#define MANAGEMENT_ARGUMENT_S3_OBJECTS            "S3Objects"
 #define MANAGEMENT_ARGUMENT_S3_KEY                "S3Key"
+#define MANAGEMENT_ARGUMENT_S3_OBJECTS            "S3Objects"
 #define MANAGEMENT_ARGUMENT_SERVER                "Server"
 #define MANAGEMENT_ARGUMENT_SERVERS               "Servers"
 #define MANAGEMENT_ARGUMENT_SERVER_SIZE           "ServerSize"
@@ -177,6 +179,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_SOURCE_FILE           "SourceFile"
 #define MANAGEMENT_ARGUMENT_START_HILSN           "StartHiLSN"
 #define MANAGEMENT_ARGUMENT_START_LOLSN           "StartLoLSN"
+#define MANAGEMENT_ARGUMENT_START_TIME            "StartTime"
 #define MANAGEMENT_ARGUMENT_START_TIMELINE        "StartTimeline"
 #define MANAGEMENT_ARGUMENT_STATUS                "Status"
 #define MANAGEMENT_ARGUMENT_TABLESPACE            "Tablespace"
@@ -382,6 +385,11 @@ extern "C" {
 #define MANAGEMENT_ERROR_LIST_S3_JSON_VALUE                 2903
 #define MANAGEMENT_ERROR_LIST_S3_NETWORK                    2904
 #define MANAGEMENT_ERROR_LIST_S3_ERROR                      2905
+
+#define MANAGEMENT_ERROR_PROGRESS_NOSERVER                  3000
+#define MANAGEMENT_ERROR_PROGRESS_NOFORK                    3001
+#define MANAGEMENT_ERROR_PROGRESS_NETWORK                   3002
+#define MANAGEMENT_ERROR_PROGRESS_ERROR                     3003
 
 /**
  * Output formats
@@ -772,6 +780,19 @@ pgmoneta_management_request_annotate(SSL* ssl, int socket, char* server, char* b
  * @return 0 upon success, otherwise 1
  */
 int pgmoneta_management_request_mode(SSL* ssl, int socket, char* server, char* action, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Create a backup progress request
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The server
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_request_progress(SSL* ssl, int socket, char* server, char* command, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Create an ok response

--- a/src/include/message.h
+++ b/src/include/message.h
@@ -365,7 +365,7 @@ pgmoneta_create_standby_status_update_message(int64_t received, int64_t flushed,
  */
 int
 pgmoneta_create_base_backup_message(int server_version, bool incremental, char* label, bool include_wal,
-                                    int compression, int compression_level,
+                                    int compression, int compression_level, bool progress,
                                     struct message** msg);
 
 /**

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -135,6 +135,9 @@ extern "C" {
 #define SLOT_NOT_FOUND               1
 #define INCORRECT_SLOT_TYPE          2
 
+#define BACKUP_PROGRESS_NONE         0
+#define BACKUP_PROGRESS_RUNNING      1
+
 #define INDENT_PER_LEVEL             2
 #define FORMAT_JSON                  0
 #define FORMAT_TEXT                  1
@@ -269,6 +272,18 @@ struct s3_configuration
    char base_dir[MAX_PATH];             /**< The S3 base directory */
 } __attribute__((aligned(64)));
 
+/** @struct backup_progress
+ * The backup_progress of a server
+ */
+struct backup_progress
+{
+   atomic_int state;         /**< The progress state */
+   atomic_llong bytes_done;  /**< The bytes transferred so far */
+   atomic_llong bytes_total; /**< The total bytes to transfer */
+   atomic_llong start_time;  /**< The start time */
+   atomic_llong elapsed;     /**< The elapsed time */
+};
+
 /** @struct server
  * Defines a server
  */
@@ -325,11 +340,13 @@ struct server
    int backup_max_rate;                                           /**< Number of tokens added to the bucket with each replenishment for backup. */
    int network_max_rate;                                          /**< Number of bytes of tokens added every one second to limit the netowrk backup rate */
    int number_of_extra;                                           /**< The number of source directory*/
+   int progress;                                                  /**< The Backup progress status */
    char extra[MAX_EXTRA][MAX_EXTRA_PATH];                         /**< Source directory*/
    bool has_extension;                                            /**< Does this have pgmoneta_ext */
    char ext_version[MISC_LENGTH];                                 /**< The major version of the extension*/
    struct extension_info extensions[NUMBER_OF_EXTENSIONS];        /**< The extensions */
    struct s3_configuration s3;                                    /**< The S3 configuration */
+   struct backup_progress backup_progress;                        /**< The backup progress */
 } __attribute__((aligned(64)));
 
 /** @struct user
@@ -486,6 +503,8 @@ struct main_configuration
    int network_max_rate; /**< Number of bytes of tokens added every one second to limit the netowrk backup rate */
 
    pgmoneta_time_t verification; /**< The sha512 verification interval */
+
+   bool progress; /**< Enable backup progress tracking */
 
 #ifdef DEBUG
    bool link; /**< Do linking */

--- a/src/include/status.h
+++ b/src/include/status.h
@@ -60,6 +60,17 @@ pgmoneta_status(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption
 void
 pgmoneta_status_details(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
 
+/**
+ * Get progress information
+ * @param ssl The SSL connection
+ * @param client_fd The client
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The payload
+ */
+void
+pgmoneta_progress(SSL* ssl, int client_fd, uint8_t compression, uint8_t encryption, struct json* payload);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgmoneta/archive.c
+++ b/src/libpgmoneta/archive.c
@@ -29,6 +29,7 @@
 /* pgmoneta */
 #include <pgmoneta.h>
 #include <achv.h>
+#include <backup.h>
 #include <logging.h>
 #include <management.h>
 #include <manifest.h>
@@ -525,6 +526,7 @@ error:
 int
 pgmoneta_receive_archive_stream(int srv, SSL* ssl, int socket, struct stream_buffer* buffer, char* basedir, struct tablespace* tablespaces, struct token_bucket* bucket, struct token_bucket* network_bucket)
 {
+   struct main_configuration* config = (struct main_configuration*)shmem;
    struct query_response* response = NULL;
    struct message* msg = (struct message*)malloc(sizeof(struct message));
    struct tuple* tup = NULL;
@@ -561,6 +563,23 @@ pgmoneta_receive_archive_stream(int srv, SSL* ssl, int socket, struct stream_buf
    if (pgmoneta_consume_data_row_messages(srv, ssl, socket, buffer, &response))
    {
       goto error;
+   }
+
+   // Extract total backup size from tablespace listing
+   if (pgmoneta_is_progress_enabled(srv))
+   {
+      int64_t total_size = 0;
+      struct tuple* t = response->tuples;
+      while (t != NULL)
+      {
+         if (t->data[2] != NULL)
+         {
+            total_size += strtoll(t->data[2], NULL, 10) * 1024;
+         }
+         t = t->next;
+      }
+      atomic_store(&config->common.servers[srv].backup_progress.bytes_total, total_size);
+      pgmoneta_log_debug("Backup progress: total size %" PRId64 " bytes", total_size);
    }
    while (msg == NULL || msg->kind != 'H')
    {
@@ -741,7 +760,40 @@ pgmoneta_receive_archive_stream(int srv, SSL* ssl, int socket, struct stream_buf
             }
             case 'p':
             {
-               // progress report, ignore this for now
+               // progress report
+               int64_t bytes_done = pgmoneta_read_int64(msg->data + 1);
+               int64_t bytes_total = atomic_load(&config->common.servers[srv].backup_progress.bytes_total);
+
+               // The total size is only approximate and might not increase monotonically
+               // so we need to update it if it's greater than the current value
+               if (bytes_done > bytes_total)
+               {
+                  bytes_total = bytes_done;
+                  atomic_store(&config->common.servers[srv].backup_progress.bytes_total, bytes_total);
+               }
+
+               int64_t bytes_remaining = bytes_total - bytes_done;
+
+               atomic_store(&config->common.servers[srv].backup_progress.bytes_done, bytes_done);
+               if (atomic_load(&config->common.servers[srv].backup_progress.start_time) > 0)
+               {
+                  time_t now = time(NULL);
+                  time_t start = atomic_load(&config->common.servers[srv].backup_progress.start_time);
+                  time_t elapsed = now - start;
+                  atomic_store(&config->common.servers[srv].backup_progress.elapsed, elapsed);
+
+                  double pct = (bytes_total > 0) ? ((double)bytes_done / (double)bytes_total) * 100.0 : 0.0;
+                  time_t remaining = (bytes_done > 0 && bytes_total > 0)
+                                        ? (time_t)((double)elapsed * ((double)bytes_remaining / (double)bytes_done))
+                                        : 0;
+
+                  int r_hours = (int)(remaining / 3600);
+                  int r_minutes = (int)((remaining % 3600) / 60);
+                  int r_seconds = (int)(remaining % 60);
+
+                  pgmoneta_log_debug("Backup progress: remaining %02d:%02d:%02d, %.1f%%",
+                                     r_hours, r_minutes, r_seconds, pct);
+               }
                break;
             }
             default:

--- a/src/libpgmoneta/backup.c
+++ b/src/libpgmoneta/backup.c
@@ -767,6 +767,25 @@ pgmoneta_get_backup_max_rate(int server)
 }
 
 bool
+pgmoneta_is_progress_enabled(int server)
+{
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   if (config->common.servers[server].progress == 1)
+   {
+      return true;
+   }
+   else if (config->common.servers[server].progress == 0)
+   {
+      return false;
+   }
+
+   return config->progress;
+}
+
+bool
 pgmoneta_is_backup_valid(int server, char* identifier)
 {
    bool result = false;

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -299,6 +299,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                   srv.workers = -1;
                   srv.backup_max_rate = -1;
                   srv.network_max_rate = -1;
+                  srv.progress = -1;
 
                   idx_server++;
                }
@@ -636,6 +637,31 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                         warnx("Hot standby configuration for server '%s' contains more than %d directories. Only the first %d will be used.", section, NUMBER_OF_HOT_STANDBY, NUMBER_OF_HOT_STANDBY);
                      }
                      free(paths);
+                  }
+               }
+               else if (!strcmp(key, "progress"))
+               {
+                  if (!strcmp(section, "pgmoneta"))
+                  {
+                     if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+                     {
+                        config->progress = true;
+                     }
+                  }
+                  else if (strlen(section) > 0)
+                  {
+                     if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+                     {
+                        srv.progress = 1;
+                     }
+                     else if (!strcmp(value, "off") || !strcmp(value, "false") || !strcmp(value, "0"))
+                     {
+                        srv.progress = 0;
+                     }
+                  }
+                  else
+                  {
+                     unknown = true;
                   }
                }
                else if (!strcmp(key, "metrics"))
@@ -3339,6 +3365,7 @@ add_configuration_response(struct json* res)
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_COMPRESSION, (uintptr_t)config->compression_type, ValueInt32);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_COMPRESSION_LEVEL, (uintptr_t)config->compression_level, ValueInt64);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_WORKERS, (uintptr_t)config->workers, ValueInt64);
+   pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_PROGRESS, (uintptr_t)config->progress, ValueBool);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_STORAGE_ENGINE, (uintptr_t)config->storage_engine, ValueInt32);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_ENCRYPTION, (uintptr_t)config->encryption, ValueInt32);
    pgmoneta_json_put(res, CONFIGURATION_ARGUMENT_CREATE_SLOT, (uintptr_t)config->create_slot, ValueInt32);
@@ -3470,6 +3497,7 @@ add_servers_configuration_response(struct json* res)
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_WORKERS, (uintptr_t)config->common.servers[i].workers, ValueInt64);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_BACKUP_MAX_RATE, (uintptr_t)config->common.servers[i].backup_max_rate, ValueInt64);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_NETWORK_MAX_RATE, (uintptr_t)config->common.servers[i].network_max_rate, ValueInt64);
+      pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_PROGRESS, (uintptr_t)config->common.servers[i].progress, ValueInt64);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_MANIFEST, (uintptr_t)"SHA512", ValueString);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_TLS_CERT_FILE, (uintptr_t)config->common.servers[i].tls_cert_file, ValueString);
       pgmoneta_json_put(server_conf, CONFIGURATION_ARGUMENT_TLS_CA_FILE, (uintptr_t)config->common.servers[i].tls_ca_file, ValueString);
@@ -4087,6 +4115,17 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
             unknown = true;
          }
       }
+      else if (!strcmp(key, "progress"))
+      {
+         if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+         {
+            srv->progress = 1;
+         }
+         else if (!strcmp(value, "off") || !strcmp(value, "false") || !strcmp(value, "0"))
+         {
+            srv->progress = 0;
+         }
+      }
       else
       {
          unknown = true;
@@ -4215,6 +4254,17 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
             unknown = true;
          }
       }
+      else if (!strcmp(key, "progress"))
+      {
+         if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+         {
+            config->progress = true;
+         }
+         else if (!strcmp(value, "off") || !strcmp(value, "false") || !strcmp(value, "0"))
+         {
+            config->progress = false;
+         }
+      }
       else
       {
          unknown = true;
@@ -4315,6 +4365,10 @@ write_config_value(char* buffer, char* config_key, size_t buffer_size)
             snprintf(buffer, buffer_size, "%s", ret ? ret : "");
             free(ret);
          }
+         else if (!strcmp(key_info.key, "progress"))
+         {
+            snprintf(buffer, buffer_size, "%s", config->progress ? "on" : "off");
+         }
          else
          {
             pgmoneta_log_debug("Unknown main configuration key: %s", key_info.key);
@@ -4409,6 +4463,10 @@ write_config_value(char* buffer, char* config_key, size_t buffer_size)
                else if (!strcmp(key_info.key, "s3_base_dir"))
                {
                   snprintf(buffer, buffer_size, "%s", srv->s3.base_dir);
+               }
+               else if (!strcmp(key_info.key, "progress"))
+               {
+                  snprintf(buffer, buffer_size, "%s", srv->progress == 1 ? "on" : (srv->progress == 0 ? "off" : "inherit"));
                }
                else
                {
@@ -5862,6 +5920,7 @@ transfer_configuration(struct main_configuration* config, struct main_configurat
    config->common.number_of_admins = reload->common.number_of_admins;
 
    config->workers = reload->workers;
+   config->progress = reload->progress;
    config->backup_max_rate = reload->backup_max_rate;
    config->network_max_rate = reload->network_max_rate;
 
@@ -5957,6 +6016,7 @@ copy_server(struct server* dst, struct server* src)
    /* memcpy(&dst->current_wal_filename[0], &src->current_wal_filename[0], MISC_LENGTH); */
    /* memcpy(&dst->current_wal_lsn[0], &src->current_wal_lsn[0], MISC_LENGTH); */
    dst->workers = src->workers;
+   dst->progress = src->progress;
    dst->backup_max_rate = src->backup_max_rate;
    dst->network_max_rate = src->network_max_rate;
 

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -914,6 +914,41 @@ error:
 }
 
 int
+pgmoneta_management_request_progress(SSL* ssl, int socket, char* server, char* command, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgmoneta_management_create_header(MANAGEMENT_PROGRESS, compression, encryption, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_COMMAND, (uintptr_t)command, ValueString);
+
+   if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgmoneta_json_destroy(j);
+
+   return 1;
+}
+
+int
 pgmoneta_management_create_response(struct json* json, int server, struct json** response)
 {
    struct json* r = NULL;

--- a/src/libpgmoneta/message.c
+++ b/src/libpgmoneta/message.c
@@ -797,7 +797,7 @@ pgmoneta_create_standby_status_update_message(int64_t received, int64_t flushed,
 
 int
 pgmoneta_create_base_backup_message(int server_version, bool incremental, char* label, bool include_wal,
-                                    int compression, int compression_level,
+                                    int compression, int compression_level, bool progress,
                                     struct message** msg)
 {
    bool use_new_format = server_version >= 15;
@@ -851,6 +851,11 @@ pgmoneta_create_base_backup_message(int server_version, bool incremental, char* 
          options = pgmoneta_append(options, "', ");
       }
 
+      if (progress)
+      {
+         options = pgmoneta_append(options, "PROGRESS true, ");
+      }
+
       options = pgmoneta_append(options, "CHECKPOINT 'fast', ");
 
       options = pgmoneta_append(options, "MANIFEST 'yes', ");
@@ -864,6 +869,11 @@ pgmoneta_create_base_backup_message(int server_version, bool incremental, char* 
       options = pgmoneta_append(options, "LABEL '");
       options = pgmoneta_append(options, label);
       options = pgmoneta_append(options, "' ");
+
+      if (progress)
+      {
+         options = pgmoneta_append(options, "PROGRESS ");
+      }
 
       options = pgmoneta_append(options, "FAST ");
 

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -2659,6 +2659,45 @@ general_information(prometheus_metrics_container_t* container)
    add_metric_to_art(container->general_metrics, "pgmoneta_extension_pgmoneta_ext", data, NULL, NULL, 0);
    free(data);
    data = NULL;
+   data = pgmoneta_append(data, "#HELP pgmoneta_backup_progress The backup progress for a server\n");
+   data = pgmoneta_append(data, "#TYPE pgmoneta_backup_progress gauge\n");
+   for (int i = 0; i < config->common.number_of_servers; i++)
+   {
+      int64_t state = atomic_load(&config->common.servers[i].backup_progress.state);
+      int64_t bytes_done = atomic_load(&config->common.servers[i].backup_progress.bytes_done);
+      int64_t bytes_total = atomic_load(&config->common.servers[i].backup_progress.bytes_total);
+      int64_t elapsed = atomic_load(&config->common.servers[i].backup_progress.elapsed);
+      int64_t percentage = (bytes_total > 0) ? (bytes_done * 100 / bytes_total) : 0;
+      int64_t remaining = (bytes_done > 0 && bytes_total > 0)
+                             ? (int64_t)((double)elapsed * ((double)(bytes_total - bytes_done) / (double)bytes_done))
+                             : 0;
+
+      data = pgmoneta_append(data, "pgmoneta_backup_progress{");
+      data = pgmoneta_append(data, "name=\"");
+      data = pgmoneta_append(data, config->common.servers[i].name);
+      data = pgmoneta_append(data, "\", type=\"state\"} ");
+      data = pgmoneta_append_int(data, (int)state);
+      data = pgmoneta_append(data, "\n");
+
+      data = pgmoneta_append(data, "pgmoneta_backup_progress{");
+      data = pgmoneta_append(data, "name=\"");
+      data = pgmoneta_append(data, config->common.servers[i].name);
+      data = pgmoneta_append(data, "\", type=\"percentage\"} ");
+      data = pgmoneta_append_int(data, (int)percentage);
+      data = pgmoneta_append(data, "\n");
+
+      data = pgmoneta_append(data, "pgmoneta_backup_progress{");
+      data = pgmoneta_append(data, "name=\"");
+      data = pgmoneta_append(data, config->common.servers[i].name);
+      data = pgmoneta_append(data, "\", type=\"remaining\"} ");
+      data = pgmoneta_append_int(data, (int)remaining);
+      data = pgmoneta_append(data, "\n");
+   }
+   data = pgmoneta_append(data, "\n");
+
+   add_metric_to_art(container->general_metrics, "pgmoneta_backup_progress", data, NULL, NULL, 0);
+   free(data);
+   data = NULL;
 }
 
 static void

--- a/src/libpgmoneta/wf_backup.c
+++ b/src/libpgmoneta/wf_backup.c
@@ -111,6 +111,7 @@ basebackup_execute(char* name __attribute__((unused)), struct art* nodes)
    char old_label_path[MAX_PATH];
    int backup_max_rate;
    int network_max_rate;
+   bool progress_enabled = false;
    uint64_t biggest_file_size;
    struct main_configuration* config;
    struct message* basebackup_msg = NULL;
@@ -252,9 +253,20 @@ basebackup_execute(char* name __attribute__((unused)), struct art* nodes)
    tag = pgmoneta_append(tag, "pgmoneta_");
    tag = pgmoneta_append(tag, label);
 
+   progress_enabled = pgmoneta_is_progress_enabled(server);
+
    pgmoneta_create_base_backup_message(config->common.servers[server].version, false, tag, true,
                                        config->compression_type, config->compression_level,
-                                       &basebackup_msg);
+                                       progress_enabled, &basebackup_msg);
+
+   if (progress_enabled)
+   {
+      atomic_store(&config->common.servers[server].backup_progress.state, BACKUP_PROGRESS_RUNNING);
+      atomic_store(&config->common.servers[server].backup_progress.bytes_done, 0);
+      atomic_store(&config->common.servers[server].backup_progress.bytes_total, 0);
+      atomic_store(&config->common.servers[server].backup_progress.elapsed, 0);
+      atomic_store(&config->common.servers[server].backup_progress.start_time, (long long)time(NULL));
+   }
 
    status = pgmoneta_write_message(ssl, socket, basebackup_msg);
    if (status != MESSAGE_STATUS_OK)
@@ -432,6 +444,11 @@ basebackup_execute(char* name __attribute__((unused)), struct art* nodes)
    free(tag);
    free(wal);
 
+   if (progress_enabled)
+   {
+      atomic_store(&config->common.servers[server].backup_progress.state, BACKUP_PROGRESS_NONE);
+   }
+
    return 0;
 
 error:
@@ -463,6 +480,11 @@ error:
    free(chkptpos);
    free(tag);
    free(wal);
+
+   if (progress_enabled)
+   {
+      atomic_store(&config->common.servers[server].backup_progress.state, BACKUP_PROGRESS_NONE);
+   }
 
    return 1;
 }

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -856,7 +856,7 @@ incr_backup_execute_17_plus(char* name __attribute__((unused)), struct art* node
 
    pgmoneta_create_base_backup_message(config->common.servers[server].version, true, tag, true,
                                        config->compression_type, config->compression_level,
-                                       &basebackup_msg);
+                                       pgmoneta_is_progress_enabled(server), &basebackup_msg);
 
    status = pgmoneta_write_message(ssl, socket, basebackup_msg);
    if (status != MESSAGE_STATUS_OK)

--- a/src/main.c
+++ b/src/main.c
@@ -2029,6 +2029,27 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          goto error;
       }
    }
+   else if (id == MANAGEMENT_PROGRESS)
+   {
+      pid = fork();
+      if (pid == -1)
+      {
+         pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_PROGRESS_NOFORK, NAME, compression, encryption, payload);
+         pgmoneta_log_error("Backup progress: No fork (%d)", MANAGEMENT_ERROR_PROGRESS_NOFORK);
+         goto error;
+      }
+      else if (pid == 0)
+      {
+         struct json* pyl = NULL;
+
+         shutdown_ports();
+
+         pgmoneta_json_clone(payload, &pyl);
+
+         pgmoneta_set_proc_title(1, ai->argv, "progress", NULL);
+         pgmoneta_progress(NULL, client_fd, compression, encryption, pyl);
+      }
+   }
    else
    {
       pgmoneta_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_UNKNOWN_COMMAND, NAME, compression, encryption, payload);


### PR DESCRIPTION
resolved #946 

Implement support for PROGRESS in the BASE_BACKUP command, by default `progress = false`.

As a simple starter, I provide a debug_ information log.

**Debug Example**
```
2026-02-26 18:46:25 DEBUG archive.c:562 Backup progress: total size 2469046272 bytes
2026-02-26 18:46:26 DEBUG archive.c:771 Backup progress (Elapsed: 00:00:1, Remaining: 00:00:5) 384313344/2469046272 bytes (15.6%), 2084732928 bytes remaining
2026-02-26 18:46:27 DEBUG archive.c:771 Backup progress (Elapsed: 00:00:2, Remaining: 00:00:3) 937895936/2469046272 bytes (38.0%), 1531150336 bytes remaining
2026-02-26 18:46:28 DEBUG archive.c:771 Backup progress (Elapsed: 00:00:3, Remaining: 00:00:1) 1495354880/2469046272 bytes (60.6%), 973691392 bytes remaining
2026-02-26 18:46:29 DEBUG archive.c:771 Backup progress (Elapsed: 00:00:4, Remaining: 00:00:0) 2039565824/2469046272 bytes (82.6%), 429480448 bytes remaining
2026-02-26 18:46:30 DEBUG archive.c:771 Backup progress (Elapsed: 00:00:5, Remaining: 00:00:0) 2445794816/2469046272 bytes (99.1%), 23251456 bytes remaining
2026-02-26 18:46:30 DEBUG archive.c:771 Backup progress (Elapsed: 00:00:5, Remaining: 00:00:0) 2485835776/2485835776 bytes (100.0%),0 bytes remaining
```