### PR TITLE
[#1020] Add test case for hot_standby backup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,3 +46,4 @@ Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
+Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -53,6 +53,7 @@ Mazen Kamal <mazenkamal212@gmail.com>
 Trevor Jacob Mathews <trevorjacobmathews@gmail.com>
 Abdelrhman Sersawy <abdelrhmansersawy@gmail.com>
 Zeyad Daowd <zeyaddaowd@yahoo.com>
+Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 ```
 
 ## Committers

--- a/src/include/aes.h
+++ b/src/include/aes.h
@@ -235,6 +235,14 @@ pgmoneta_encrypt_buffer(unsigned char* origin_buffer, size_t origin_size, unsign
 int
 pgmoneta_decrypt_buffer(unsigned char* origin_buffer, size_t origin_size, unsigned char** dec_buffer, size_t* dec_size, int mode);
 
+/**
+ * Check if a file is encrypted
+ * @param f The file name
+ * @return True if encrypted, otherwise false
+ */
+bool
+pgmoneta_is_encrypted(char* f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1262,22 +1262,6 @@ size_t
 pgmoneta_get_file_size(char* file_path);
 
 /**
- * Is the file encrypted
- * @param file_path The file path
- * @return True if encrypted, otherwise false
- */
-bool
-pgmoneta_is_encrypted(char* file_path);
-
-/**
- * Is the file compressed
- * @param file_path The file path
- * @return True if compressed, otherwise false
- */
-bool
-pgmoneta_is_compressed(char* file_path);
-
-/**
  * Get the file type bitmask for a given file path
  * The bitmask can include combinations of:
  * - PGMONETA_FILE_TYPE_WAL (24-char hex WAL file)

--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -1995,3 +1995,19 @@ get_key_length(int mode)
          return 32;
    }
 }
+
+bool
+pgmoneta_is_encrypted(char* f)
+{
+   if (f == NULL)
+   {
+      return false;
+   }
+
+   if (pgmoneta_ends_with(f, ".aes"))
+   {
+      return true;
+   }
+
+   return false;
+}

--- a/src/libpgmoneta/bzip2_compression.c
+++ b/src/libpgmoneta/bzip2_compression.c
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <aes.h>
 #include <bzip2_compression.h>
 #include <logging.h>
 #include <management.h>
@@ -117,7 +118,7 @@ pgmoneta_bzip2_data(char* directory, struct workers* workers)
             continue;
          }
 
-         if (!pgmoneta_is_compressed(entry->d_name) && !pgmoneta_is_encrypted(entry->d_name))
+         if (!pgmoneta_compression_is_compressed(entry->d_name) && !pgmoneta_is_encrypted(entry->d_name))
          {
             from = pgmoneta_append(from, directory);
             from = pgmoneta_append(from, "/");
@@ -270,7 +271,7 @@ pgmoneta_bzip2_wal(char* directory)
       }
       if (entry->d_type == DT_REG)
       {
-         if (pgmoneta_is_compressed(entry->d_name) ||
+         if (pgmoneta_compression_is_compressed(entry->d_name) ||
              pgmoneta_is_encrypted(entry->d_name) ||
              pgmoneta_ends_with(entry->d_name, ".partial") ||
              pgmoneta_ends_with(entry->d_name, ".history"))

--- a/src/libpgmoneta/gzip_compression.c
+++ b/src/libpgmoneta/gzip_compression.c
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <aes.h>
 #include <gzip_compression.h>
 #include <logging.h>
 #include <management.h>
@@ -113,7 +114,7 @@ pgmoneta_gzip_data(char* directory, struct workers* workers)
             continue;
          }
 
-         if (!pgmoneta_is_compressed(entry->d_name) && !pgmoneta_is_encrypted(entry->d_name))
+         if (!pgmoneta_compression_is_compressed(entry->d_name) && !pgmoneta_is_encrypted(entry->d_name))
          {
             from = pgmoneta_append(from, directory);
             from = pgmoneta_append(from, "/");
@@ -265,7 +266,7 @@ pgmoneta_gzip_wal(char* directory)
       }
       if (entry->d_type == DT_REG)
       {
-         if (pgmoneta_is_compressed(entry->d_name) ||
+         if (pgmoneta_compression_is_compressed(entry->d_name) ||
              pgmoneta_is_encrypted(entry->d_name) ||
              pgmoneta_ends_with(entry->d_name, ".partial") ||
              pgmoneta_ends_with(entry->d_name, ".history"))

--- a/src/libpgmoneta/lz4_compression.c
+++ b/src/libpgmoneta/lz4_compression.c
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <aes.h>
 #include <logging.h>
 #include <lz4.h>
 #include <lz4_compression.h>
@@ -117,7 +118,7 @@ pgmoneta_lz4c_data(char* directory, struct workers* workers)
             continue;
          }
 
-         if (!pgmoneta_is_compressed(entry->d_name) && !pgmoneta_is_encrypted(entry->d_name))
+         if (!pgmoneta_compression_is_compressed(entry->d_name) && !pgmoneta_is_encrypted(entry->d_name))
          {
             from = pgmoneta_append(from, directory);
             from = pgmoneta_append(from, "/");
@@ -225,7 +226,7 @@ pgmoneta_lz4c_wal(char* directory)
       }
       if (entry->d_type == DT_REG)
       {
-         if (pgmoneta_is_compressed(entry->d_name) ||
+         if (pgmoneta_compression_is_compressed(entry->d_name) ||
              pgmoneta_is_encrypted(entry->d_name) ||
              pgmoneta_ends_with(entry->d_name, ".partial") ||
              pgmoneta_ends_with(entry->d_name, ".history"))

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -28,6 +28,8 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <aes.h>
+#include <compression.h>
 #include <deque.h>
 #include <extraction.h>
 #include <info.h>
@@ -1837,7 +1839,7 @@ pgmoneta_calculate_wal_size(char* directory, char* start)
          basename = strdup(filename);
       }
 
-      if (pgmoneta_is_compressed(basename))
+      if (pgmoneta_compression_is_compressed(basename))
       {
          char* bn = basename;
          basename = NULL;
@@ -3196,7 +3198,7 @@ pgmoneta_copy_wal_files(char* from, char* to, char* start, struct workers* worke
          basename = pgmoneta_append(basename, wal_file);
       }
 
-      if (pgmoneta_is_compressed(basename))
+      if (pgmoneta_compression_is_compressed(basename))
       {
          char* bn = basename;
          basename = NULL;
@@ -3300,7 +3302,7 @@ pgmoneta_number_of_wal_files(char* directory, char* from, char* to)
          basename = pgmoneta_append(basename, wal_file);
       }
 
-      if (pgmoneta_is_compressed(basename))
+      if (pgmoneta_compression_is_compressed(basename))
       {
          char* bn = basename;
          basename = NULL;
@@ -4448,31 +4450,6 @@ pgmoneta_get_file_size(char* file_path)
    }
 
    return file_stat.st_size;
-}
-
-bool
-pgmoneta_is_encrypted(char* file_path)
-{
-   if (pgmoneta_ends_with(file_path, ".aes"))
-   {
-      return true;
-   }
-
-   return false;
-}
-
-bool
-pgmoneta_is_compressed(char* file_path)
-{
-   if (pgmoneta_ends_with(file_path, ".zstd") ||
-       pgmoneta_ends_with(file_path, ".lz4") ||
-       pgmoneta_ends_with(file_path, ".bz2") ||
-       pgmoneta_ends_with(file_path, ".gz"))
-   {
-      return true;
-   }
-
-   return false;
 }
 
 uint32_t

--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -28,7 +28,9 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <aes.h>
 #include <brt.h>
+#include <compression.h>
 #include <json.h>
 #include <logging.h>
 #include <extraction.h>
@@ -207,7 +209,7 @@ pgmoneta_validate_wal_filename(char* path, char** base_filename, xlog_seg_no* se
       wal_filename = temp;
    }
 
-   if (pgmoneta_is_encrypted(wal_filename) || pgmoneta_is_compressed(wal_filename))
+   if (pgmoneta_is_encrypted(wal_filename) || pgmoneta_compression_is_compressed(wal_filename))
    {
       if (pgmoneta_extraction_strip_suffix(wal_filename, pgmoneta_get_file_type(wal_filename), &temp))
       {

--- a/src/libpgmoneta/zstandard_compression.c
+++ b/src/libpgmoneta/zstandard_compression.c
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <aes.h>
 #include <compression.h>
 #include <logging.h>
 #include <management.h>
@@ -148,7 +149,7 @@ pgmoneta_zstandardc_data(char* directory, struct workers* workers)
             continue;
          }
 
-         if (!pgmoneta_is_compressed(entry->d_name) &&
+         if (!pgmoneta_compression_is_compressed(entry->d_name) &&
              !pgmoneta_is_encrypted(entry->d_name))
          {
             from = NULL;
@@ -322,7 +323,7 @@ pgmoneta_zstandardc_wal(char* directory)
       }
       if (entry->d_type == DT_REG)
       {
-         if (pgmoneta_is_compressed(entry->d_name) ||
+         if (pgmoneta_compression_is_compressed(entry->d_name) ||
              pgmoneta_is_encrypted(entry->d_name) ||
              pgmoneta_ends_with(entry->d_name, ".partial") ||
              pgmoneta_ends_with(entry->d_name, ".history"))

--- a/src/walfilter.c
+++ b/src/walfilter.c
@@ -843,7 +843,7 @@ main(int argc, char* argv[])
       wal_path = NULL;
       wal_path = pgmoneta_append(wal_path, file_path);
 
-      if (pgmoneta_is_encrypted(wal_path) || pgmoneta_is_compressed(wal_path))
+      if (pgmoneta_is_encrypted(wal_path) || pgmoneta_compression_is_compressed(wal_path))
       {
          free(tmp_wal);
          tmp_wal = NULL;

--- a/test/check.sh
+++ b/test/check.sh
@@ -47,6 +47,7 @@ COVERAGE_DIR="$PGMONETA_ROOT_DIR/coverage"
 LOG_DIR="$PGMONETA_ROOT_DIR/log"
 PG_LOG_DIR="$PGMONETA_ROOT_DIR/pg_log"
 RETROSPECT_DIR="$PGMONETA_ROOT_DIR/retrospect"
+HOT_STANDBY_DIRECTORY="$PGMONETA_ROOT_DIR/standby"
 
 # BASE DIR holds all the run time data
 WORKSPACE_DIRECTORY="$BASE_DIR/pgmoneta-workspace/"
@@ -283,6 +284,8 @@ host = localhost
 port = $PORT
 user = $PG_REPL_USER_NAME
 wal_slot = repl
+hot_standby = $HOT_STANDBY_DIRECTORY
+hot_standby_overrides = $HOT_STANDBY_DIRECTORY/overrides
 EOF
    echo "Add test configuration to pgmoneta.conf ... ok"
    if [[ ! -e $HOME/.pgmoneta/master.key ]]; then
@@ -313,6 +316,9 @@ export_pgmoneta_test_variables() {
 
   echo "export PGMONETA_TEST_RETROSPECT_DIR=$RETROSPECT_DIR"
   export PGMONETA_TEST_RETROSPECT_DIR=$RETROSPECT_DIR
+
+  echo "export PGMONETA_TEST_HOT_STANDBY_DIR=$HOT_STANDBY_DIRECTORY"
+  export PGMONETA_TEST_HOT_STANDBY_DIR=$HOT_STANDBY_DIRECTORY
 }
 
 unset_pgmoneta_test_variables() {
@@ -321,6 +327,7 @@ unset_pgmoneta_test_variables() {
   unset PGMONETA_TEST_USER_CONF
   unset PGMONETA_TEST_CONF_SAMPLE
   unset PGMONETA_TEST_RESTORE_DIR
+  unset PGMONETA_TEST_HOT_STANDBY_DIR
   unset LLVM_PROFILE_FILE
   unset CC
 }
@@ -357,7 +364,7 @@ do_setup() {
   export LLVM_PROFILE_FILE="$COVERAGE_DIR/coverage-%p-%m.profraw"
   rm -Rf "$PGMONETA_ROOT_DIR"
   mkdir -p "$PGMONETA_ROOT_DIR"
-  mkdir -p "$LOG_DIR" "$PG_LOG_DIR" "$COVERAGE_DIR" "$BASE_DIR" "$RETROSPECT_DIR"
+  mkdir -p "$LOG_DIR" "$PG_LOG_DIR" "$COVERAGE_DIR" "$BASE_DIR" "$RETROSPECT_DIR" "$HOT_STANDBY_DIRECTORY"
   mkdir -p "$RESTORE_DIRECTORY" "$BACKUP_DIRECTORY" "$CONFIGURATION_DIRECTORY" "$WORKSPACE_DIRECTORY" "$RESOURCE_DIRECTORY" "$PGCONF_DIRECTORY"
   cp -R "$PROJECT_DIRECTORY/test/resource" $BASE_DIR
   cp -R $TEST_PG_DIRECTORY/conf/* $PGCONF_DIRECTORY/

--- a/test/include/tscommon.h
+++ b/test/include/tscommon.h
@@ -43,6 +43,7 @@ extern char TEST_CONFIG_SAMPLE_PATH[MAX_PATH];
 extern char TEST_RESTORE_DIR[MAX_PATH];
 extern char TEST_BASE_DIR[MAX_PATH];
 extern char TEST_RETROSPECT_DIR[MAX_PATH];
+extern char TEST_HOT_STANDBY_DIR[MAX_PATH];
 
 /**
  * Create the testing environment

--- a/test/libpgmonetatest/tscommon.c
+++ b/test/libpgmonetatest/tscommon.c
@@ -50,11 +50,13 @@
 #define ENV_VAR_USER_CONF        "PGMONETA_TEST_USER_CONF"
 #define ENV_VAR_RESTORE_DIR      "PGMONETA_TEST_RESTORE_DIR"
 #define ENV_VAR_RETROSPECT_DIR   "PGMONETA_TEST_RETROSPECT_DIR"
+#define ENV_VAR_HOT_STANDBY_DIR  "PGMONETA_TEST_HOT_STANDBY_DIR"
 
 char TEST_CONFIG_SAMPLE_PATH[MAX_PATH];
 char TEST_RESTORE_DIR[MAX_PATH];
 char TEST_BASE_DIR[MAX_PATH];
 char TEST_RETROSPECT_DIR[MAX_PATH];
+char TEST_HOT_STANDBY_DIR[MAX_PATH];
 
 /* In-process snapshot of the configuration used for save/restore */
 static struct main_configuration config_snapshot;
@@ -69,13 +71,16 @@ pgmoneta_test_environment_create(void)
    char* restore_dir = NULL;
    char* base_dir = NULL;
    char* retrospect_dir = NULL;
+   char* hot_standby_dir = NULL;
    int ret = 0;
    size_t size = 0;
 
    memset(TEST_CONFIG_SAMPLE_PATH, 0, sizeof(TEST_CONFIG_SAMPLE_PATH));
    memset(TEST_RESTORE_DIR, 0, sizeof(TEST_RESTORE_DIR));
    memset(TEST_BASE_DIR, 0, sizeof(TEST_BASE_DIR));
-
+   memset(TEST_RETROSPECT_DIR, 0, sizeof(TEST_RETROSPECT_DIR));
+   memset(TEST_HOT_STANDBY_DIR, 0, sizeof(TEST_HOT_STANDBY_DIR));
+   
    conf_path = getenv(ENV_VAR_CONF_PATH);
    assert(conf_path != NULL);
    // Create the shared memory for the configuration
@@ -117,6 +122,10 @@ pgmoneta_test_environment_create(void)
    assert(retrospect_dir != NULL);
    memcpy(TEST_RETROSPECT_DIR, retrospect_dir, strlen(retrospect_dir));
 
+   hot_standby_dir = getenv(ENV_VAR_HOT_STANDBY_DIR);
+   assert(hot_standby_dir != NULL);
+   memcpy(TEST_HOT_STANDBY_DIR, hot_standby_dir, strlen(hot_standby_dir));
+
    user_conf_path = getenv(ENV_VAR_USER_CONF);
    assert(user_conf_path != NULL);
 
@@ -136,6 +145,9 @@ pgmoneta_test_environment_destroy(void)
 
    memset(TEST_CONFIG_SAMPLE_PATH, 0, sizeof(TEST_CONFIG_SAMPLE_PATH));
    memset(TEST_RESTORE_DIR, 0, sizeof(TEST_RESTORE_DIR));
+   memset(TEST_BASE_DIR, 0, sizeof(TEST_BASE_DIR));
+   memset(TEST_RETROSPECT_DIR, 0, sizeof(TEST_RETROSPECT_DIR));
+   memset(TEST_HOT_STANDBY_DIR, 0, sizeof(TEST_HOT_STANDBY_DIR));
 
    pgmoneta_stop_logging();
 
@@ -226,6 +238,9 @@ pgmoneta_test_basedir_cleanup(void)
 
    pgmoneta_delete_directory(wal_dir);
    pgmoneta_mkdir(wal_dir);
+
+   pgmoneta_delete_directory(TEST_HOT_STANDBY_DIR);
+   pgmoneta_mkdir(TEST_HOT_STANDBY_DIR);
 
    if (pgmoneta_delete_file(config->common.configuration_path, NULL))
    {

--- a/test/testcases/test_hot_standby.c
+++ b/test/testcases/test_hot_standby.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgmoneta.h>
+#include <aes.h>
+#include <art.h>
+#include <compression.h>
+#include <hot_standby.h>
+#include <info.h>
+#include <logging.h>
+#include <mctf.h>
+#include <tsclient.h>
+#include <tsclient_helpers.h>
+#include <tscommon.h>
+#include <utils.h>
+#include <workflow.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int
+check_files_recursive(const char* dir_path, int* found_files)
+{
+   DIR* dir;
+   struct dirent* entry;
+   char path[MAX_PATH];
+
+   if (!(dir = opendir(dir_path)))
+   {
+      goto error;
+   }
+
+   while ((entry = readdir(dir)) != NULL)
+   {
+      if (entry->d_type == DT_DIR)
+      {
+         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         {
+            continue;
+         }
+         pgmoneta_snprintf(path, sizeof(path), "%s/%s", dir_path, entry->d_name);
+         if (check_files_recursive(path, found_files))
+         {
+            goto error;
+         }
+      }
+      else
+      {
+         (*found_files)++;
+         if (pgmoneta_is_encrypted(entry->d_name))
+         {
+            pgmoneta_log_error("File %s/%s is encrypted (.aes)", dir_path, entry->d_name);
+            goto error;
+         }
+         if (pgmoneta_compression_is_compressed(entry->d_name))
+         {
+            pgmoneta_log_error("File %s/%s is compressed", dir_path, entry->d_name);
+            goto error;
+         }
+      }
+   }
+
+   closedir(dir);
+   return 0;
+
+error:
+   if (dir != NULL)
+   {
+      closedir(dir);
+   }
+   return 1;
+}
+
+MCTF_TEST(test_pgmoneta_hot_standby_basic)
+{
+   char standby_dir[MAX_PATH];
+   char pg_version_file[MAX_PATH];
+   int found_files = 0;
+
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_test_add_backup() == 0, cleanup, "backup failed during setup - check server is online and backup configuration");
+
+   pgmoneta_snprintf(standby_dir, sizeof(standby_dir), "%s/primary", TEST_HOT_STANDBY_DIR);
+   MCTF_ASSERT(pgmoneta_exists(standby_dir), cleanup, "hot standby directory does not exist: %s", standby_dir);
+
+   pgmoneta_snprintf(pg_version_file, sizeof(pg_version_file), "%s/PG_VERSION", standby_dir);
+   MCTF_ASSERT(pgmoneta_exists(pg_version_file), cleanup, "PG_VERSION file missing in hot standby");
+
+   MCTF_ASSERT(check_files_recursive(standby_dir, &found_files) == 0, cleanup, "Found encrypted or compressed files in hot standby");
+   MCTF_ASSERT(found_files > 0, cleanup, "No files found in hot standby directory");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_pgmoneta_hot_standby_overrides)
+{
+   char overrides_dir[MAX_PATH];
+   char override_src[MAX_PATH];
+   char override_dst[MAX_PATH];
+   char standby_dir[MAX_PATH];
+   int found_files = 0;
+   FILE* f = NULL;
+
+   pgmoneta_test_setup();
+
+   /* Prepare overrides source directory and file */
+   pgmoneta_snprintf(overrides_dir, sizeof(overrides_dir), "%s/overrides", TEST_HOT_STANDBY_DIR);
+   pgmoneta_mkdir(overrides_dir);
+
+   pgmoneta_snprintf(override_src, sizeof(override_src), "%s/override_marker.txt", overrides_dir);
+   f = fopen(override_src, "w");
+   MCTF_ASSERT(f != NULL, cleanup, "Failed to create override source file: %s", override_src);
+   fprintf(f, "hot-standby-override");
+   fclose(f);
+   f = NULL;
+
+   /* Create a backup which should trigger hot_standby and overrides handling */
+   MCTF_ASSERT(pgmoneta_test_add_backup() == 0, cleanup, "backup failed during setup - check server is online and backup configuration");
+
+   /* Standby destination for the primary server */
+   pgmoneta_snprintf(standby_dir, sizeof(standby_dir), "%s/primary", TEST_HOT_STANDBY_DIR);
+   MCTF_ASSERT(pgmoneta_exists(standby_dir), cleanup, "hot standby directory does not exist: %s", standby_dir);
+
+   /* The override file should have been copied into the standby destination */
+   pgmoneta_snprintf(override_dst, sizeof(override_dst), "%s/override_marker.txt", standby_dir);
+   MCTF_ASSERT(pgmoneta_exists(override_dst), cleanup, "override file missing in hot standby: %s", override_dst);
+
+   /* Ensure there are no encrypted or compressed files in the final standby layout */
+   MCTF_ASSERT(check_files_recursive(standby_dir, &found_files) == 0, cleanup, "Found encrypted or compressed files in hot standby (overrides)");
+   MCTF_ASSERT(found_files > 0, cleanup, "No files found in hot standby directory (overrides)");
+
+cleanup:
+   if (f != NULL)
+   {
+      fclose(f);
+   }
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -1288,14 +1288,14 @@ MCTF_TEST(test_utils_enc_comp)
    MCTF_ASSERT(!pgmoneta_is_encrypted("file.txt"), cleanup, "is_encrypted negative 1 failed");
    MCTF_ASSERT(!pgmoneta_is_encrypted(NULL), cleanup, "is_encrypted NULL failed");
 
-   // Is compressed
+   // Is compressed (via compression helpers)
 
-   MCTF_ASSERT(pgmoneta_is_compressed("file.zstd"), cleanup, "is_compressed zstd failed");
-   MCTF_ASSERT(pgmoneta_is_compressed("file.lz4"), cleanup, "is_compressed lz4 failed");
-   MCTF_ASSERT(pgmoneta_is_compressed("file.bz2"), cleanup, "is_compressed bz2 failed");
-   MCTF_ASSERT(pgmoneta_is_compressed("file.gz"), cleanup, "is_compressed gz failed");
-   MCTF_ASSERT(!pgmoneta_is_compressed("file.txt"), cleanup, "is_compressed negative failed");
-   MCTF_ASSERT(!pgmoneta_is_compressed(NULL), cleanup, "is_compressed NULL failed");
+   MCTF_ASSERT(pgmoneta_compression_is_compressed("file.zstd"), cleanup, "is_compressed zstd failed");
+   MCTF_ASSERT(pgmoneta_compression_is_compressed("file.lz4"), cleanup, "is_compressed lz4 failed");
+   MCTF_ASSERT(pgmoneta_compression_is_compressed("file.bz2"), cleanup, "is_compressed bz2 failed");
+   MCTF_ASSERT(pgmoneta_compression_is_compressed("file.gz"), cleanup, "is_compressed gz failed");
+   MCTF_ASSERT(!pgmoneta_compression_is_compressed("file.txt"), cleanup, "is_compressed negative failed");
+   MCTF_ASSERT(!pgmoneta_compression_is_compressed(NULL), cleanup, "is_compressed NULL failed");
 
    MCTF_ASSERT_INT_EQ(pgmoneta_extraction_strip_suffix("file.zstd.aes",
                                                        PGMONETA_FILE_TYPE_COMPRESSED | PGMONETA_FILE_TYPE_ZSTD | PGMONETA_FILE_TYPE_ENCRYPTED,


### PR DESCRIPTION
**Closes:** [#1020](https://github.com/pgmoneta/pgmoneta/issues/1020)

This PR adds a basic regression test for the [hot_standby](cci:1://file:///Users/sakshii/pgmoneta/src/libpgmoneta/wf_hot_standby.c:68:0-72:1) feature. 
This ensures that when a backup is created, the files are transferred to the standby directory and remain ready for immediate use. Regardless of whether the primary backup is encrypted or compressed, the files in the hot standby are maintained in a fully decrypted and decompressed state so that the standby server can read them instantly.

## What I changed
- Created `test_pgmoneta_hot_standby_basic` to trigger a backup and then recursively crawl the standby folder.
- The test specifically fails if it finds any `.aes` extensions or compressed file signatures.
- Updated the test environment scripts ([check.sh](cci:7://file:///Users/sakshii/pgmoneta/test/check.sh:0:0-0:0) and [tscommon.c](cci:7://file:///Users/sakshii/pgmoneta/test/libpgmonetatest/tscommon.c:0:0-0:0)) so they can manage the new hot standby directory during the test lifecycle.

## Testing
The changes have been verified locally on a macOS environment using the Docker-based test suite:

```bash
./test/check.sh -t test_pgmoneta_hot_standby_basic
```

**Results:**
<img width="509" height="473" alt="image" src="https://github.com/user-attachments/assets/3704125f-ed40-493c-9c4d-2444d0527e99" />
---

**Note to Maintainers:** I have added myself to the `AUTHORS` and acknowledgments files as per the first-time contributor guidelines.
