### PR TITLE
Skip in-progress .partial WAL segments in summarize_walfiles

### DIFF
--- a/src/libpgmoneta/walfile/wal_summary.c
+++ b/src/libpgmoneta/walfile/wal_summary.c
@@ -301,6 +301,12 @@ retry1:
       char* file = (char*)file_iterator->value->data;
       char* fn = NULL;
 
+      if (pgmoneta_ends_with(file, ".partial"))
+      {
+         pgmoneta_log_debug("summarize_walfiles: skipping in-progress segment %s", file);
+         continue;
+      }
+
       fn = get_wal_file_name(file);
 
       memset(file_path, 0, MAX_PATH);


### PR DESCRIPTION
this issue is only on `0.20.x` , because of the outdated `get_wal_file_name() `

how it is handled in `main`:
```
read 1C.partial → check each record LSN → all > e_lsn → discard all → BRT unchanged
```

current pr fix: 
```
see 1C.partial → continue → never read → BRT unchanged
```
adding continue just before `get_wal_file_name()`
this is safe because `.partial` only exists after `pg_switch_wal()`, which is always called after `e_lsn` is captured, so its records are always > `e_lsn`.
 