### PR TITLE
[#956] refactor: Use bitmask for compression constants

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -1787,46 +1787,43 @@ compress_data_client(char* from, uint8_t compression)
 
    to = pgmoneta_append(to, from);
 
-   if (compression == COMPRESSION_CLIENT_GZIP || compression == COMPRESSION_SERVER_GZIP)
+   switch (COMPRESSION_ALGORITHM(compression))
    {
-      to = pgmoneta_append(to, ".gz");
-      if (pgmoneta_gzip_file(from, to))
-      {
-         pgmoneta_log_error("Compress: GZIP compression failed");
+      case COMPRESSION_ALG_GZIP:
+         to = pgmoneta_append(to, ".gz");
+         if (pgmoneta_gzip_file(from, to))
+         {
+            pgmoneta_log_error("Compress: GZIP compression failed");
+            goto error;
+         }
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         to = pgmoneta_append(to, ".zstd");
+         if (pgmoneta_zstandardc_file(from, to))
+         {
+            pgmoneta_log_error("Compress: ZSTD compression failed");
+            goto error;
+         }
+         break;
+      case COMPRESSION_ALG_LZ4:
+         to = pgmoneta_append(to, ".lz4");
+         if (pgmoneta_lz4c_file(from, to))
+         {
+            pgmoneta_log_error("Compress: LZ4 compression failed");
+            goto error;
+         }
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         to = pgmoneta_append(to, ".bz2");
+         if (pgmoneta_bzip2_file(from, to))
+         {
+            pgmoneta_log_error("Compress: BZIP2 compression failed");
+            goto error;
+         }
+         break;
+      default:
+         pgmoneta_log_error("Compress: Unknown compression type: %d", compression);
          goto error;
-      }
-   }
-   else if (compression == COMPRESSION_CLIENT_ZSTD || compression == COMPRESSION_SERVER_ZSTD)
-   {
-      to = pgmoneta_append(to, ".zstd");
-      if (pgmoneta_zstandardc_file(from, to))
-      {
-         pgmoneta_log_error("Compress: ZSTD compression failed");
-         goto error;
-      }
-   }
-   else if (compression == COMPRESSION_CLIENT_LZ4 || compression == COMPRESSION_SERVER_LZ4)
-   {
-      to = pgmoneta_append(to, ".lz4");
-      if (pgmoneta_lz4c_file(from, to))
-      {
-         pgmoneta_log_error("Compress: LZ4 compression failed");
-         goto error;
-      }
-   }
-   else if (compression == COMPRESSION_CLIENT_BZIP2)
-   {
-      to = pgmoneta_append(to, ".bz2");
-      if (pgmoneta_bzip2_file(from, to))
-      {
-         pgmoneta_log_error("Compress: BZIP2 compression failed");
-         goto error;
-      }
-   }
-   else
-   {
-      pgmoneta_log_error("Compress: Unknown compression type: %d", compression);
-      goto error;
    }
 
    free(to);
@@ -2703,24 +2700,21 @@ static char*
 translate_compression(int32_t compression_code)
 {
    char* compression_output = NULL;
-   switch (compression_code)
+   switch (COMPRESSION_ALGORITHM(compression_code))
    {
-      case COMPRESSION_CLIENT_GZIP:
-      case COMPRESSION_SERVER_GZIP:
+      case COMPRESSION_ALG_GZIP:
          compression_output = pgmoneta_append(compression_output, "gzip");
          break;
-      case COMPRESSION_CLIENT_ZSTD:
-      case COMPRESSION_SERVER_ZSTD:
+      case COMPRESSION_ALG_ZSTD:
          compression_output = pgmoneta_append(compression_output, "zstd");
          break;
-      case COMPRESSION_CLIENT_LZ4:
-      case COMPRESSION_SERVER_LZ4:
+      case COMPRESSION_ALG_LZ4:
          compression_output = pgmoneta_append(compression_output, "lz4");
          break;
-      case COMPRESSION_CLIENT_BZIP2:
+      case COMPRESSION_ALG_BZIP2:
          compression_output = pgmoneta_append(compression_output, "bzip2");
          break;
-      case COMPRESSION_NONE:
+      case COMPRESSION_ALG_NONE:
          compression_output = pgmoneta_append(compression_output, "none");
          break;
       default:

--- a/src/include/compression.h
+++ b/src/include/compression.h
@@ -96,6 +96,52 @@ void
 pgmoneta_compressor_destroy(struct compressor* compressor);
 
 /**
+ * Get the algorithm suffix (e.g. ".gz", ".zstd") for a compression type.
+ *
+ * The returned suffix is owned by the library and must not be freed.
+ * On success, *suffix is set to either a non-NULL string or NULL if
+ * there is no compression suffix for the given type.
+ *
+ * @param type The compression type (including side bits)
+ * @param suffix [out] Pointer to receive the suffix
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_compression_get_suffix(int type, const char** suffix);
+
+/**
+ * Clamp a compression level according to the compression algorithm.
+ *
+ * Updates *level in-place to fall within the supported range for the
+ * given compression type. If the algorithm doesn't use a level, the
+ * value is left unchanged.
+ *
+ * @param type The compression type (including side bits)
+ * @param level [in/out] The compression level to clamp
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_compression_get_level(int type, int* level);
+
+/**
+ * Remove compression and optional encryption suffixes from a file name.
+ *
+ * This helper uses the configured compression type and encryption mode to
+ * strip any matching algorithm suffix (e.g. ".gz", ".zstd") and a trailing
+ * ".aes" encryption suffix, if present.
+ *
+ * The returned string must be freed by the caller.
+ *
+ * @param str The original file name
+ * @param compression_type The configured compression type
+ * @param encryption The configured encryption type
+ * @param result [out] Pointer that will receive the trimmed file name
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_compression_trim_suffix(char* str, int compression_type, int encryption, char** result);
+
+/**
  * Decompress a file using the appropriate decompression method.
  *
  * This function determines the compression type of the input file by calling

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -45,6 +45,7 @@ extern "C" {
 #include <sys/types.h>
 #include <openssl/ssl.h>
 
+// clang-format off
 #define VERSION                      "0.21.0"
 
 #define PGMONETA_HOMEPAGE            "https://pgmoneta.github.io/"
@@ -106,14 +107,34 @@ extern "C" {
 #define DIRECT_IO_AUTO               1
 #define DIRECT_IO_ON                 2
 
-#define COMPRESSION_NONE             0
-#define COMPRESSION_CLIENT_GZIP      1
-#define COMPRESSION_CLIENT_ZSTD      2
-#define COMPRESSION_CLIENT_LZ4       3
-#define COMPRESSION_CLIENT_BZIP2     4
-#define COMPRESSION_SERVER_GZIP      5
-#define COMPRESSION_SERVER_ZSTD      6
-#define COMPRESSION_SERVER_LZ4       7
+// clang-format on
+/* Compression type bits */
+#define COMPRESSION_TYPE_CLIENT 0x10
+#define COMPRESSION_TYPE_SERVER 0x20
+#define COMPRESSION_TYPE_BOTH   (COMPRESSION_TYPE_CLIENT | COMPRESSION_TYPE_SERVER)
+#define COMPRESSION_TYPE_MASK   0x30
+
+/* Compression algorithm bits (bits 0-3) */
+#define COMPRESSION_ALG_NONE         0x00
+#define COMPRESSION_ALG_GZIP         0x01
+#define COMPRESSION_ALG_ZSTD         0x02
+#define COMPRESSION_ALG_LZ4          0x03
+#define COMPRESSION_ALG_BZIP2        0x04
+
+#define COMPRESSION_NONE             0x00
+
+#define COMPRESSION_CLIENT_GZIP      (COMPRESSION_TYPE_CLIENT | COMPRESSION_ALG_GZIP)
+#define COMPRESSION_CLIENT_ZSTD      (COMPRESSION_TYPE_CLIENT | COMPRESSION_ALG_ZSTD)
+#define COMPRESSION_CLIENT_LZ4       (COMPRESSION_TYPE_CLIENT | COMPRESSION_ALG_LZ4)
+#define COMPRESSION_CLIENT_BZIP2     (COMPRESSION_TYPE_CLIENT | COMPRESSION_ALG_BZIP2)
+
+#define COMPRESSION_SERVER_GZIP      (COMPRESSION_TYPE_SERVER | COMPRESSION_ALG_GZIP)
+#define COMPRESSION_SERVER_ZSTD      (COMPRESSION_TYPE_SERVER | COMPRESSION_ALG_ZSTD)
+#define COMPRESSION_SERVER_LZ4       (COMPRESSION_TYPE_SERVER | COMPRESSION_ALG_LZ4)
+
+#define COMPRESSION_IS_SERVER(t)     (!!((t) & COMPRESSION_TYPE_SERVER))
+#define COMPRESSION_IS_CLIENT(t)     (!!((t) & COMPRESSION_TYPE_CLIENT))
+#define COMPRESSION_ALGORITHM(t)     ((t) & 0x0F)
 
 #define STORAGE_ENGINE_LOCAL         1 << 0
 #define STORAGE_ENGINE_SSH           1 << 1

--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -28,6 +28,7 @@
 
 #include <pgmoneta.h>
 #include <aes.h>
+#include <compression.h>
 #include <logging.h>
 #include <management.h>
 #include <security.h>
@@ -246,31 +247,18 @@ pgmoneta_encrypt_wal(char* d)
    struct dirent* entry;
    char* compress_suffix = NULL;
    struct main_configuration* config;
+   const char* alg_suffix = NULL;
 
    config = (struct main_configuration*)shmem;
-   switch (config->compression_type)
+
+   pgmoneta_compression_get_suffix(config->compression_type, &alg_suffix);
+   if (alg_suffix != NULL)
    {
-      case COMPRESSION_CLIENT_GZIP:
-      case COMPRESSION_SERVER_GZIP:
-         compress_suffix = ".gz";
-         break;
-      case COMPRESSION_CLIENT_ZSTD:
-      case COMPRESSION_SERVER_ZSTD:
-         compress_suffix = ".zstd";
-         break;
-      case COMPRESSION_CLIENT_LZ4:
-      case COMPRESSION_SERVER_LZ4:
-         compress_suffix = ".lz4";
-         break;
-      case COMPRESSION_CLIENT_BZIP2:
-         compress_suffix = ".bz2";
-         break;
-      case COMPRESSION_NONE:
-         compress_suffix = "";
-         break;
-      default:
-         pgmoneta_log_error("encryption_execute: Unknown compression type");
-         break;
+      compress_suffix = (char*)alg_suffix;
+   }
+   else
+   {
+      compress_suffix = "";
    }
 
    if (!(dir = opendir(d)))
@@ -328,31 +316,18 @@ pgmoneta_encrypt_wal_file(char* d, char* f)
    char* to = NULL;
    char* compress_suffix = NULL;
    struct main_configuration* config;
+   const char* alg_suffix = NULL;
 
    config = (struct main_configuration*)shmem;
-   switch (config->compression_type)
+
+   pgmoneta_compression_get_suffix(config->compression_type, &alg_suffix);
+   if (alg_suffix != NULL)
    {
-      case COMPRESSION_CLIENT_GZIP:
-      case COMPRESSION_SERVER_GZIP:
-         compress_suffix = ".gz";
-         break;
-      case COMPRESSION_CLIENT_ZSTD:
-      case COMPRESSION_SERVER_ZSTD:
-         compress_suffix = ".zstd";
-         break;
-      case COMPRESSION_CLIENT_LZ4:
-      case COMPRESSION_SERVER_LZ4:
-         compress_suffix = ".lz4";
-         break;
-      case COMPRESSION_CLIENT_BZIP2:
-         compress_suffix = ".bz2";
-         break;
-      case COMPRESSION_NONE:
-         compress_suffix = "";
-         break;
-      default:
-         pgmoneta_log_error("encryption_execute: Unknown compression type");
-         break;
+      compress_suffix = (char*)alg_suffix;
+   }
+   else
+   {
+      compress_suffix = "";
    }
 
    from = NULL;

--- a/src/libpgmoneta/archive.c
+++ b/src/libpgmoneta/archive.c
@@ -52,7 +52,6 @@
 
 #define NAME "archive"
 
-static bool is_server_side_compression(void);
 static const char* basebackup_archive_extension(void);
 
 void
@@ -558,7 +557,8 @@ pgmoneta_receive_archive_stream(int srv, SSL* ssl, int socket, struct stream_buf
                // append two blocks of null buffer and extract the tar file
                if (file != NULL)
                {
-                  if ((!is_server_side_compression()) && fwrite(null_buffer, 2 * 512, 1, file) != 1)
+                  struct main_configuration* config = (struct main_configuration*)shmem;
+                  if (!COMPRESSION_IS_SERVER(config->compression_type) && fwrite(null_buffer, 2 * 512, 1, file) != 1)
                   {
                      pgmoneta_log_error("could not write to file %s", file_path);
                      fflush(file);
@@ -644,7 +644,8 @@ pgmoneta_receive_archive_stream(int srv, SSL* ssl, int socket, struct stream_buf
                // start of manifest, finish off previous data archive receiving
                if (file != NULL)
                {
-                  if ((!is_server_side_compression()) && fwrite(null_buffer, 2 * 512, 1, file) != 1)
+                  struct main_configuration* config = (struct main_configuration*)shmem;
+                  if (!COMPRESSION_IS_SERVER(config->compression_type) && fwrite(null_buffer, 2 * 512, 1, file) != 1)
                   {
                      pgmoneta_log_error("could not write to file %s", file_path);
                      fflush(file);
@@ -840,7 +841,7 @@ pgmoneta_extract_backup_tar_file(char* file_path, char* destination, struct art*
    a = archive_read_new();
    archive_read_support_format_tar(a);
 
-   if (is_server_side_compression())
+   if (COMPRESSION_IS_SERVER(config->compression_type))
    {
       if (pgmoneta_vfile_create_local(file_path, "r", &reader))
       {
@@ -1058,17 +1059,6 @@ error:
    pgmoneta_hasher_destroy(hasher);
    free(entry_path_cpy);
    return 1;
-}
-
-static bool
-is_server_side_compression(void)
-{
-   struct main_configuration* config;
-
-   config = (struct main_configuration*)shmem;
-   return config->compression_type == COMPRESSION_SERVER_GZIP ||
-          config->compression_type == COMPRESSION_SERVER_LZ4 ||
-          config->compression_type == COMPRESSION_SERVER_ZSTD;
 }
 
 static const char*

--- a/src/libpgmoneta/compresssion.c
+++ b/src/libpgmoneta/compresssion.c
@@ -92,19 +92,17 @@ int
 pgmoneta_compressor_create(int compression_type, struct compressor** compressor)
 {
    *compressor = NULL;
-   switch (compression_type)
+   switch (COMPRESSION_ALGORITHM(compression_type))
    {
-      case COMPRESSION_CLIENT_ZSTD:
-      case COMPRESSION_SERVER_ZSTD:
+      case COMPRESSION_ALG_ZSTD:
          return pgmoneta_zstd_compressor_create(compressor);
-      case COMPRESSION_CLIENT_LZ4:
-      case COMPRESSION_SERVER_LZ4:
+      case COMPRESSION_ALG_LZ4:
          return pgmoneta_lz4_compressor_create(compressor);
-      case COMPRESSION_CLIENT_BZIP2:
+      case COMPRESSION_ALG_BZIP2:
          return pgmoneta_bzip2_compressor_create(compressor);
-      case COMPRESSION_CLIENT_GZIP:
-      case COMPRESSION_SERVER_GZIP:
+      case COMPRESSION_ALG_GZIP:
          return pgmoneta_gzip_compressor_create(compressor);
+      case COMPRESSION_ALG_NONE:
       default:
          return create_noop_compressor(compressor);
    }
@@ -170,6 +168,141 @@ pgmoneta_compressor_destroy(struct compressor* compressor)
    }
    compressor->close(compressor);
    free(compressor);
+}
+
+int
+pgmoneta_compression_get_suffix(int type, const char** suffix)
+{
+   if (suffix == NULL)
+   {
+      return 1;
+   }
+
+   *suffix = NULL;
+
+   switch (COMPRESSION_ALGORITHM(type))
+   {
+      case COMPRESSION_ALG_GZIP:
+         *suffix = ".gz";
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         *suffix = ".zstd";
+         break;
+      case COMPRESSION_ALG_LZ4:
+         *suffix = ".lz4";
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         *suffix = ".bz2";
+         break;
+      case COMPRESSION_ALG_NONE:
+      default:
+         break;
+   }
+
+   return 0;
+}
+
+int
+pgmoneta_compression_get_level(int type, int* level)
+{
+   if (level == NULL)
+   {
+      return 1;
+   }
+
+   switch (COMPRESSION_ALGORITHM(type))
+   {
+      case COMPRESSION_ALG_GZIP:
+         if (*level < 1)
+         {
+            *level = 1;
+         }
+         else if (*level > 9)
+         {
+            *level = 9;
+         }
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         if (*level < -131072)
+         {
+            *level = -131072;
+         }
+         else if (*level > 22)
+         {
+            *level = 22;
+         }
+         break;
+      case COMPRESSION_ALG_LZ4:
+         if (*level < 1)
+         {
+            *level = 1;
+         }
+         else if (*level > 12)
+         {
+            *level = 12;
+         }
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         if (*level < 1)
+         {
+            *level = 1;
+         }
+         else if (*level > 9)
+         {
+            *level = 9;
+         }
+         break;
+      case COMPRESSION_ALG_NONE:
+      default:
+         break;
+   }
+
+   return 0;
+}
+
+int
+pgmoneta_compression_trim_suffix(char* str, int compression_type, int encryption, char** result)
+{
+   char* res = NULL;
+   char* tmp = NULL;
+   const char* alg_suffix = NULL;
+
+   if (str == NULL || result == NULL)
+   {
+      return 1;
+   }
+
+   *result = NULL;
+
+   /* Start with a copy of the original string */
+   res = pgmoneta_append(NULL, str);
+   if (res == NULL)
+   {
+      return 1;
+   }
+
+   /* Strip the compression algorithm suffix, if any */
+   if (!pgmoneta_compression_get_suffix(compression_type, &alg_suffix) && alg_suffix != NULL)
+   {
+      if (pgmoneta_ends_with(res, (char*)alg_suffix))
+      {
+         tmp = pgmoneta_remove_suffix(res, (char*)alg_suffix);
+         free(res);
+         res = tmp;
+      }
+   }
+
+   /* Strip encryption suffix if present */
+   if (encryption != ENCRYPTION_NONE && pgmoneta_ends_with(res, ".aes"))
+   {
+      tmp = pgmoneta_remove_suffix(res, ".aes");
+      free(res);
+      res = tmp;
+   }
+
+   *result = res;
+
+   return 0;
 }
 
 static int

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -29,6 +29,7 @@
 /* pgmoneta */
 #include <pgmoneta.h>
 #include <aes.h>
+#include <compression.h>
 #include <configuration.h>
 #include <logging.h>
 #include <management.h>
@@ -1882,50 +1883,7 @@ pgmoneta_validate_main_configuration(void* shm)
       return 1;
    }
 
-   if (config->compression_type == COMPRESSION_CLIENT_GZIP || config->compression_type == COMPRESSION_SERVER_GZIP)
-   {
-      if (config->compression_level < 1)
-      {
-         config->compression_level = 1;
-      }
-      else if (config->compression_level > 9)
-      {
-         config->compression_level = 9;
-      }
-   }
-   else if (config->compression_type == COMPRESSION_CLIENT_ZSTD || config->compression_type == COMPRESSION_SERVER_ZSTD)
-   {
-      if (config->compression_level < -131072)
-      {
-         config->compression_level = -131072;
-      }
-      else if (config->compression_level > 22)
-      {
-         config->compression_level = 22;
-      }
-   }
-   else if (config->compression_type == COMPRESSION_CLIENT_LZ4 || config->compression_type == COMPRESSION_SERVER_LZ4)
-   {
-      if (config->compression_level < 1)
-      {
-         config->compression_level = 1;
-      }
-      else if (config->compression_level > 12)
-      {
-         config->compression_level = 12;
-      }
-   }
-   else if (config->compression_type == COMPRESSION_CLIENT_BZIP2)
-   {
-      if (config->compression_level < 1)
-      {
-         config->compression_level = 1;
-      }
-      else if (config->compression_level > 9)
-      {
-         config->compression_level = 9;
-      }
-   }
+   pgmoneta_compression_get_level(config->compression_type, &config->compression_level);
 
    if (config->workers < 0)
    {

--- a/src/libpgmoneta/info.c
+++ b/src/libpgmoneta/info.c
@@ -77,6 +77,9 @@ split_file_path(char* path, char** relative_path, char** bare_file_name);
 static void
 write_info(FILE* sfile, const char* fmt, ...);
 
+static int
+migrate_compression_value(int compression);
+
 static void
 create_info(char* directory, char* label, int status);
 
@@ -686,7 +689,7 @@ pgmoneta_load_info(char* directory, char* identifier, struct backup** backup)
          }
          else if (pgmoneta_starts_with(&key[0], INFO_COMPRESSION))
          {
-            bck->compression = atoi(&value[0]);
+            bck->compression = migrate_compression_value(atoi(&value[0]));
          }
          else if (pgmoneta_starts_with(&key[0], INFO_ENCRYPTION))
          {
@@ -1780,6 +1783,7 @@ file_final_name(char* file, int encryption, int compression, char** finalname)
    final = pgmoneta_append(final, file);
    {
       char* suffix = NULL;
+
       if (pgmoneta_extraction_get_suffix(compression, encryption, &suffix))
       {
          goto error;
@@ -1787,8 +1791,8 @@ file_final_name(char* file, int encryption, int compression, char** finalname)
       if (suffix != NULL)
       {
          final = pgmoneta_append(final, suffix);
-         free(suffix);
       }
+      free(suffix);
    }
 
    *finalname = final;
@@ -1843,6 +1847,22 @@ split_file_path(char* path, char** relative_path, char** bare_file_name)
 error:
    free(path_copy);
    return 1;
+}
+
+static int
+migrate_compression_value(int compression)
+{
+   switch (compression)
+   {
+      case 5:
+         return COMPRESSION_SERVER_GZIP;
+      case 6:
+         return COMPRESSION_SERVER_ZSTD;
+      case 7:
+         return COMPRESSION_SERVER_LZ4;
+      default:
+         return compression;
+   }
 }
 
 static void

--- a/src/libpgmoneta/link.c
+++ b/src/libpgmoneta/link.c
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <compression.h>
 #include <link.h>
 #include <logging.h>
 #include <utils.h>
@@ -481,44 +482,28 @@ do_comparefiles(struct worker_common* wc)
 static char*
 trim_suffix(char* str)
 {
-   char* res = NULL;
    struct main_configuration* config;
 
-   config = (struct main_configuration*)shmem;
-   int len = 0;
    if (str == NULL)
    {
       return NULL;
    }
-   len = strlen(str) + 1;
 
-   if (!pgmoneta_compare_string(str, "backup_label") &&
-       !pgmoneta_compare_string(str, "backup_manifest"))
+   config = (struct main_configuration*)shmem;
+
+   /* Special files should not have their suffixes trimmed */
+   if (pgmoneta_compare_string(str, "backup_label") ||
+       pgmoneta_compare_string(str, "backup_manifest"))
    {
-      switch (config->compression_type)
-      {
-         case COMPRESSION_CLIENT_GZIP:
-         case COMPRESSION_SERVER_GZIP:
-            len -= 3;
-            break;
-         case COMPRESSION_CLIENT_ZSTD:
-         case COMPRESSION_SERVER_ZSTD:
-            len -= 5;
-            break;
-         case COMPRESSION_CLIENT_LZ4:
-         case COMPRESSION_SERVER_LZ4:
-         case COMPRESSION_CLIENT_BZIP2:
-            len -= 4;
-            break;
-      }
-      if (config->encryption != ENCRYPTION_NONE)
-      {
-         len -= 4;
-      }
+      return pgmoneta_append(NULL, str);
    }
 
-   res = malloc(len);
-   memset(res, 0, len);
-   memcpy(res, str, len - 1);
+   char* res = NULL;
+
+   if (pgmoneta_compression_trim_suffix(str, config->compression_type, config->encryption, &res))
+   {
+      return NULL;
+   }
+
    return res;
 }

--- a/src/libpgmoneta/message.c
+++ b/src/libpgmoneta/message.c
@@ -843,26 +843,26 @@ pgmoneta_create_base_backup_message(int server_version, bool incremental, char* 
          options = pgmoneta_append(options, ", ");
       }
 
-      if (compression == COMPRESSION_SERVER_GZIP)
+      switch (compression)
       {
-         options = pgmoneta_append(options, "COMPRESSION 'gzip', ");
-         options = pgmoneta_append(options, "COMPRESSION_DETAIL 'level=");
-         options = pgmoneta_append_int(options, compression_level);
-         options = pgmoneta_append(options, "', ");
-      }
-      else if (compression == COMPRESSION_SERVER_ZSTD)
-      {
-         options = pgmoneta_append(options, "COMPRESSION 'zstd', ");
-         options = pgmoneta_append(options, "COMPRESSION_DETAIL 'level=");
-         options = pgmoneta_append_int(options, compression_level);
-         options = pgmoneta_append(options, ",workers=4', ");
-      }
-      else if (compression == COMPRESSION_SERVER_LZ4)
-      {
-         options = pgmoneta_append(options, "COMPRESSION 'lz4', ");
-         options = pgmoneta_append(options, "COMPRESSION_DETAIL 'level=");
-         options = pgmoneta_append_int(options, compression_level);
-         options = pgmoneta_append(options, "', ");
+         case COMPRESSION_SERVER_GZIP:
+            options = pgmoneta_append(options, "COMPRESSION 'gzip', ");
+            options = pgmoneta_append(options, "COMPRESSION_DETAIL 'level=");
+            options = pgmoneta_append_int(options, compression_level);
+            options = pgmoneta_append(options, "', ");
+            break;
+         case COMPRESSION_SERVER_ZSTD:
+            options = pgmoneta_append(options, "COMPRESSION 'zstd', ");
+            options = pgmoneta_append(options, "COMPRESSION_DETAIL 'level=");
+            options = pgmoneta_append_int(options, compression_level);
+            options = pgmoneta_append(options, ",workers=4', ");
+            break;
+         case COMPRESSION_SERVER_LZ4:
+            options = pgmoneta_append(options, "COMPRESSION 'lz4', ");
+            options = pgmoneta_append(options, "COMPRESSION_DETAIL 'level=");
+            options = pgmoneta_append_int(options, compression_level);
+            options = pgmoneta_append(options, "', ");
+            break;
       }
 
       if (progress)

--- a/src/libpgmoneta/stream.c
+++ b/src/libpgmoneta/stream.c
@@ -30,6 +30,7 @@
 #include <aes.h>
 #include <compression.h>
 #include <deque.h>
+#include <extraction.h>
 #include <logging.h>
 #include <stream.h>
 #include <utils.h>
@@ -354,39 +355,26 @@ static int
 get_backup_file_name_cb(struct streamer* this, char* file_name, char** dest_file_name)
 {
    char* dest = NULL;
+   char* suffix = NULL;
    if (this == NULL || file_name == NULL)
    {
       goto error;
    }
    dest = pgmoneta_append(dest, file_name);
-   switch (this->compression)
+   if (pgmoneta_extraction_get_suffix(this->compression, this->encryption, &suffix))
    {
-      case COMPRESSION_CLIENT_ZSTD:
-      case COMPRESSION_SERVER_ZSTD:
-         dest = pgmoneta_append(dest, ".zstd");
-         break;
-      case COMPRESSION_CLIENT_GZIP:
-      case COMPRESSION_SERVER_GZIP:
-         dest = pgmoneta_append(dest, ".gz");
-         break;
-      case COMPRESSION_SERVER_LZ4:
-      case COMPRESSION_CLIENT_LZ4:
-         dest = pgmoneta_append(dest, ".lz4");
-         break;
-      case COMPRESSION_CLIENT_BZIP2:
-         dest = pgmoneta_append(dest, ".bz2");
-         break;
-      default:
-         break;
+      goto error;
    }
-   if (this->encryption != ENCRYPTION_NONE)
+   if (suffix != NULL)
    {
-      dest = pgmoneta_append(dest, ".aes");
+      dest = pgmoneta_append(dest, suffix);
+      free(suffix);
    }
    *dest_file_name = dest;
    return 0;
 error:
    free(dest);
+   free(suffix);
    return 1;
 }
 

--- a/src/libpgmoneta/wal.c
+++ b/src/libpgmoneta/wal.c
@@ -1759,49 +1759,48 @@ retry:
       {
          d = pgmoneta_get_server_wal(srv);
 
-         if (config->compression_type == COMPRESSION_CLIENT_GZIP || config->compression_type == COMPRESSION_SERVER_GZIP)
+         switch (COMPRESSION_ALGORITHM(config->compression_type))
          {
-            if (scan)
-            {
-               pgmoneta_gzip_wal(d);
-            }
-            else
-            {
-               pgmoneta_gzip_wal_file(d, wal_file);
-            }
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_ZSTD || config->compression_type == COMPRESSION_SERVER_ZSTD)
-         {
-            if (scan)
-            {
-               pgmoneta_zstandardc_wal(d);
-            }
-            else
-            {
-               pgmoneta_zstandardc_wal_file(d, wal_file);
-            }
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_LZ4 || config->compression_type == COMPRESSION_SERVER_LZ4)
-         {
-            if (scan)
-            {
-               pgmoneta_lz4c_wal(d);
-            }
-            else
-            {
-               pgmoneta_lz4c_wal_file(d, wal_file);
-            }
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_BZIP2)
-         {
-            if (scan)
-            {
-               pgmoneta_bzip2_wal(d);
-            }
-            else
-            {
-               pgmoneta_bzip2_wal_file(d, wal_file);
-            }
+            case COMPRESSION_ALG_GZIP:
+               if (scan)
+               {
+                  pgmoneta_gzip_wal(d);
+               }
+               else
+               {
+                  pgmoneta_gzip_wal_file(d, wal_file);
+               }
+               break;
+            case COMPRESSION_ALG_ZSTD:
+               if (scan)
+               {
+                  pgmoneta_zstandardc_wal(d);
+               }
+               else
+               {
+                  pgmoneta_zstandardc_wal_file(d, wal_file);
+               }
+               break;
+            case COMPRESSION_ALG_LZ4:
+               if (scan)
+               {
+                  pgmoneta_lz4c_wal(d);
+               }
+               else
+               {
+                  pgmoneta_lz4c_wal_file(d, wal_file);
+               }
+               break;
+            case COMPRESSION_ALG_BZIP2:
+               if (scan)
+               {
+                  pgmoneta_bzip2_wal(d);
+               }
+               else
+               {
+                  pgmoneta_bzip2_wal_file(d, wal_file);
+               }
+               break;
          }
 
          if (config->encryption != ENCRYPTION_NONE)

--- a/src/libpgmoneta/wf_encryption.c
+++ b/src/libpgmoneta/wf_encryption.c
@@ -29,6 +29,7 @@
 /* pgmoneta */
 #include <pgmoneta.h>
 #include <aes.h>
+#include <compression.h>
 #include <logging.h>
 #include <utils.h>
 #include <workflow.h>
@@ -156,29 +157,16 @@ encryption_execute(char* name __attribute__((unused)), struct art* nodes)
    }
    else
    {
-      switch (config->compression_type)
+      const char* alg_suffix = NULL;
+
+      pgmoneta_compression_get_suffix(config->compression_type, &alg_suffix);
+      if (alg_suffix != NULL)
       {
-         case COMPRESSION_CLIENT_GZIP:
-         case COMPRESSION_SERVER_GZIP:
-            compress_suffix = ".gz";
-            break;
-         case COMPRESSION_CLIENT_ZSTD:
-         case COMPRESSION_SERVER_ZSTD:
-            compress_suffix = ".zstd";
-            break;
-         case COMPRESSION_CLIENT_LZ4:
-         case COMPRESSION_SERVER_LZ4:
-            compress_suffix = ".lz4";
-            break;
-         case COMPRESSION_CLIENT_BZIP2:
-            compress_suffix = ".bz2";
-            break;
-         case COMPRESSION_NONE:
-            compress_suffix = "";
-            break;
-         default:
-            pgmoneta_log_error("encryption_execute: Unknown compression type");
-            break;
+         compress_suffix = (char*)alg_suffix;
+      }
+      else
+      {
+         compress_suffix = "";
       }
 
       d = pgmoneta_append(d, tarfile);

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -518,25 +518,24 @@ wf_restore(struct backup* backup)
       current = current->next;
    }
 
-   if (backup->compression == COMPRESSION_CLIENT_GZIP || backup->compression == COMPRESSION_SERVER_GZIP)
+   switch (COMPRESSION_ALGORITHM(backup->compression))
    {
-      current->next = pgmoneta_create_gzip(false);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_ZSTD || backup->compression == COMPRESSION_SERVER_ZSTD)
-   {
-      current->next = pgmoneta_create_zstd(false);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_LZ4 || backup->compression == COMPRESSION_SERVER_LZ4)
-   {
-      current->next = pgmoneta_create_lz4(false);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_BZIP2)
-   {
-      current->next = pgmoneta_create_bzip2(false);
-      current = current->next;
+      case COMPRESSION_ALG_GZIP:
+         current->next = pgmoneta_create_gzip(false);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         current->next = pgmoneta_create_zstd(false);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_LZ4:
+         current->next = pgmoneta_create_lz4(false);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         current->next = pgmoneta_create_bzip2(false);
+         current = current->next;
+         break;
    }
 
    current->next = pgmoneta_create_copy_wal();
@@ -626,25 +625,24 @@ wf_post_rollup(struct backup* backup)
    current->next = pgmoneta_storage_create_local();
    current = current->next;
 
-   if (backup->compression == COMPRESSION_CLIENT_GZIP || backup->compression == COMPRESSION_SERVER_GZIP)
+   switch (COMPRESSION_ALGORITHM(backup->compression))
    {
-      current->next = pgmoneta_create_gzip(true);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_ZSTD || backup->compression == COMPRESSION_SERVER_ZSTD)
-   {
-      current->next = pgmoneta_create_zstd(true);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_LZ4 || backup->compression == COMPRESSION_SERVER_LZ4)
-   {
-      current->next = pgmoneta_create_lz4(true);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_BZIP2)
-   {
-      current->next = pgmoneta_create_bzip2(true);
-      current = current->next;
+      case COMPRESSION_ALG_GZIP:
+         current->next = pgmoneta_create_gzip(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         current->next = pgmoneta_create_zstd(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_LZ4:
+         current->next = pgmoneta_create_lz4(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         current->next = pgmoneta_create_bzip2(true);
+         current = current->next;
+         break;
    }
 
    if (backup->encryption != ENCRYPTION_NONE)
@@ -729,25 +727,24 @@ wf_incremental_backup(void)
    current->next = pgmoneta_create_hot_standby();
    current = current->next;
 
-   if (config->compression_type == COMPRESSION_CLIENT_GZIP || config->compression_type == COMPRESSION_SERVER_GZIP)
+   switch (COMPRESSION_ALGORITHM(config->compression_type))
    {
-      current->next = pgmoneta_create_gzip(true);
-      current = current->next;
-   }
-   else if (config->compression_type == COMPRESSION_CLIENT_ZSTD || config->compression_type == COMPRESSION_SERVER_ZSTD)
-   {
-      current->next = pgmoneta_create_zstd(true);
-      current = current->next;
-   }
-   else if (config->compression_type == COMPRESSION_CLIENT_LZ4 || config->compression_type == COMPRESSION_SERVER_LZ4)
-   {
-      current->next = pgmoneta_create_lz4(true);
-      current = current->next;
-   }
-   else if (config->compression_type == COMPRESSION_CLIENT_BZIP2)
-   {
-      current->next = pgmoneta_create_bzip2(true);
-      current = current->next;
+      case COMPRESSION_ALG_GZIP:
+         current->next = pgmoneta_create_gzip(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         current->next = pgmoneta_create_zstd(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_LZ4:
+         current->next = pgmoneta_create_lz4(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         current->next = pgmoneta_create_bzip2(true);
+         current = current->next;
+         break;
    }
 
    if (config->encryption != ENCRYPTION_NONE)
@@ -816,25 +813,24 @@ wf_verify(struct backup* backup)
       current = current->next;
    }
 
-   if (backup->compression == COMPRESSION_CLIENT_GZIP || backup->compression == COMPRESSION_SERVER_GZIP)
+   switch (COMPRESSION_ALGORITHM(backup->compression))
    {
-      current->next = pgmoneta_create_gzip(false);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_ZSTD || backup->compression == COMPRESSION_SERVER_ZSTD)
-   {
-      current->next = pgmoneta_create_zstd(false);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_LZ4 || backup->compression == COMPRESSION_SERVER_LZ4)
-   {
-      current->next = pgmoneta_create_lz4(false);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_BZIP2)
-   {
-      current->next = pgmoneta_create_bzip2(false);
-      current = current->next;
+      case COMPRESSION_ALG_GZIP:
+         current->next = pgmoneta_create_gzip(false);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         current->next = pgmoneta_create_zstd(false);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_LZ4:
+         current->next = pgmoneta_create_lz4(false);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         current->next = pgmoneta_create_bzip2(false);
+         current = current->next;
+         break;
    }
 
    current->next = pgmoneta_restore_excluded_files();
@@ -870,27 +866,24 @@ wf_archive(struct backup* backup)
    head = pgmoneta_create_archive();
    current = head;
 
-   if (backup->compression == COMPRESSION_CLIENT_GZIP || backup->compression == COMPRESSION_SERVER_GZIP)
+   switch (COMPRESSION_ALGORITHM(backup->compression))
    {
-      current->next = pgmoneta_create_gzip(true);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_ZSTD || backup->compression == COMPRESSION_SERVER_ZSTD)
-   {
-      current->next = pgmoneta_create_zstd(true);
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_LZ4 || backup->compression == COMPRESSION_SERVER_LZ4)
-   {
-      current->next = pgmoneta_create_lz4(true);
-
-      current = current->next;
-   }
-   else if (backup->compression == COMPRESSION_CLIENT_BZIP2)
-   {
-      current->next = pgmoneta_create_bzip2(true);
-
-      current = current->next;
+      case COMPRESSION_ALG_GZIP:
+         current->next = pgmoneta_create_gzip(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_ZSTD:
+         current->next = pgmoneta_create_zstd(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_LZ4:
+         current->next = pgmoneta_create_lz4(true);
+         current = current->next;
+         break;
+      case COMPRESSION_ALG_BZIP2:
+         current->next = pgmoneta_create_bzip2(true);
+         current = current->next;
+         break;
    }
 
    if (backup->encryption != ENCRYPTION_NONE)

--- a/src/main.c
+++ b/src/main.c
@@ -1753,30 +1753,28 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
          pgmoneta_json_clone(payload, &pyl);
 
-         if (config->compression_type == COMPRESSION_CLIENT_GZIP || config->compression_type == COMPRESSION_SERVER_GZIP)
+         switch (COMPRESSION_ALGORITHM(config->compression_type))
          {
-            pgmoneta_set_proc_title(1, ai->argv, "decompress/gzip", NULL);
-            pgmoneta_gunzip_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_ZSTD || config->compression_type == COMPRESSION_SERVER_ZSTD)
-         {
-            pgmoneta_set_proc_title(1, ai->argv, "decompress/zstd", NULL);
-            pgmoneta_zstandardd_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_LZ4 || config->compression_type == COMPRESSION_SERVER_LZ4)
-         {
-            pgmoneta_set_proc_title(1, ai->argv, "decompress/lz4", NULL);
-            pgmoneta_lz4d_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_BZIP2)
-         {
-            pgmoneta_set_proc_title(1, ai->argv, "decompress/bz2", NULL);
-            pgmoneta_bunzip2_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else
-         {
-            pgmoneta_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_DECOMPRESS_UNKNOWN, NAME, compression, encryption, payload);
-            pgmoneta_log_error("Decompress: Unknown compression (%d)", MANAGEMENT_ERROR_DECOMPRESS_NOFORK);
+            case COMPRESSION_ALG_GZIP:
+               pgmoneta_set_proc_title(1, ai->argv, "decompress/gzip", NULL);
+               pgmoneta_gunzip_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            case COMPRESSION_ALG_ZSTD:
+               pgmoneta_set_proc_title(1, ai->argv, "decompress/zstd", NULL);
+               pgmoneta_zstandardd_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            case COMPRESSION_ALG_LZ4:
+               pgmoneta_set_proc_title(1, ai->argv, "decompress/lz4", NULL);
+               pgmoneta_lz4d_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            case COMPRESSION_ALG_BZIP2:
+               pgmoneta_set_proc_title(1, ai->argv, "decompress/bz2", NULL);
+               pgmoneta_bunzip2_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            default:
+               pgmoneta_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_DECOMPRESS_UNKNOWN, NAME, compression, encryption, payload);
+               pgmoneta_log_error("Decompress: Unknown compression (%d)", MANAGEMENT_ERROR_DECOMPRESS_NOFORK);
+               break;
          }
       }
    }
@@ -1797,30 +1795,28 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
          pgmoneta_json_clone(payload, &pyl);
 
-         if (config->compression_type == COMPRESSION_CLIENT_GZIP || config->compression_type == COMPRESSION_SERVER_GZIP)
+         switch (COMPRESSION_ALGORITHM(config->compression_type))
          {
-            pgmoneta_set_proc_title(1, ai->argv, "compress/gzip", NULL);
-            pgmoneta_gzip_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_ZSTD || config->compression_type == COMPRESSION_SERVER_ZSTD)
-         {
-            pgmoneta_set_proc_title(1, ai->argv, "compress/zstd", NULL);
-            pgmoneta_zstandardc_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_LZ4 || config->compression_type == COMPRESSION_SERVER_LZ4)
-         {
-            pgmoneta_set_proc_title(1, ai->argv, "compress/lz4", NULL);
-            pgmoneta_lz4c_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else if (config->compression_type == COMPRESSION_CLIENT_BZIP2)
-         {
-            pgmoneta_set_proc_title(1, ai->argv, "compress/bz2", NULL);
-            pgmoneta_bzip2_request(NULL, client_fd, compression, encryption, pyl);
-         }
-         else
-         {
-            pgmoneta_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_COMPRESS_UNKNOWN, NAME, compression, encryption, payload);
-            pgmoneta_log_error("Compress: Unknown compression (%d)", MANAGEMENT_ERROR_DECOMPRESS_NOFORK);
+            case COMPRESSION_ALG_GZIP:
+               pgmoneta_set_proc_title(1, ai->argv, "compress/gzip", NULL);
+               pgmoneta_gzip_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            case COMPRESSION_ALG_ZSTD:
+               pgmoneta_set_proc_title(1, ai->argv, "compress/zstd", NULL);
+               pgmoneta_zstandardc_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            case COMPRESSION_ALG_LZ4:
+               pgmoneta_set_proc_title(1, ai->argv, "compress/lz4", NULL);
+               pgmoneta_lz4c_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            case COMPRESSION_ALG_BZIP2:
+               pgmoneta_set_proc_title(1, ai->argv, "compress/bz2", NULL);
+               pgmoneta_bzip2_request(NULL, client_fd, compression, encryption, pyl);
+               break;
+            default:
+               pgmoneta_management_response_error(NULL, client_fd, NULL, MANAGEMENT_ERROR_COMPRESS_UNKNOWN, NAME, compression, encryption, payload);
+               pgmoneta_log_error("Compress: Unknown compression (%d)", MANAGEMENT_ERROR_DECOMPRESS_NOFORK);
+               break;
          }
       }
    }
@@ -2953,9 +2949,7 @@ init_replication_slot(int server)
             goto server_done;
          }
 
-         if (config->common.servers[server].version < 15 && (config->compression_type == COMPRESSION_SERVER_GZIP ||
-                                                             config->compression_type == COMPRESSION_SERVER_ZSTD ||
-                                                             config->compression_type == COMPRESSION_SERVER_LZ4))
+         if (config->common.servers[server].version < 15 && COMPRESSION_IS_SERVER(config->compression_type))
          {
             pgmoneta_log_error("PostgreSQL 15 or higher is required for server %s for server side compression",
                                config->common.servers[server].name);


### PR DESCRIPTION
- closes #956 

**changes**: 
- Redefine compression constants as bitmask (bit 4 = server, bits 0-3 = algorithm)
- Add `COMPRESSION_IS_SERVER()`, `COMPRESSION_ALGORITHM()` helper macros
- Replace all `if`/`else if` chains with switch (`COMPRESSION_ALGORITHM()`)
- Remove `is_server_side_compression()` function, use macro instead