### PR TITLE
[#1027] test: MCTF per-test max runtime to catch performance regressions

### DIFF
--- a/doc/TEST.md
+++ b/doc/TEST.md
@@ -28,6 +28,7 @@ It is recommended that you **ALWAYS** run tests before raising PR.
 
 - **Automatic test registration** - Tests register automatically via constructor attributes
 - **Per-test pgmoneta log slicing and validation** - Captures each test's log window to `/tmp/pgmoneta-test/log/<module>__<test_name>.pgmoneta.log`; positive tests fail on unexpected `ERROR` lines, while `MCTF_TEST_NEGATIVE` is used for expected-error scenarios
+- **Maximum runtime (performance gate)** - `MCTF_TEST_MAX(name, seconds)` fails the test if it runs longer than the limit; `MCTF_TEST_MAX_NEGATIVE(name, seconds)` adds a time limit to a negative test. Use to catch performance regressions (e.g. after OpenSSL changes).
 
 **Add Testcases**
 
@@ -48,6 +49,25 @@ Behavior:
 - `MCTF_TEST`: fails if the test itself passes but the log slice contains unexpected `ERROR` lines
 - `MCTF_TEST_NEGATIVE`: skips the log-error failure gate for that test (still must satisfy test assertions)
 - `WARN` lines are included in summaries but do not fail a passing test
+
+**Maximum test runtime (performance gate)**
+
+Use `MCTF_TEST_MAX(test_name, max_seconds)` to enforce a maximum allowed runtime. If the test completes successfully but takes longer than `max_seconds`, it is reported as **FAILED** with a message that the maximum time was exceeded.
+
+- **`MCTF_TEST_MAX(name, seconds)`** – Positive test with a time limit.
+- **`MCTF_TEST_MAX_NEGATIVE(name, seconds)`** – Negative test (log errors allowed) with a time limit.
+
+```c
+MCTF_TEST_MAX(test_backup_full, 60)
+{
+   // Test must pass and finish within 60 seconds
+   ...
+}
+```
+
+- Limit is in **seconds**; only the test body runtime is measured (after per-test setup, before per-test teardown).
+- If the test fails by assertion or is skipped, the max-time check does not override that.
+- On timeout, the failure message looks like: `Test exceeded maximum time: 65.234s (limit 60s)`.
 
 **Lifecycle Hooks**
 

--- a/doc/manual/en/76-test.md
+++ b/doc/manual/en/76-test.md
@@ -35,6 +35,7 @@ MCTF (Minimal C Test Framework) is pgmoneta's custom test framework designed for
 - **Test filtering** - Run tests by name pattern (`-t`) or by module (`-m`)
 - **Test skipping** - Skip tests conditionally using `MCTF_SKIP()` when prerequisites aren't met
 - **Per-test pgmoneta log slicing and validation** - Captures each test's log window to `/tmp/pgmoneta-test/log/<module>__<test_name>.pgmoneta.log`; positive tests fail on unexpected `ERROR` lines, while `MCTF_TEST_NEGATIVE` is used for expected-error scenarios
+- **Maximum runtime (performance gate)** - `MCTF_TEST_MAX(name, seconds)` fails the test if it runs longer than the limit; `MCTF_TEST_MAX_NEGATIVE(name, seconds)` adds a time limit to a negative test. Use to catch performance regressions (e.g. after OpenSSL changes).
 - **Lifecycle hooks** – Automatic per-test and per-module setup/teardown via `MCTF_TEST_SETUP`, `MCTF_TEST_TEARDOWN`, `MCTF_MODULE_SETUP`, `MCTF_MODULE_TEARDOWN`
 - **Config snapshot/restore** – `pgmoneta_test_config_save()` / `pgmoneta_test_config_restore()` to isolate shared-memory config changes between tests
 - **Cleanup pattern** - Structured cleanup using goto labels for resource management
@@ -44,7 +45,7 @@ MCTF (Minimal C Test Framework) is pgmoneta's custom test framework designed for
 **What MCTF Cannot Do (Limitations):**
 - **No parameterized tests** - Tests cannot be parameterized (each variation needs a separate test function)
 - **No parallel or async execution** - Tests run sequentially and synchronously
-- **No built-in timeouts** - No framework-level test timeouts (rely on OS-level signals or manual timeouts)
+- **No hard kill on timeout** - Max-time only fails after the test returns; it does not interrupt a stuck test (rely on OS signals or external timeouts for that)
 - **No test organization beyond modules** - No test suites, groups, tags, or metadata beyond module names extracted from filenames
 
 **Add Testcases**
@@ -66,6 +67,25 @@ Behavior:
 - `MCTF_TEST`: fails if the test itself passes but the log slice contains unexpected `ERROR` lines
 - `MCTF_TEST_NEGATIVE`: skips the log-error failure gate for that test (still must satisfy test assertions)
 - `WARN` lines are included in summaries but do not fail a passing test
+
+**Maximum test runtime (performance gate)**
+
+Use `MCTF_TEST_MAX(test_name, max_seconds)` to enforce a maximum allowed runtime. If the test completes successfully but takes longer than `max_seconds`, it is reported as **FAILED** with a message that the maximum time was exceeded.
+
+- **`MCTF_TEST_MAX(name, seconds)`** – Positive test with a time limit.
+- **`MCTF_TEST_MAX_NEGATIVE(name, seconds)`** – Negative test (log errors allowed) with a time limit.
+
+```c
+MCTF_TEST_MAX(test_backup_full, 60)
+{
+   // Test must pass and finish within 60 seconds
+   ...
+}
+```
+
+- Limit is in **seconds**; only the test body runtime is measured (after per-test setup, before per-test teardown).
+- If the test fails by assertion or is skipped, the max-time check does not override that.
+- On timeout, the failure message looks like: `Test exceeded maximum time: 65.234s (limit 60s)`.
 
 **Lifecycle Hooks**
 

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -60,12 +60,13 @@ typedef void (*mctf_hook_func_t)(void);
  */
 typedef struct mctf_test
 {
-   const char* name;       /**< Test name */
-   const char* module;     /**< Module name */
-   const char* file;       /**< Source file name */
-   mctf_test_func_t func;  /**< Test function pointer */
-   bool is_negative;       /**< True if this is a negative test */
-   struct mctf_test* next; /**< Next test in linked list */
+   const char* name;             /**< Test name */
+   const char* module;           /**< Module name */
+   const char* file;             /**< Source file name */
+   mctf_test_func_t func;        /**< Test function pointer */
+   bool is_negative;             /**< True if this is a negative test */
+   unsigned int max_elapsed_sec; /**< Max allowed runtime in seconds; 0 = no limit */
+   struct mctf_test* next;       /**< Next test in linked list */
 } mctf_test_t;
 
 /**
@@ -157,6 +158,29 @@ mctf_register_test(const char* name, const char* module, const char* file, mctf_
  */
 void
 mctf_register_test_with_flags(const char* name, const char* module, const char* file, mctf_test_func_t func, bool is_negative);
+
+/**
+ * Register a test function with a maximum allowed runtime.
+ * If the test runs longer than @p max_seconds, it is reported as failed (performance regression).
+ * @param name The test name
+ * @param module The module name
+ * @param file The source file name
+ * @param func The test function
+ * @param max_seconds Maximum allowed runtime in seconds; test fails if exceeded
+ */
+void
+mctf_register_test_with_max_time(const char* name, const char* module, const char* file, mctf_test_func_t func, unsigned int max_seconds);
+
+/**
+ * Register a test function that is both negative (allows ERROR in pgmoneta.log) and has a max runtime.
+ * @param name The test name
+ * @param module The module name
+ * @param file The source file name
+ * @param func The test function
+ * @param max_seconds Maximum allowed runtime in seconds; 0 = no limit
+ */
+void
+mctf_register_test_with_max_time_negative(const char* name, const char* module, const char* file, mctf_test_func_t func, unsigned int max_seconds);
 
 /**
  * Register a per-test setup hook for a module.
@@ -434,6 +458,42 @@ mctf_get_results(size_t* count);
       mctf_register_test_with_flags(#name, mctf_extract_module_name(file_path), filename, \
                                     name, true);                                          \
    }                                                                                      \
+   static int name(void)
+
+/**
+ * Register a test function with a maximum allowed runtime (performance gate).
+ * The test is run normally; if it completes successfully but takes longer than
+ * @p max_seconds, it is reported as FAILED with a message that the maximum time
+ * was exceeded. Use this to catch performance regressions (e.g. after OpenSSL
+ * or other dependency changes).
+ *
+ * Usage: MCTF_TEST_MAX(my_test, 60) { ... }
+ * Module name is derived from the source file name (same as MCTF_TEST).
+ */
+#define MCTF_TEST_MAX(name, max_seconds)                                                     \
+   static int name(void);                                                                    \
+   static void __attribute__((constructor)) mctf_register_maxtime_##name(void)               \
+   {                                                                                         \
+      const char* file_path = __FILE__;                                                      \
+      const char* filename = mctf_extract_filename(file_path);                               \
+      mctf_register_test_with_max_time(#name, mctf_extract_module_name(file_path), filename, \
+                                       name, (unsigned int)(max_seconds));                   \
+   }                                                                                         \
+   static int name(void)
+
+/**
+ * Register a test that is both negative (allows ERROR in log) and has a max runtime.
+ * Usage: MCTF_TEST_MAX_NEGATIVE(name, max_seconds) { ... }
+ */
+#define MCTF_TEST_MAX_NEGATIVE(name, max_seconds)                                             \
+   static int name(void);                                                                     \
+   static void __attribute__((constructor)) mctf_register_maxtime_negative_##name(void)       \
+   {                                                                                          \
+      const char* file_path = __FILE__;                                                       \
+      const char* filename = mctf_extract_filename(file_path);                                \
+      mctf_register_test_with_max_time_negative(#name, mctf_extract_module_name(file_path),   \
+                                                filename, name, (unsigned int)(max_seconds)); \
+   }                                                                                          \
    static int name(void)
 
 /**

--- a/test/libpgmonetatest/mctf.c
+++ b/test/libpgmonetatest/mctf.c
@@ -215,8 +215,10 @@ mctf_cleanup(void)
    memset(&g_runner, 0, sizeof(g_runner));
 }
 
-void
-mctf_register_test_with_flags(const char* name, const char* module, const char* file, mctf_test_func_t func, bool is_negative)
+/** Internal: register a test with both is_negative and max_elapsed_sec (0 = no limit). */
+static void
+mctf_register_test_with_options(const char* name, const char* module, const char* file,
+                                mctf_test_func_t func, bool is_negative, unsigned int max_elapsed_sec)
 {
    if (!g_initialized)
    {
@@ -259,10 +261,9 @@ mctf_register_test_with_flags(const char* name, const char* module, const char* 
 
    test->func = func;
    test->is_negative = is_negative;
+   test->max_elapsed_sec = max_elapsed_sec;
    test->next = NULL;
 
-   /* Preserve declaration/registration order to keep test sequencing deterministic.
-    * Use tests_tail for O(1) append instead of traversing the full list. */
    if (g_runner.tests == NULL)
    {
       g_runner.tests = test;
@@ -278,11 +279,28 @@ mctf_register_test_with_flags(const char* name, const char* module, const char* 
 }
 
 void
+mctf_register_test_with_flags(const char* name, const char* module, const char* file, mctf_test_func_t func, bool is_negative)
+{
+   mctf_register_test_with_options(name, module, file, func, is_negative, 0);
+}
+
+void
 mctf_register_test(const char* name, const char* module, const char* file, mctf_test_func_t func)
 {
    mctf_register_test_with_flags(name, module, file, func, false);
 }
 
+void
+mctf_register_test_with_max_time(const char* name, const char* module, const char* file, mctf_test_func_t func, unsigned int max_seconds)
+{
+   mctf_register_test_with_options(name, module, file, func, false, max_seconds);
+}
+
+void
+mctf_register_test_with_max_time_negative(const char* name, const char* module, const char* file, mctf_test_func_t func, unsigned int max_seconds)
+{
+   mctf_register_test_with_options(name, module, file, func, true, max_seconds);
+}
 
 /** Find or create a mctf_test_hooks_t record for @p module in the runner. */
 static mctf_test_hooks_t*
@@ -639,7 +657,32 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
 
          bool base_pass = (ret == 0 && mctf_errno == 0);
 
-         if (base_pass)
+         /* Performance gate: fail if test exceeded max allowed runtime */
+         bool timeout = (test->max_elapsed_sec > 0 &&
+                        (unsigned long)elapsed_ms > (unsigned long)test->max_elapsed_sec * 1000UL);
+
+         if (timeout)
+         {
+            result->passed = false;
+            result->error_code = 0;
+            if (result->error_message)
+            {
+               free((void*)result->error_message);
+               result->error_message = NULL;
+            }
+            {
+               char buf[128];
+               snprintf(buf, sizeof(buf),
+                       "Test exceeded maximum time: %ld.%03lds (limit %us)",
+                       elapsed_ms / 1000, elapsed_ms % 1000, test->max_elapsed_sec);
+               result->error_message = strdup(buf);
+            }
+            g_runner.failed_count++;
+            mctf_logf("  %s (%02ld:%02ld:%02ld,%03ld) [FAIL]\n",
+                      test->name, hours, minutes, seconds, milliseconds);
+            mctf_logf("    %s\n", result->error_message);
+         }
+         else if (base_pass)
          {
             /* Passed by assertions; now enforce log cleanliness for positive tests */
             if (!test->is_negative && has_log_errors)
@@ -773,11 +816,22 @@ mctf_print_summary(void)
             }
             else if (r->error_message)
             {
-               mctf_logf("  - %s (%s:%d) - %s\n",
-                         r->test_name,
-                         r->file,
-                         r->error_code,
-                         r->error_message);
+               /* Timeout (and similar) use error_code 0; only print file:line when it's an assertion failure */
+               if (r->error_code != 0)
+               {
+                  mctf_logf("  - %s (%s:%d) - %s\n",
+                            r->test_name,
+                            r->file,
+                            r->error_code,
+                            r->error_message);
+               }
+               else
+               {
+                  mctf_logf("  - %s (%s) - %s\n",
+                            r->test_name,
+                            r->file,
+                            r->error_message);
+               }
             }
             else
             {


### PR DESCRIPTION
new macros: 
`MCTF_TEST_MAX(name, max_seconds)`
`MCTF_TEST_MAX_NEGATIVE(name, max_seconds)`

sample output: 
```
Failed tests:
     - test_exceeds_max_time (test_max_time.c) - Test exceeded maximum time: 5.000s (limit 3s)
```