### PR TITLE
robust memory cleanup in error paths

### DIFF
--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -470,6 +470,10 @@ pgmoneta_encrypt_file(char* from, char* to)
 
    if (encrypt_file(from, to, 1) != 0)
    {
+      if (flag)
+      {
+         free(to);
+      }
       return 1;
    }
 

--- a/src/libpgmoneta/walfile.c
+++ b/src/libpgmoneta/walfile.c
@@ -321,46 +321,55 @@ pgmoneta_destroy_walfile(struct walfile* wf)
       return;
    }
 
-   if (pgmoneta_deque_iterator_create(wf->records, &record_iterator) || pgmoneta_deque_iterator_create(wf->page_headers, &page_header_iterator))
+   /* Cleanup records - only if deque was initialized */
+   if (wf->records != NULL)
    {
-      return;
+      if (pgmoneta_deque_iterator_create(wf->records, &record_iterator) == 0)
+      {
+         while (pgmoneta_deque_iterator_next(record_iterator))
+         {
+            struct decoded_xlog_record* record = (struct decoded_xlog_record*)record_iterator->value->data;
+            if (record->partial)
+            {
+               free(record);
+               continue;
+            }
+            if (record->main_data != NULL)
+            {
+               free(record->main_data);
+            }
+            for (int i = 0; i <= record->max_block_id; i++)
+            {
+               if (record->blocks[i].has_data)
+               {
+                  free(record->blocks[i].data);
+               }
+               if (record->blocks[i].has_image)
+               {
+                  free(record->blocks[i].bkp_image);
+               }
+            }
+            free(record);
+         }
+         pgmoneta_deque_iterator_destroy(record_iterator);
+      }
+      pgmoneta_deque_destroy(wf->records);
    }
 
-   while (pgmoneta_deque_iterator_next(record_iterator))
+   /* Cleanup page headers - only if deque was initialized */
+   if (wf->page_headers != NULL)
    {
-      struct decoded_xlog_record* record = (struct decoded_xlog_record*)record_iterator->value->data;
-      if (record->partial)
+      if (pgmoneta_deque_iterator_create(wf->page_headers, &page_header_iterator) == 0)
       {
-         free(record);
-         continue;
-      }
-      if (record->main_data != NULL)
-      {
-         free(record->main_data);
-      }
-      for (int i = 0; i <= record->max_block_id; i++)
-      {
-         if (record->blocks[i].has_data)
+         while (pgmoneta_deque_iterator_next(page_header_iterator))
          {
-            free(record->blocks[i].data);
+            struct xlog_page_header_data* page_header = (struct xlog_page_header_data*)page_header_iterator->value->data;
+            free(page_header);
          }
-         if (record->blocks[i].has_image)
-         {
-            free(record->blocks[i].bkp_image);
-         }
+         pgmoneta_deque_iterator_destroy(page_header_iterator);
       }
-      free(record);
+      pgmoneta_deque_destroy(wf->page_headers);
    }
-   pgmoneta_deque_iterator_destroy(record_iterator);
-   pgmoneta_deque_destroy(wf->records);
-
-   while (pgmoneta_deque_iterator_next(page_header_iterator))
-   {
-      struct xlog_page_header_data* page_header = (struct xlog_page_header_data*)page_header_iterator->value->data;
-      free(page_header);
-   }
-   pgmoneta_deque_iterator_destroy(page_header_iterator);
-   pgmoneta_deque_destroy(wf->page_headers);
 
    free(wf->long_phd);
    free(wf);

--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -172,6 +172,7 @@ read_all_page_headers(FILE* file, struct xlog_long_page_header_data* long_header
       if (bytes_read != 1)
       {
          pgmoneta_log_error("Error: Failed to read the complete data");
+         free(page_header);
          goto error;
       }
       pgmoneta_deque_add(wal_file->page_headers, NULL, (uintptr_t)page_header, ValueRef);
@@ -275,6 +276,7 @@ pgmoneta_wal_parse_wal_file(char* path, int server, struct walfile* wal_file)
    uint32_t next_record;
    int page_number = 0;
    wal_file->long_phd = long_header;
+   long_header = NULL;
    read_all_page_headers(file, wal_file->long_phd, wal_file);
 
    if (xlog_from_file_name(basename(path), &tli, &logSegNo, wal_segz_bytes))
@@ -284,12 +286,12 @@ pgmoneta_wal_parse_wal_file(char* path, int server, struct walfile* wal_file)
    }
    XLOG_SEG_NO_OFFEST_TO_REC_PTR(logSegNo, 0, wal_segz_bytes, base);
 
