### PR TITLE
[#902]   implement s3 delete command

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -480,17 +480,19 @@ Manage the s3 storage
 Command
 
 ```sh
-pgmoneta-cli s3 [ls] <server>
+pgmoneta-cli s3 <action> <arguments>
 ```
 
 Subcommand
 
 - `ls` : List all the files in s3
+- `delete` : Delete all files under a remote prefix in s3
 
 Example
 
 ```sh
 pgmoneta-cli s3 ls primary
+pgmoneta-cli s3 delete primary 20260302163357
 ```
 ### s3 ls
 
@@ -503,6 +505,19 @@ Examples
 ```sh
 pgmoneta-cli s3 ls primary
 pgmoneta-cli s3 ls
+```
+
+### s3 delete
+
+Delete all server files/objects in remote storage s3 under a given prefix.
+
+- prefix is relative to `<s3_base_dir>/<server>/backup/`
+
+Examples
+
+```sh
+pgmoneta-cli s3 delete primary 20260302163357/
+pgmoneta-cli s3 delete primary wal/
 ```
 ## clear
 

--- a/doc/S3.md
+++ b/doc/S3.md
@@ -131,6 +131,14 @@ pgmoneta-cli s3 ls primary
 
 `pgmoneta-cli s3 ls` lists objects recursively under the configured server path and returns all objects in one result set.
 
+Delete remote objects by prefix:
+
+```sh
+pgmoneta-cli s3 delete primary <prefix>
+```
+
+`pgmoneta-cli s3 delete` removes all objects under `<s3_base_dir>/<server>/backup/<prefix>`.
+
 ## Per-Server Configuration
 
 All S3 configuration settings can be specified within a server's configuration section. This allows you to use different S3 buckets, credentials, or even regions for different PostgreSQL servers.

--- a/doc/manual/en/05-cli.md
+++ b/doc/manual/en/05-cli.md
@@ -517,17 +517,19 @@ Manage the s3 storage
 Command
 
 ```sh
-pgmoneta-cli s3 [ls] <server>
+pgmoneta-cli s3 <action> <arguments>
 ```
 
 Subcommand
 
 - `ls` : List all the files in s3
+- `delete` : Delete all files under a remote prefix in s3
 
 Example
 
 ```sh
 pgmoneta-cli s3 ls primary
+pgmoneta-cli s3 delete primary 20260302163357
 ```
 
 ### s3 ls
@@ -541,6 +543,19 @@ Examples
 ```sh
 pgmoneta-cli s3 ls primary
 pgmoneta-cli s3 ls
+```
+
+### s3 delete
+
+Delete all server files/objects in remote storage s3 under a given prefix.
+
+- prefix is relative to `<s3_base_dir>/<server>/backup/`
+
+Examples
+
+```sh
+pgmoneta-cli s3 delete primary 20260302163357/
+pgmoneta-cli s3 delete primary wal/
 ```
 
 

--- a/doc/manual/en/17-s3.md
+++ b/doc/manual/en/17-s3.md
@@ -91,3 +91,11 @@ pgmoneta-cli s3 ls primary
 ```
 
 `pgmoneta-cli s3 ls` lists objects recursively in the configured remote path and prints all discovered objects in one output.
+
+Delete remote objects by prefix:
+
+``` sh
+pgmoneta-cli s3 delete primary <prefix>
+```
+
+`pgmoneta-cli s3 delete` removes all objects under `<s3_base_dir>/<server>/backup/<prefix>`.

--- a/src/cli.c
+++ b/src/cli.c
@@ -102,6 +102,7 @@ static void help_restore(void);
 static void help_verify(void);
 static void help_archive(void);
 static void help_delete(void);
+static void help_s3(void);
 static void help_retain(void);
 static void help_expunge(void);
 static void help_decrypt(void);
@@ -122,6 +123,7 @@ static void display_helper(char* command);
 static int backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, char* incremental, int32_t output_format);
 static int list_backup(SSL* ssl, int socket, char* server, char* sort_order, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int list_s3_objects(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int delete_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int restore(SSL* ssl, int socket, char* server, char* backup_id, char* position, char* directory, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int verify(SSL* ssl, int socket, char* server, char* backup_id, char* directory, char* files, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int archive(SSL* ssl, int socket, char* server, char* backup_id, char* position, char* directory, uint8_t compression, uint8_t encryption, int32_t output_format);
@@ -235,6 +237,9 @@ usage(void)
    printf("  restore                  Restore a backup from a server\n");
    printf("  retain                   Retain a backup from a server\n");
    printf("  shutdown                 Shutdown pgmoneta\n");
+   printf("  s3 <action>              Manage s3 data, with:\n");
+   printf("                           - 'ls' to list remote objects\n");
+   printf("                           - 'delete' to delete remote objects under a prefix\n");
    printf("  status [details]         Status of pgmoneta, with optional details\n");
    printf("  verify                   Verify a backup from a server\n");
    printf("\n");
@@ -265,6 +270,12 @@ struct pgmoneta_command command_table[] = {
     .action = MANAGEMENT_S3_LS,
     .deprecated = false,
     .log_message = "<s3 ls>"},
+   {.command = "s3",
+    .subcommand = "delete",
+    .accepted_argument_count = {2},
+    .action = MANAGEMENT_S3_DELETE,
+    .deprecated = false,
+    .log_message = "<s3 delete>"},
    {
       .command = "restore",
       .subcommand = "",
@@ -916,6 +927,10 @@ execute:
    {
       exit_code = list_s3_objects(s_ssl, socket, parsed.args[0], compression, encryption, output_format);
    }
+   else if (parsed.cmd->action == MANAGEMENT_S3_DELETE)
+   {
+      exit_code = delete_s3_objects(s_ssl, socket, parsed.args[0], parsed.args[1], compression, encryption, output_format);
+   }
    else if (parsed.cmd->action == MANAGEMENT_RESTORE)
    {
       if (parsed.args[3])
@@ -1122,7 +1137,8 @@ static void
 help_s3(void)
 {
    printf("Manage the s3\n");
-   printf("  pgmoneta-cli s3 [ls] <server>\n");
+   printf("  pgmoneta-cli s3 ls <server>\n");
+   printf("  pgmoneta-cli s3 delete <server> <prefix>\n");
 }
 
 static void
@@ -1409,6 +1425,25 @@ list_s3_objects(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t
       goto error;
    }
    return 0;
+error:
+   return 1;
+}
+
+static int
+delete_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   if (pgmoneta_management_request_delete_s3_objects(ssl, socket, server, prefix, compression, encryption, output_format))
+   {
+      goto error;
+   }
+
+   if (process_result(ssl, socket, output_format))
+   {
+      goto error;
+   }
+
+   return 0;
+
 error:
    return 1;
 }
@@ -2584,6 +2619,11 @@ translate_command(int32_t cmd_code)
          command_output = pgmoneta_append_char(command_output, ' ');
          command_output = pgmoneta_append(command_output, "ls");
          break;
+      case MANAGEMENT_S3_DELETE:
+         command_output = pgmoneta_append(command_output, COMMAND_S3);
+         command_output = pgmoneta_append_char(command_output, ' ');
+         command_output = pgmoneta_append(command_output, "delete");
+         break;
       case MANAGEMENT_RESTORE:
          command_output = pgmoneta_append(command_output, COMMAND_RESTORE);
          break;
@@ -3267,6 +3307,8 @@ translate_json_object(struct json* j)
                   translate_servers_argument((struct json*)pgmoneta_value_data(server_it->value));
                }
                pgmoneta_json_iterator_destroy(server_it);
+               break;
+            case MANAGEMENT_S3_DELETE:
                break;
             case MANAGEMENT_STATUS_DETAILS:
                translate_response_argument(response);

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -95,6 +95,7 @@ extern "C" {
 #define MANAGEMENT_LIST_USERS     104
 
 #define MANAGEMENT_S3_LS          200
+#define MANAGEMENT_S3_DELETE      201
 
 /**
  * Management categories
@@ -171,6 +172,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_RETENTION_YEARS       "RetentionYears"
 #define MANAGEMENT_ARGUMENT_S3_KEY                "S3Key"
 #define MANAGEMENT_ARGUMENT_S3_OBJECTS            "S3Objects"
+#define MANAGEMENT_ARGUMENT_S3_PREFIX             "S3Prefix"
 #define MANAGEMENT_ARGUMENT_SERVER                "Server"
 #define MANAGEMENT_ARGUMENT_SERVERS               "Servers"
 #define MANAGEMENT_ARGUMENT_SERVER_SIZE           "ServerSize"
@@ -391,6 +393,13 @@ extern "C" {
 #define MANAGEMENT_ERROR_PROGRESS_NETWORK                   3002
 #define MANAGEMENT_ERROR_PROGRESS_ERROR                     3003
 
+#define MANAGEMENT_ERROR_DELETE_S3_NOSERVER                 3100
+#define MANAGEMENT_ERROR_DELETE_S3_NOFORK                   3101
+#define MANAGEMENT_ERROR_DELETE_S3_WORKFLOW                 3102
+#define MANAGEMENT_ERROR_DELETE_S3_NETWORK                  3103
+#define MANAGEMENT_ERROR_DELETE_S3_INVALID_PREFIX           3104
+#define MANAGEMENT_ERROR_DELETE_S3_ERROR                    3105
+
 /**
  * Output formats
  */
@@ -481,6 +490,20 @@ pgmoneta_management_request_list_backup(SSL* ssl, int socket, char* server, char
  */
 int
 pgmoneta_management_request_list_s3_objects(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Create a delete s3 objects request
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The server
+ * @param prefix The prefix to delete under the server backup path
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_request_delete_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Create a restore request

--- a/src/include/s3.h
+++ b/src/include/s3.h
@@ -47,6 +47,18 @@ extern "C" {
  */
 void
 pgmoneta_list_s3_objects(int client_fd, int server, uint8_t compression, uint8_t encryption, struct json* payload);
+
+/**
+ * Delete S3 objects for a server under a prefix
+ * @param client_fd The client
+ * @param server The server
+ * @param prefix The prefix under server backup path
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The payload
+ */
+void
+pgmoneta_delete_s3_objects(int client_fd, int server, char* prefix, uint8_t compression, uint8_t encryption, struct json* payload);
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -53,6 +53,7 @@ extern "C" {
 #define WORKFLOW_TYPE_POST_ROLLUP        10
 
 #define WORKFLOW_TYPE_S3_LIST            100
+#define WORKFLOW_TYPE_S3_DELETE          101
 
 #define PERMISSION_TYPE_BACKUP           0
 #define PERMISSION_TYPE_RESTORE          1

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -158,6 +158,41 @@ error:
 }
 
 int
+pgmoneta_management_request_delete_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgmoneta_management_create_header(MANAGEMENT_S3_DELETE, compression, encryption, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_S3_PREFIX, (uintptr_t)prefix, ValueString);
+
+   if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgmoneta_json_destroy(j);
+
+   return 1;
+}
+
+int
 pgmoneta_management_request_restore(SSL* ssl, int socket, char* server, char* backup_id, char* position, char* directory, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    struct json* j = NULL;

--- a/src/libpgmoneta/s3.c
+++ b/src/libpgmoneta/s3.c
@@ -42,6 +42,27 @@
 #include <workflow.h>
 
 #define NAME "s3"
+
+static bool
+s3_is_safe_prefix(char* prefix)
+{
+   if (pgmoneta_contains(prefix, "/") || pgmoneta_contains(prefix, ".") || pgmoneta_contains(prefix, ".."))
+   {
+      return false;
+   }
+   if (prefix[0] == '/')
+   {
+      return false;
+   }
+
+   if (strstr(prefix, "..") != NULL)
+   {
+      return false;
+   }
+
+   return true;
+}
+
 void
 pgmoneta_list_s3_objects(int client_fd, int server, uint8_t compression, uint8_t encryption, struct json* payload)
 {
@@ -169,6 +190,118 @@ error:
 
    pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
                                       ec != -1 ? ec : MANAGEMENT_ERROR_LIST_S3_ERROR, en != NULL ? en : NAME,
+                                      compression, encryption, payload);
+
+   pgmoneta_json_destroy(payload);
+   pgmoneta_art_destroy(nodes);
+   pgmoneta_workflow_destroy(workflow);
+   free(elapsed);
+
+   pgmoneta_disconnect(client_fd);
+   pgmoneta_stop_logging();
+   exit(1);
+}
+
+void
+pgmoneta_delete_s3_objects(int client_fd, int server, char* prefix, uint8_t compression, uint8_t encryption, struct json* payload)
+{
+   char* elapsed = NULL;
+   char* en = NULL;
+   int ec = -1;
+   struct timespec start_t;
+   struct timespec end_t;
+   double total_seconds;
+   struct json* response = NULL;
+   struct art* nodes = NULL;
+   struct workflow* workflow = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+#endif
+
+   if (!s3_is_safe_prefix(prefix))
+   {
+      ec = MANAGEMENT_ERROR_DELETE_S3_INVALID_PREFIX;
+      pgmoneta_log_error("S3 delete: invalid prefix for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+   if (pgmoneta_art_create(&nodes))
+   {
+      ec = MANAGEMENT_ERROR_DELETE_S3_WORKFLOW;
+      goto error;
+   }
+
+   if (pgmoneta_art_insert(nodes, NODE_SERVER_ID, (uintptr_t)server, ValueInt32))
+   {
+      ec = MANAGEMENT_ERROR_DELETE_S3_WORKFLOW;
+      goto error;
+   }
+
+   if (pgmoneta_art_insert(nodes, NODE_LABEL, (uintptr_t)prefix, ValueString))
+   {
+      ec = MANAGEMENT_ERROR_DELETE_S3_WORKFLOW;
+      goto error;
+   }
+
+   workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_S3_DELETE, NULL);
+
+   if (workflow == NULL)
+   {
+      ec = MANAGEMENT_ERROR_DELETE_S3_WORKFLOW;
+      pgmoneta_log_error("S3 delete: S3 storage engine is not configured for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+   if (pgmoneta_workflow_execute(workflow, nodes, &en, &ec))
+   {
+      pgmoneta_log_error("S3 delete: workflow failed for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+   if (pgmoneta_management_create_response(payload, server, &response))
+   {
+      ec = MANAGEMENT_ERROR_ALLOCATION;
+      goto error;
+   }
+
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->common.servers[server].name, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_S3_PREFIX, (uintptr_t)prefix, ValueString);
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+#endif
+
+   if (pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload))
+   {
+      ec = MANAGEMENT_ERROR_DELETE_S3_NETWORK;
+      pgmoneta_log_error("S3 delete: error sending response for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+   elapsed = pgmoneta_get_timestamp_string(start_t, end_t, &total_seconds);
+   pgmoneta_log_info("S3 delete: %s/%s (Elapsed: %s)", config->common.servers[server].name, prefix, elapsed);
+
+   pgmoneta_json_destroy(payload);
+   pgmoneta_art_destroy(nodes);
+   pgmoneta_workflow_destroy(workflow);
+   free(elapsed);
+
+   pgmoneta_disconnect(client_fd);
+   pgmoneta_stop_logging();
+   exit(0);
+
+error:
+
+   pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
+                                      ec != -1 ? ec : MANAGEMENT_ERROR_DELETE_S3_ERROR, en != NULL ? en : NAME,
                                       compression, encryption, payload);
 
    pgmoneta_json_destroy(payload);

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -38,6 +38,7 @@
 /* system */
 #include <assert.h>
 #include <dirent.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -47,15 +48,21 @@ static int s3_storage_setup(char*, struct art*);
 static int s3_storage_execute(char*, struct art*);
 static int s3_storage_list(char*, struct art*);
 static int s3_storage_teardown(char*, struct art*);
+static int s3_storage_cleanup(char*, struct art*);
 static int s3_upload_files(char* local_root, char* s3_root, char* relative_path, int server);
 static int s3_send_upload_request(char* local_root, char* s3_root, char* relative_path, int server);
 static int s3_list_objects(char* relative_path, char* s3_list, int server, struct deque** objects);
+static int s3_delete_all_objects(char* relative_path, char* s3_list, int server, struct art*) __attribute__((unused));
 static int s3_send_list_request(char* relative_path, char* s3_list, int server, char* continuationToken, struct http_response** response);
+static int s3_send_delete_request(char* relative_path, char* s3_list, int server, char* xml_body, struct http_response** response);
 static int s3_add_request_headers(struct http_request* request, char* auth_value, char* file_sha256, char* long_date, char* storage_class);
 
 static char* s3_get_host(int server);
 static char* s3_get_basepath(int server, char* identifier);
 static char* s3_url_encode(char* str);
+static int xml_parse_s3_delete_result(char* xml, bool* has_fatal_error);
+static int xml_s3_build_delete_key(char** xml, char* key);
+static int xml_s3_build_delete_list(char** xml, struct deque* keys, size_t max_keys);
 static int xml_parse_s3_list_truncated(char* xml, bool* is_truncated, char** continuationToken);
 static int xml_parse_s3_list(char* xml, struct deque** keys);
 
@@ -77,7 +84,10 @@ pgmoneta_storage_create_s3(int workflow_type)
       case WORKFLOW_TYPE_S3_LIST:
          wf->execute = &s3_storage_list;
          break;
-
+      case WORKFLOW_TYPE_DELETE_BACKUP:
+      case WORKFLOW_TYPE_S3_DELETE:
+         wf->execute = &s3_storage_cleanup;
+         break;
       default:
          break;
    }
@@ -429,6 +439,48 @@ s3_storage_teardown(char* name __attribute__((unused)), struct art* nodes)
 
    return 0;
 }
+static int
+s3_storage_cleanup(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server = -1;
+   char* label = NULL;
+   char* s3_root = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+#ifdef DEBUG
+   pgmoneta_dump_art(nodes);
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
+   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
+#endif
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+
+   pgmoneta_log_debug("S3 storage engine (cleanup): %s/%s",
+                      config->common.servers[server].name, label);
+   pgmoneta_log_debug("S3 effective config: bucket=%s, region=%s, endpoint=%s",
+                      s3_get_effective_bucket(server),
+                      s3_get_effective_region(server),
+                      s3_get_effective_endpoint(server));
+
+   s3_root = s3_get_basepath(server, label);
+
+   if (s3_delete_all_objects("", s3_root, server, nodes))
+   {
+      goto error;
+   }
+
+   free(s3_root);
+
+   return 0;
+
+error:
+   free(s3_root);
+   return 1;
+}
 
 static int
 s3_upload_files(char* local_root, char* s3_root, char* relative_path, int server)
@@ -539,6 +591,80 @@ error:
    return 1;
 }
 
+static int
+s3_delete_all_objects(char* relative_path, char* s3_root, int server, struct art* nodes)
+{
+   struct http_response* list_response = NULL;
+   struct http_response* delete_response = NULL;
+   struct deque* objects = NULL;
+   char* continuation_token = NULL;
+   char* delete_xml = NULL;
+   bool is_truncated = true;
+
+   (void)nodes;
+
+   while (is_truncated)
+   {
+      if (s3_send_list_request(relative_path, s3_root, server, continuation_token, &list_response))
+      {
+         goto error;
+      }
+
+      free(continuation_token);
+      continuation_token = NULL;
+
+      if (xml_parse_s3_list_truncated(list_response->payload.data, &is_truncated, &continuation_token))
+      {
+         goto error;
+      }
+
+      if (xml_parse_s3_list(list_response->payload.data, &objects))
+      {
+         goto error;
+      }
+
+      pgmoneta_http_response_destroy(list_response);
+      list_response = NULL;
+
+      if (objects != NULL && pgmoneta_deque_size(objects) > 0)
+      {
+         size_t sample_size = pgmoneta_deque_size(objects);
+         if (xml_s3_build_delete_list(&delete_xml, objects, sample_size))
+         {
+            goto error;
+         }
+
+         pgmoneta_deque_destroy(objects);
+         objects = NULL;
+
+         if (s3_send_delete_request(relative_path, s3_root, server, delete_xml, &delete_response))
+         {
+            goto error;
+         }
+         pgmoneta_http_response_destroy(delete_response);
+         delete_response = NULL;
+
+         free(delete_xml);
+         delete_xml = NULL;
+      }
+      else
+      {
+         pgmoneta_deque_destroy(objects);
+         objects = NULL;
+      }
+   }
+
+   free(continuation_token);
+   return 0;
+
+error:
+   pgmoneta_http_response_destroy(list_response);
+   pgmoneta_http_response_destroy(delete_response);
+   pgmoneta_deque_destroy(objects);
+   free(delete_xml);
+   free(continuation_token);
+   return 1;
+}
 static int
 s3_send_list_request(char* relative_path, char* s3_root, int server, char* continuationToken, struct http_response** response)
 {
@@ -796,6 +922,278 @@ error:
    return 1;
 }
 
+static int
+s3_send_delete_request(char* relative_path, char* s3_root, int server, char* xml_body, struct http_response** response)
+{
+   char short_date[SHORT_TIME_LENGTH];
+   char long_date[LONG_TIME_LENGTH];
+   char* canonical_request = NULL;
+   char* auth_value = NULL;
+   char* string_to_sign = NULL;
+   char* s3_host = NULL;
+   char* s3_path = NULL;
+   char* request_path = NULL;
+   char* canonical_request_sha256 = NULL;
+   char* key = NULL;
+   char* query_string = NULL;
+   char* body_hash = NULL;
+   unsigned char* date_key_hmac = NULL;
+   unsigned char* date_region_key_hmac = NULL;
+   unsigned char* date_region_service_key_hmac = NULL;
+   unsigned char* signing_key_hmac = NULL;
+   unsigned char* signature_hmac = NULL;
+   unsigned char* signature_hex = NULL;
+   int hmac_length = 0;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+
+   char* effective_endpoint = s3_get_effective_endpoint(server);
+   char* effective_region = s3_get_effective_region(server);
+   char* effective_access_key_id = s3_get_effective_access_key_id(server);
+   char* effective_secret_access_key = s3_get_effective_secret_access_key(server);
+   char* effective_bucket = s3_get_effective_bucket(server);
+   int effective_port = s3_get_effective_port(server);
+   bool effective_use_tls = s3_get_effective_use_tls(server);
+   bool path_style = (strlen(effective_endpoint) > 0);
+
+   s3_path = pgmoneta_append(s3_path, s3_root);
+   if (strlen(relative_path) > 0)
+   {
+      if (!pgmoneta_ends_with(s3_root, "/"))
+      {
+         s3_path = pgmoneta_append(s3_path, "/");
+      }
+      s3_path = pgmoneta_append(s3_path, relative_path);
+   }
+
+   memset(&short_date[0], 0, sizeof(short_date));
+   memset(&long_date[0], 0, sizeof(long_date));
+
+   if (pgmoneta_get_timestamp_ISO8601_format(short_date, long_date))
+   {
+      goto error;
+   }
+
+   if (xml_body == NULL || strlen(xml_body) == 0)
+   {
+      pgmoneta_log_error("S3 delete request requires a non-empty XML body");
+      goto error;
+   }
+
+   query_string = pgmoneta_append(query_string, "delete=");
+
+   if (pgmoneta_generate_string_sha256_hash(xml_body, &body_hash))
+   {
+      goto error;
+   }
+
+   s3_host = s3_get_host(server);
+
+   canonical_request = pgmoneta_append(canonical_request, "POST\n/");
+   if (path_style)
+   {
+      canonical_request = pgmoneta_append(canonical_request, effective_bucket);
+   }
+   canonical_request = pgmoneta_append(canonical_request, "\n");
+   canonical_request = pgmoneta_append(canonical_request, query_string);
+   canonical_request = pgmoneta_append(canonical_request, "\n");
+   canonical_request = pgmoneta_append(canonical_request, "host:");
+   canonical_request = pgmoneta_append(canonical_request, s3_host);
+   canonical_request = pgmoneta_append(canonical_request, "\nx-amz-content-sha256:");
+   canonical_request = pgmoneta_append(canonical_request, body_hash);
+   canonical_request = pgmoneta_append(canonical_request, "\nx-amz-date:");
+   canonical_request = pgmoneta_append(canonical_request, long_date);
+   canonical_request = pgmoneta_append(canonical_request, "\n\nhost;x-amz-content-sha256;x-amz-date\n");
+   canonical_request = pgmoneta_append(canonical_request, body_hash);
+
+   pgmoneta_generate_string_sha256_hash(canonical_request, &canonical_request_sha256);
+
+   string_to_sign = pgmoneta_append(string_to_sign, "AWS4-HMAC-SHA256\n");
+   string_to_sign = pgmoneta_append(string_to_sign, long_date);
+   string_to_sign = pgmoneta_append(string_to_sign, "\n");
+   string_to_sign = pgmoneta_append(string_to_sign, short_date);
+   string_to_sign = pgmoneta_append(string_to_sign, "/");
+   string_to_sign = pgmoneta_append(string_to_sign, effective_region);
+   string_to_sign = pgmoneta_append(string_to_sign, "/s3/aws4_request\n");
+   string_to_sign = pgmoneta_append(string_to_sign, canonical_request_sha256);
+
+   key = pgmoneta_append(key, "AWS4");
+   key = pgmoneta_append(key, effective_secret_access_key);
+
+   if (pgmoneta_generate_string_hmac_sha256_hash(key, strlen(key), short_date, SHORT_TIME_LENGTH - 1, &date_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)date_key_hmac, hmac_length, effective_region, strlen(effective_region), &date_region_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)date_region_key_hmac, hmac_length, "s3", strlen("s3"), &date_region_service_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)date_region_service_key_hmac, hmac_length, "aws4_request", strlen("aws4_request"), &signing_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)signing_key_hmac, hmac_length, string_to_sign, strlen(string_to_sign), &signature_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   pgmoneta_convert_base32_to_hex(signature_hmac, hmac_length, &signature_hex);
+
+   // Build authorization header with matching signed headers
+   auth_value = pgmoneta_append(auth_value, "AWS4-HMAC-SHA256 Credential=");
+   auth_value = pgmoneta_append(auth_value, effective_access_key_id);
+   auth_value = pgmoneta_append(auth_value, "/");
+   auth_value = pgmoneta_append(auth_value, short_date);
+   auth_value = pgmoneta_append(auth_value, "/");
+   auth_value = pgmoneta_append(auth_value, effective_region);
+   auth_value = pgmoneta_append(auth_value, "/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=");
+   auth_value = pgmoneta_append(auth_value, (char*)signature_hex);
+
+   int s3_port;
+
+   if (effective_port != 0)
+   {
+      s3_port = effective_port;
+   }
+   else
+   {
+      s3_port = effective_use_tls ? 443 : 80;
+   }
+
+   bool use_tls = effective_use_tls;
+   if (s3_port == 443)
+   {
+      use_tls = true;
+   }
+
+   if (pgmoneta_http_create(s3_host, s3_port, use_tls, &connection))
+   {
+      goto error;
+   }
+
+   if (path_style)
+   {
+      request_path = pgmoneta_append(request_path, "/");
+      request_path = pgmoneta_append(request_path, effective_bucket);
+      request_path = pgmoneta_append(request_path, "?");
+   }
+   else
+   {
+      request_path = pgmoneta_append(request_path, "/?");
+   }
+   request_path = pgmoneta_append(request_path, query_string);
+
+   if (pgmoneta_http_request_create(PGMONETA_HTTP_POST, request_path, &request))
+   {
+      goto error;
+   }
+
+   if (s3_add_request_headers(request, auth_value, body_hash, long_date, ""))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_http_request_add_header(request, "Content-Type", "application/xml"))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_http_set_data(request, xml_body, strlen(xml_body)))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_http_invoke(connection, request, response))
+   {
+      goto error;
+   }
+
+   if ((*response)->status_code >= 200 && (*response)->status_code < 300)
+   {
+      bool has_fatal_error = false;
+
+      if (xml_parse_s3_delete_result((*response)->payload.data, &has_fatal_error))
+      {
+         goto error;
+      }
+
+      if (has_fatal_error)
+      {
+         pgmoneta_log_error("S3 delete response contains object-level errors for path: %s", s3_path);
+         goto error;
+      }
+
+      pgmoneta_log_info("Successfully deleted files from URL: https://%s/%s", s3_host, s3_path);
+   }
+   else
+   {
+      pgmoneta_log_error("S3 delete failed with status code: %d. Failed to delete files from S3 path: %s",
+                         (*response)->status_code, s3_path);
+      goto error;
+   }
+
+   free(s3_host);
+   free(request_path);
+   free(signature_hex);
+   free(signature_hmac);
+   free(signing_key_hmac);
+   free(date_region_service_key_hmac);
+   free(date_region_key_hmac);
+   free(date_key_hmac);
+   free(key);
+   free(s3_path);
+   free(body_hash);
+   free(canonical_request_sha256);
+   free(canonical_request);
+   free(string_to_sign);
+   free(auth_value);
+   free(query_string);
+
+   pgmoneta_http_request_destroy(request);
+   pgmoneta_http_destroy(connection);
+
+   return 0;
+
+error:
+
+   free(s3_host);
+   free(request_path);
+   free(signature_hex);
+   free(signature_hmac);
+
+   free(signing_key_hmac);
+   free(date_region_service_key_hmac);
+   free(date_region_key_hmac);
+   free(date_key_hmac);
+   free(key);
+   free(s3_path);
+   free(body_hash);
+   free(canonical_request_sha256);
+   free(canonical_request);
+   free(string_to_sign);
+   free(auth_value);
+   free(query_string);
+
+   if (connection != NULL)
+   {
+      pgmoneta_http_destroy(connection);
+   }
+
+   if (request != NULL)
+   {
+      pgmoneta_http_request_destroy(request);
+   }
+
+   return 1;
+}
 static int
 s3_send_upload_request(char* local_root, char* s3_root, char* relative_path, int server)
 {
@@ -1323,4 +1721,142 @@ xml_parse_s3_list_truncated(char* xml, bool* is_truncated, char** continuation_t
    }
 
    return 0;
+}
+
+static int
+xml_parse_s3_delete_result(char* xml, bool* has_fatal_error)
+{
+   char* cursor = NULL;
+
+   if (xml == NULL || has_fatal_error == NULL)
+   {
+      return 1;
+   }
+
+   *has_fatal_error = false;
+   cursor = xml;
+
+   while ((cursor = strstr(cursor, "<Error>")) != NULL)
+   {
+      char* end = strstr(cursor, "</Error>");
+      char* error_block = NULL;
+      struct deque* key_values = NULL;
+      struct deque* code_values = NULL;
+      struct deque* message_values = NULL;
+      char* key = NULL;
+      char* code = NULL;
+      char* message = NULL;
+      size_t block_len = 0;
+
+      if (end == NULL)
+      {
+         return 1;
+      }
+
+      end += strlen("</Error>");
+      block_len = (size_t)(end - cursor);
+
+      error_block = (char*)malloc(block_len + 1);
+      if (error_block == NULL)
+      {
+         return 1;
+      }
+      memcpy(error_block, cursor, block_len);
+      error_block[block_len] = '\0';
+
+      if (xml_extract_tag(error_block, "Key", &key_values))
+      {
+         free(error_block);
+         return 1;
+      }
+      if (xml_extract_tag(error_block, "Code", &code_values))
+      {
+         pgmoneta_deque_destroy(key_values);
+         free(error_block);
+         return 1;
+      }
+      if (xml_extract_tag(error_block, "Message", &message_values))
+      {
+         pgmoneta_deque_destroy(key_values);
+         pgmoneta_deque_destroy(code_values);
+         free(error_block);
+         return 1;
+      }
+
+      key = key_values != NULL && pgmoneta_deque_size(key_values) > 0 ? (char*)pgmoneta_deque_peek(key_values, NULL) : "unknown";
+      code = code_values != NULL && pgmoneta_deque_size(code_values) > 0 ? (char*)pgmoneta_deque_peek(code_values, NULL) : "unknown";
+      message = message_values != NULL && pgmoneta_deque_size(message_values) > 0 ? (char*)pgmoneta_deque_peek(message_values, NULL) : "unknown";
+
+      pgmoneta_log_warn("S3 delete object error: key=%s code=%s message=%s", key, code, message);
+
+      if (strcmp(code, "NoSuchKey"))
+      {
+         *has_fatal_error = true;
+      }
+
+      pgmoneta_deque_destroy(key_values);
+      pgmoneta_deque_destroy(code_values);
+      pgmoneta_deque_destroy(message_values);
+      free(error_block);
+
+      cursor = end;
+   }
+
+   return 0;
+}
+
+static int
+xml_s3_build_delete_key(char** xml, char* key)
+{
+   const char* open_tag = "<Object><Key>";
+   const char* close_tag = "</Key></Object>";
+
+   if (xml == NULL || key == NULL)
+   {
+      return 1;
+   }
+
+   *xml = pgmoneta_append(*xml, open_tag);
+   *xml = pgmoneta_append(*xml, key);
+   *xml = pgmoneta_append(*xml, close_tag);
+
+   return 0;
+}
+
+static int
+xml_s3_build_delete_list(char** xml, struct deque* keys, size_t max_keys)
+{
+   if (xml == NULL || keys == NULL || max_keys == 0)
+   {
+      goto error;
+   }
+
+   const char* quiet_tag = "<Quiet>true</Quiet>";
+   const char* header_tag = "<Delete xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
+   *xml = pgmoneta_append(*xml, header_tag);
+   *xml = pgmoneta_append(*xml, quiet_tag);
+
+   while (max_keys > 0 && pgmoneta_deque_size(keys) > 0)
+   {
+      char* key = (char*)pgmoneta_deque_poll(keys, NULL);
+      if (key == NULL)
+      {
+         goto error;
+      }
+
+      if (xml_s3_build_delete_key(xml, key))
+      {
+         free(key);
+         goto error;
+      }
+
+      free(key);
+      max_keys--;
+   }
+
+   *xml = pgmoneta_append(*xml, "</Delete>");
+   return 0;
+
+error:
+   return 1;
 }

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -57,6 +57,7 @@ static struct workflow* wf_delete_backup(void);
 static struct workflow* wf_retention(void);
 static struct workflow* wf_post_rollup(struct backup* backup);
 static struct workflow* wf_list_s3_objects(void);
+static struct workflow* wf_delete_s3_objects(void);
 
 static int get_error_code(int type, int flow, struct art* nodes);
 
@@ -94,6 +95,9 @@ pgmoneta_workflow_create(int workflow_type, struct backup* backup)
          break;
       case WORKFLOW_TYPE_S3_LIST:
          w = wf_list_s3_objects();
+         break;
+      case WORKFLOW_TYPE_S3_DELETE:
+         w = wf_delete_s3_objects();
          break;
       case WORKFLOW_TYPE_RETENTION:
          w = wf_retention();
@@ -944,11 +948,21 @@ static struct workflow*
 wf_delete_backup(void)
 {
    struct workflow* head = NULL;
+   struct workflow* current = NULL;
+   struct main_configuration* config = NULL;
 
    head = pgmoneta_create_delete_backup();
+   current = head;
+
+   config = (struct main_configuration*)shmem;
+
+   if (config->storage_engine & STORAGE_ENGINE_S3)
+   {
+      current->next = pgmoneta_storage_create_s3(WORKFLOW_TYPE_DELETE_BACKUP);
+      current = current->next;
+   }
 
 #ifdef DEBUG
-   struct workflow* current = NULL;
    current = head;
    while (current != NULL)
    {
@@ -974,6 +988,34 @@ wf_list_s3_objects(void)
    if (config->storage_engine & STORAGE_ENGINE_S3)
    {
       head = pgmoneta_storage_create_s3(WORKFLOW_TYPE_S3_LIST);
+   }
+
+#ifdef DEBUG
+   struct workflow* current = head;
+   while (current != NULL)
+   {
+      assert(current->name != NULL);
+      assert(current->setup != NULL);
+      assert(current->execute != NULL);
+      assert(current->teardown != NULL);
+      current = current->next;
+   }
+#endif
+
+   return head;
+}
+
+static struct workflow*
+wf_delete_s3_objects(void)
+{
+   struct workflow* head = NULL;
+   struct main_configuration* config = NULL;
+
+   config = (struct main_configuration*)shmem;
+
+   if (config->storage_engine & STORAGE_ENGINE_S3)
+   {
+      head = pgmoneta_storage_create_s3(WORKFLOW_TYPE_S3_DELETE);
    }
 
 #ifdef DEBUG

--- a/src/main.c
+++ b/src/main.c
@@ -1250,6 +1250,50 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          goto error;
       }
    }
+   else if (id == MANAGEMENT_S3_DELETE)
+   {
+      char* prefix = NULL;
+
+      server = (char*)pgmoneta_json_get(request, MANAGEMENT_ARGUMENT_SERVER);
+      prefix = (char*)pgmoneta_json_get(request, MANAGEMENT_ARGUMENT_S3_PREFIX);
+
+      srv = -1;
+      for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
+      {
+         if (!strcmp(config->common.servers[i].name, server))
+         {
+            srv = i;
+         }
+      }
+
+      if (srv != -1)
+      {
+         pid = fork();
+         if (pid == -1)
+         {
+            pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_DELETE_S3_NOFORK, NAME, compression, encryption, payload);
+            pgmoneta_log_error("S3 delete: No fork %s (%d)", server, MANAGEMENT_ERROR_DELETE_S3_NOFORK);
+            goto error;
+         }
+         else if (pid == 0)
+         {
+            struct json* pyl = NULL;
+
+            shutdown_ports();
+
+            pgmoneta_json_clone(payload, &pyl);
+
+            pgmoneta_set_proc_title(1, ai->argv, "s3 delete", config->common.servers[srv].name);
+            pgmoneta_delete_s3_objects(client_fd, srv, prefix, compression, encryption, pyl);
+         }
+      }
+      else
+      {
+         pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_DELETE_S3_NOSERVER, NAME, compression, encryption, payload);
+         pgmoneta_log_error("S3 delete: No server %s (%d)", server, MANAGEMENT_ERROR_DELETE_S3_NOSERVER);
+         goto error;
+      }
+   }
 
    else if (id == MANAGEMENT_DELETE)
    {


### PR DESCRIPTION
 - pgmoneta-cli s3 delete <server> <prefix> now exists, backed by a matching management command, workflow type, and S3 handler that paginates list/delete calls, signs the XML payload, parses delete responses, and reports per-key issues while avoiding metadata lookups when only remote files exist.
 - previously the delete command expected local backup metadata, so you couldn’t clean up orphaned S3 objects; the new command lets you trim remote prefixes without touching the normal delete workflow.