-   if (long_header->std.xlp_rem_len > 0)
+   if (wal_file->long_phd->std.xlp_rem_len > 0)
    {
       next_record = MAXALIGN(
          ftell(file) +
-         ((long_header->std.xlp_rem_len / long_header->xlp_xlog_blcksz) * SIZE_OF_XLOG_SHORT_PHD) +
-         long_header->std.xlp_rem_len % long_header->xlp_xlog_blcksz);
+         ((wal_file->long_phd->std.xlp_rem_len / wal_file->long_phd->xlp_xlog_blcksz) * SIZE_OF_XLOG_SHORT_PHD) +
+         wal_file->long_phd->std.xlp_rem_len % wal_file->long_phd->xlp_xlog_blcksz);
 
       if (partial_record->xlog_record_bytes_read == 0)
       {
@@ -318,7 +320,6 @@ pgmoneta_wal_parse_wal_file(char* path, int server, struct walfile* wal_file)
    {
       next_record = SIZE_OF_XLOG_LONG_PHD;
    }
-   long_header = NULL;
    fseek(file, next_record, SEEK_SET);
    while (true)
    {
@@ -557,6 +558,7 @@ finish:
       decoded->next_lsn = lsn_array[idx++];
    }
 
+   decoded = (struct decoded_xlog_record*)pgmoneta_deque_peek_last(wal_file->records, NULL);
    if (decoded != NULL)
    {
       decoded->next_lsn = 0; // Handle last record
@@ -731,7 +733,8 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
                  blk->bimg_len == block_size))
             {
                pgmoneta_log_fatal(
-                  "BKPIMAGE_HAS_HOLE set, but hole offset %u length %u block image length %u at %X/%X");
+                  "BKPIMAGE_HAS_HOLE set, but hole offset %u length %u block image length %u at %s",
+                  blk->hole_offset, blk->hole_length, blk->bimg_len, pgmoneta_lsn_to_string(lsn));
                goto err;
             }
 
@@ -742,7 +745,8 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
             if (!(blk->bimg_info & BKPIMAGE_HAS_HOLE) &&
                 (blk->hole_offset != 0 || blk->hole_length != 0))
             {
-               pgmoneta_log_fatal("BKPIMAGE_HAS_HOLE not set, but hole offset %u length %u at %X/%X");
+               pgmoneta_log_fatal("BKPIMAGE_HAS_HOLE not set, but hole offset %u length %u at %s",
+                                  blk->hole_offset, blk->hole_length, pgmoneta_lsn_to_string(lsn));
                goto err;
             }
 
@@ -752,7 +756,8 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
             if (pgmoneta_wal_is_bkp_image_compressed(magic_value, blk->bimg_info) &&
                 blk->bimg_len == block_size)
             {
-               pgmoneta_log_fatal("BKPIMAGE_COMPRESSED set, but block image length %u at %X/%X");
+               pgmoneta_log_fatal("BKPIMAGE_COMPRESSED set, but block image length %u at %s",
+                                  blk->bimg_len, pgmoneta_lsn_to_string(lsn));
                goto err;
             }
 
@@ -765,7 +770,8 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
                 blk->bimg_len != block_size)
             {
                pgmoneta_log_fatal(
-                  "neither BKPIMAGE_HAS_HOLE nor BKPIMAGE_COMPRESSED set, but block image length is %u at %X/%X");
+                  "neither BKPIMAGE_HAS_HOLE nor BKPIMAGE_COMPRESSED set, but block image length is %u at %s",
+                  blk->bimg_len, pgmoneta_lsn_to_string(lsn));
                goto err;
             }
          }
@@ -778,7 +784,7 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
          {
             if (rlocator == NULL)
             {
-               pgmoneta_log_fatal("BKPBLOCK_SAME_REL set but no previous rel at %X/%X");
+               pgmoneta_log_fatal("BKPBLOCK_SAME_REL set but no previous rel at %s", pgmoneta_lsn_to_string(lsn));
                goto err;
             }
 
@@ -788,7 +794,7 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
       }
       else
       {
-         pgmoneta_log_fatal("Invalid block_id %u at %X/%X");
+         pgmoneta_log_fatal("Invalid block_id %u at %s", block_id, pgmoneta_lsn_to_string(lsn));
          goto err;
       }
    }

--- a/src/libpgmoneta/walfile/wal_summary.c
+++ b/src/libpgmoneta/walfile/wal_summary.c
@@ -111,6 +111,21 @@ pgmoneta_summarize_wal(int srv, char* dir, uint64_t start_lsn, uint64_t end_lsn,
 error:
    free(wal_dir);
    pgmoneta_brt_destroy(brt);
+
+   if (partial_record != NULL)
+   {
+      if (partial_record->xlog_record != NULL)
+      {
+         free(partial_record->xlog_record);
+      }
+      if (partial_record->data_buffer != NULL)
+      {
+         free(partial_record->data_buffer);
+      }
+      free(partial_record);
+      partial_record = NULL;
+   }
+
    return 1;
 }
 

--- a/test/testcases/test_wal_summary.c
+++ b/test/testcases/test_wal_summary.c
@@ -129,16 +129,31 @@ START_TEST(test_pgmoneta_wal_summary)
 
    /* Create summary directory in the base_dir of a server if not already present */
    summary_dir = pgmoneta_get_server_summary(PRIMARY_SERVER);
-   ck_assert_msg(!pgmoneta_mkdir(summary_dir), "failed to create %s directory", summary_dir);
+   if (pgmoneta_mkdir(summary_dir))
+   {
+      free(summary_dir);
+      ck_abort_msg("failed to create directory");
+   }
 
    wal_dir = pgmoneta_get_server_wal(PRIMARY_SERVER);
 
    ck_assert_int_ge(e_lsn, s_lsn);
    ret = !pgmoneta_summarize_wal(PRIMARY_SERVER, wal_dir, s_lsn, e_lsn, &brt);
-   ck_assert_msg(ret, "failed to summarize the wal");
+   if (!ret)
+   {
+      free(summary_dir);
+      free(wal_dir);
+      ck_abort_msg("failed to summarize the wal");
+   }
 
    ret = !pgmoneta_wal_summary_save(PRIMARY_SERVER, s_lsn, e_lsn, brt);
-   ck_assert_msg(ret, "failed to save the wal summary to disk");
+   if (!ret)
+   {
+      free(summary_dir);
+      free(wal_dir);
+      pgmoneta_brt_destroy(brt);
+      ck_abort_msg("failed to save the wal summary to disk");
+   }
 
    pgmoneta_brt_destroy(brt);
    pgmoneta_disconnect(srv_socket);


### PR DESCRIPTION
Refactored `pgmoneta_destroy_walfile` to independently check and destroy `wf->records` and `wf->page_headers`. The previous combined check would short-circuit if one deque failed to initialize, leaking the rest of the `struct walfile`.
Added comprehensive cleanup for the globally accessible `partial_record` structure in the `error:` path of `pgmoneta_summarize_wal`.
 Ensured the dynamically allocated destination path (`to`) is properly freed in `pgmoneta_encrypt_file`
 Fixed multiple pgmoneta_log_fatal calls in decode_xlog_record that had format specifiers (e.g., %u, %s) but were missing the corresponding variables.
 In pgmoneta_wal_parse_wal_file, explicitly transferred ownership of long_header to wal_file->long_phd and immediately nullified the local pointer (long_header = NULL). This prevents the local error-handling path from freeing the pointer while the caller simultaneously attempts to free it via pgmoneta_destroy_walfile. Updated subsequent math calculations to safely reference the struct.
 Added a missing free(page_header) in the early error-return path of read_all_page_headers
 Explicitly used pgmoneta_deque_peek_last in the finish: block to ensure the next_lsn termination logic is applied to the guaranteed last record, rather than relying on a potentially stale loop pointer.
 
 CI:
 Replaced ck_assert_msg with explicit conditional checks (if (!ret)) when summarizing and saving WALs. Because libcheck instantly aborts the thread on assertion failure, the previous code would skip downstream free() statements during slow I/O runs, triggering LeakSanitizer. Memory is now cleanly freed before ck_abort_msg is called.
 
 Edit: The C code is stable and free of ASan/LSan errors. The final CI failure is an llvm-cov zlib decompression error caused by an incomplete .profraw flush during test failures. The actual memory leaks and SEGVs are resolved.
 