### PR TITLE
Implement s3 restore to download backups from S3

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -153,6 +153,31 @@ pgmoneta-cli restore primary newest time=2025-01-15\ 10:30:00 /tmp
 pgmoneta-cli restore primary newest timeline=2 /tmp
 ```
 
+## s3 restore
+
+Download a backup from S3 to the local backup directory
+
+This subcommand downloads a backup from S3 storage and makes it available locally. The flow is:
+
+* Download `backup.sha512`, `backup.info`, and `backup.manifest` from S3
+* Verify `backup.info` integrity using the SHA512 checksum
+* Download all data files listed in the manifest, applying the correct compression and encryption extensions
+* Atomically move the downloaded backup into the local backup directory
+
+After `s3 restore` completes, the backup appears in `status details` and can be restored using `pgmoneta-cli restore`.
+
+Command
+
+```sh
+pgmoneta-cli s3 restore <server> <timestamp>
+```
+
+Example
+
+```sh
+pgmoneta-cli s3 restore primary 20260316000957
+```
+
 ## verify
 
 Verify a backup from a server
@@ -487,12 +512,14 @@ Subcommand
 
 - `ls` : List all the files in s3
 - `delete` : Delete all files under a remote prefix in s3
+- `restore` : Download a backup from s3 to the local backup directory
 
 Example
 
 ```sh
 pgmoneta-cli s3 ls primary
 pgmoneta-cli s3 delete primary 20260302163357
+pgmoneta-cli s3 restore primary 20260316000957
 ```
 ### s3 ls
 
@@ -518,6 +545,20 @@ Examples
 ```sh
 pgmoneta-cli s3 delete primary 20260302163357/
 pgmoneta-cli s3 delete primary wal/
+```
+
+### s3 restore
+
+Download a backup from S3 to the local backup directory.
+
+- Downloads and verifies `backup.info` integrity via SHA512
+- Downloads all data files with correct compression/encryption extensions
+- The backup becomes available for `pgmoneta-cli restore`
+
+Examples
+
+```sh
+pgmoneta-cli s3 restore primary 20260316000957
 ```
 ## clear
 

--- a/doc/manual/en/05-cli.md
+++ b/doc/manual/en/05-cli.md
@@ -169,6 +169,31 @@ pgmoneta-cli restore primary newest time=2025-01-15\ 10:30:00 /tmp
 pgmoneta-cli restore primary newest timeline=2 /tmp
 ```
 
+## s3 restore
+
+Download a backup from S3 to the local backup directory
+
+This subcommand downloads a backup from S3 storage and makes it available locally. The flow is:
+
+* Download `backup.sha512`, `backup.info`, and `backup.manifest` from S3
+* Verify `backup.info` integrity using the SHA512 checksum
+* Download all data files listed in the manifest, applying the correct compression and encryption extensions
+* Atomically move the downloaded backup into the local backup directory
+
+After `s3 restore` completes, the backup appears in `status details` and can be restored using `pgmoneta-cli restore`.
+
+Command
+
+``` sh
+pgmoneta-cli s3 restore <server> <timestamp>
+```
+
+Example
+
+``` sh
+pgmoneta-cli s3 restore primary 20260316000957
+```
+
 ## verify
 
 Verify a backup from a server
@@ -524,12 +549,14 @@ Subcommand
 
 - `ls` : List all the files in s3
 - `delete` : Delete all files under a remote prefix in s3
+- `restore` : Download a backup from s3 to the local backup directory
 
 Example
 
 ```sh
 pgmoneta-cli s3 ls primary
 pgmoneta-cli s3 delete primary 20260302163357
+pgmoneta-cli s3 restore primary 20260316000957
 ```
 
 ### s3 ls
@@ -558,6 +585,19 @@ pgmoneta-cli s3 delete primary 20260302163357/
 pgmoneta-cli s3 delete primary wal/
 ```
 
+### s3 restore
+
+Download a backup from S3 to the local backup directory.
+
+- Downloads and verifies `backup.info` integrity via SHA512
+- Downloads all data files with correct compression/encryption extensions
+- The backup becomes available for `pgmoneta-cli restore`
+
+Examples
+
+``` sh
+pgmoneta-cli s3 restore primary 20260316000957
+```
 
 ## clear
 

--- a/doc/manual/en/09-restore.md
+++ b/doc/manual/en/09-restore.md
@@ -94,6 +94,26 @@ Response:
 
 This command take the latest backup and all Write-Ahead Log (WAL) segments and restore it into the `/tmp/primary-20240928065644` directory for an up-to-date copy.
 
+## Restore from S3
+
+If your backups are stored in S3, you first need to download them to the local backup directory using `pgmoneta-cli s3 restore`, then restore normally.
+
+Step 1: Download the backup from S3
+
+```
+pgmoneta-cli s3 restore primary 20260316000957
+```
+
+This downloads the backup files from S3, verifies `backup.info` integrity via SHA512, and places the backup in the local backup directory.
+
+Step 2: Restore the backup
+
+```
+pgmoneta-cli restore primary 20260316000957 current /tmp
+```
+
+This decompresses, decrypts, applies WAL, and produces a usable PostgreSQL data directory.
+
 ## Hot standby
 
 In order to use hot standby, simply add

--- a/src/cli.c
+++ b/src/cli.c
@@ -124,6 +124,7 @@ static int backup(SSL* ssl, int socket, char* server, uint8_t compression, uint8
 static int list_backup(SSL* ssl, int socket, char* server, char* sort_order, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int list_s3_objects(SSL* ssl, int socket, char* server, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int delete_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format);
+static int restore_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int restore(SSL* ssl, int socket, char* server, char* backup_id, char* position, char* directory, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int verify(SSL* ssl, int socket, char* server, char* backup_id, char* directory, char* files, uint8_t compression, uint8_t encryption, int32_t output_format);
 static int archive(SSL* ssl, int socket, char* server, char* backup_id, char* position, char* directory, uint8_t compression, uint8_t encryption, int32_t output_format);
@@ -276,6 +277,12 @@ struct pgmoneta_command command_table[] = {
     .action = MANAGEMENT_S3_DELETE,
     .deprecated = false,
     .log_message = "<s3 delete>"},
+   {.command = "s3",
+    .subcommand = "restore",
+    .accepted_argument_count = {1, 2},
+    .action = MANAGEMENT_S3_RESTORE,
+    .deprecated = false,
+    .log_message = "<s3 restore>"},
    {
       .command = "restore",
       .subcommand = "",
@@ -931,6 +938,10 @@ execute:
    {
       exit_code = delete_s3_objects(s_ssl, socket, parsed.args[0], parsed.args[1], compression, encryption, output_format);
    }
+   else if (parsed.cmd->action == MANAGEMENT_S3_RESTORE)
+   {
+      exit_code = restore_s3_objects(s_ssl, socket, parsed.args[0], parsed.args[1], compression, encryption, output_format);
+   }
    else if (parsed.cmd->action == MANAGEMENT_RESTORE)
    {
       if (parsed.args[3])
@@ -1139,6 +1150,7 @@ help_s3(void)
    printf("Manage the s3\n");
    printf("  pgmoneta-cli s3 ls <server>\n");
    printf("  pgmoneta-cli s3 delete <server> <prefix>\n");
+   printf("  pgmoneta-cli s3 restore <server> <prefix> \n");
 }
 
 static void
@@ -1433,6 +1445,24 @@ static int
 delete_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    if (pgmoneta_management_request_delete_s3_objects(ssl, socket, server, prefix, compression, encryption, output_format))
+   {
+      goto error;
+   }
+
+   if (process_result(ssl, socket, output_format))
+   {
+      goto error;
+   }
+
+   return 0;
+
+error:
+   return 1;
+}
+static int
+restore_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   if (pgmoneta_management_request_restore_s3_objects(ssl, socket, server, prefix, compression, encryption, output_format))
    {
       goto error;
    }
@@ -2621,6 +2651,11 @@ translate_command(int32_t cmd_code)
          command_output = pgmoneta_append_char(command_output, ' ');
          command_output = pgmoneta_append(command_output, "delete");
          break;
+      case MANAGEMENT_S3_RESTORE:
+         command_output = pgmoneta_append(command_output, COMMAND_S3);
+         command_output = pgmoneta_append_char(command_output, ' ');
+         command_output = pgmoneta_append(command_output, "restore");
+         break;
       case MANAGEMENT_RESTORE:
          command_output = pgmoneta_append(command_output, COMMAND_RESTORE);
          break;
@@ -3302,6 +3337,7 @@ translate_json_object(struct json* j)
                }
                pgmoneta_json_iterator_destroy(server_it);
                break;
+            case MANAGEMENT_S3_RESTORE:
             case MANAGEMENT_S3_DELETE:
                break;
             case MANAGEMENT_STATUS_DETAILS:

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -96,6 +96,7 @@ extern "C" {
 
 #define MANAGEMENT_S3_LS          200
 #define MANAGEMENT_S3_DELETE      201
+#define MANAGEMENT_S3_RESTORE     202
 
 /**
  * Management categories
@@ -400,6 +401,12 @@ extern "C" {
 #define MANAGEMENT_ERROR_DELETE_S3_INVALID_PREFIX           3104
 #define MANAGEMENT_ERROR_DELETE_S3_ERROR                    3105
 
+#define MANAGEMENT_ERROR_RESTORE_S3_NOSERVER                3200
+#define MANAGEMENT_ERROR_RESTORE_S3_NOFORK                  3201
+#define MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW                3202
+#define MANAGEMENT_ERROR_RESTORE_S3_NETWORK                 3203
+#define MANAGEMENT_ERROR_RESTORE_S3_ERROR                   3204
+
 /**
  * Output formats
  */
@@ -504,6 +511,20 @@ pgmoneta_management_request_list_s3_objects(SSL* ssl, int socket, char* server, 
  */
 int
 pgmoneta_management_request_delete_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format);
+
+/**
+ * Create a restore s3 objects request
+ * @param ssl The SSL connection
+ * @param socket The socket descriptor
+ * @param server The server
+ * @param prefix The prefix to delete under the server backup path
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param output_format The output format
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_request_restore_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format);
 
 /**
  * Create a restore request

--- a/src/include/s3.h
+++ b/src/include/s3.h
@@ -59,6 +59,19 @@ pgmoneta_list_s3_objects(int client_fd, int server, uint8_t compression, uint8_t
  */
 void
 pgmoneta_delete_s3_objects(int client_fd, int server, char* prefix, uint8_t compression, uint8_t encryption, struct json* payload);
+
+/**
+ * restore S3 objects for a server under a prefix
+ * @param client_fd The client
+ * @param server The server
+ * @param prefix The prefix under server backup path
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The payload
+ */
+void
+pgmoneta_restore_s3_objects(int client_fd, int server, char* prefix, uint8_t compression, uint8_t encryption, struct json* payload);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -727,6 +727,20 @@ pgmoneta_get_directories(char* base, int* number_of_directories, char*** dirs);
  */
 int
 pgmoneta_delete_directory(char* path);
+/**
+ * Append a buffer to a file (create if missing), with an optional offset check.
+ *
+ * The function will create parent directories for tmp_path if needed.
+ *
+ * @param tmp_path The temporary/in-progress file path (e.g. "<final>.tmp")
+ * @param data The buffer to append
+ * @param data_size The number of bytes to append
+ * @param expected_offset The expected current size of tmp_path before writing,
+ *                        or (size_t)-1 to skip the check
+ * @return 0 on success, otherwise 1
+*/
+int
+pgmoneta_append_file_chunk(const char* tmp_path, const void* data, size_t data_size, long expected_offset);
 
 /**
  * Get files with type filtering and optional recursion

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -54,6 +54,7 @@ extern "C" {
 
 #define WORKFLOW_TYPE_S3_LIST            100
 #define WORKFLOW_TYPE_S3_DELETE          101
+#define WORKFLOW_TYPE_S3_RESTORE         102
 
 #define PERMISSION_TYPE_BACKUP           0
 #define PERMISSION_TYPE_RESTORE          1

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -193,6 +193,40 @@ error:
 }
 
 int
+pgmoneta_management_request_restore_s3_objects(SSL* ssl, int socket, char* server, char* prefix, uint8_t compression, uint8_t encryption, int32_t output_format)
+{
+   struct json* j = NULL;
+   struct json* request = NULL;
+
+   if (pgmoneta_management_create_header(MANAGEMENT_S3_RESTORE, compression, encryption, output_format, &j))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_management_create_request(j, &request))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)server, ValueString);
+   pgmoneta_json_put(request, MANAGEMENT_ARGUMENT_S3_PREFIX, (uintptr_t)prefix, ValueString);
+
+   if (pgmoneta_management_write_json(ssl, socket, compression, encryption, j))
+   {
+      goto error;
+   }
+
+   pgmoneta_json_destroy(j);
+
+   return 0;
+
+error:
+
+   pgmoneta_json_destroy(j);
+
+   return 1;
+}
+int
 pgmoneta_management_request_restore(SSL* ssl, int socket, char* server, char* backup_id, char* position, char* directory, uint8_t compression, uint8_t encryption, int32_t output_format)
 {
    struct json* j = NULL;

--- a/src/libpgmoneta/s3.c
+++ b/src/libpgmoneta/s3.c
@@ -313,3 +313,105 @@ error:
    pgmoneta_stop_logging();
    exit(1);
 }
+void
+pgmoneta_restore_s3_objects(int client_fd, int server, char* prefix, uint8_t compression, uint8_t encryption, struct json* payload)
+{
+   char* elapsed = NULL;
+   char* en = NULL;
+   int ec = -1;
+   struct timespec start_t;
+   struct timespec end_t;
+   double total_seconds;
+   // struct json* response = NULL;
+   struct art* nodes = NULL;
+   struct workflow* workflow = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
+#endif
+
+   if (!s3_is_safe_prefix(prefix))
+   {
+      ec = MANAGEMENT_ERROR_RESTORE_S3_ERROR;
+      pgmoneta_log_error("S3 restore: invalid prefix for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+   if (pgmoneta_art_create(&nodes))
+   {
+      ec = MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW;
+      goto error;
+   }
+
+   if (pgmoneta_art_insert(nodes, NODE_SERVER_ID, (uintptr_t)server, ValueInt32))
+   {
+      ec = MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW;
+      goto error;
+   }
+
+   if (pgmoneta_art_insert(nodes, NODE_LABEL, (uintptr_t)prefix, ValueString))
+   {
+      ec = MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW;
+      goto error;
+   }
+
+   workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_S3_RESTORE, NULL);
+
+   if (workflow == NULL)
+   {
+      ec = MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW;
+      pgmoneta_log_error("S3 restore: S3 storage engine is not configured for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+   if (pgmoneta_workflow_execute(workflow, nodes, &en, &ec))
+   {
+      pgmoneta_log_error("S3 restore: workflow failed for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+#endif
+
+   if (pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload))
+   {
+      ec = MANAGEMENT_ERROR_RESTORE_S3_NETWORK;
+      pgmoneta_log_error("S3 restore: error sending response for %s", config->common.servers[server].name);
+      goto error;
+   }
+
+   elapsed = pgmoneta_get_timestamp_string(start_t, end_t, &total_seconds);
+   pgmoneta_log_info("S3 restore: %s/%s (Elapsed: %s)", config->common.servers[server].name, prefix, elapsed);
+
+   pgmoneta_json_destroy(payload);
+   pgmoneta_art_destroy(nodes);
+   pgmoneta_workflow_destroy(workflow);
+   free(elapsed);
+
+   pgmoneta_disconnect(client_fd);
+   pgmoneta_stop_logging();
+   exit(0);
+
+error:
+
+   pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
+                                      ec != -1 ? ec : MANAGEMENT_ERROR_RESTORE_S3_ERROR, en != NULL ? en : NAME,
+                                      compression, encryption, payload);
+
+   pgmoneta_json_destroy(payload);
+   pgmoneta_art_destroy(nodes);
+   pgmoneta_workflow_destroy(workflow);
+   free(elapsed);
+
+   pgmoneta_disconnect(client_fd);
+   pgmoneta_stop_logging();
+   exit(1);
+}

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -28,9 +28,13 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <csv.h>
 #include <deque.h>
+#include <extraction.h>
 #include <http.h>
+#include <info.h>
 #include <logging.h>
+#include <manifest.h>
 #include <security.h>
 #include <utils.h>
 #include <workflow.h>
@@ -46,16 +50,21 @@
 static char* s3_storage_name(void);
 static int s3_storage_setup(char*, struct art*);
 static int s3_storage_execute(char*, struct art*);
+static int s3_storage_restore(char*, struct art*);
 static int s3_storage_list(char*, struct art*);
 static int s3_storage_teardown(char*, struct art*);
+static int s3_storage_noop_teardown(char*, struct art*);
 static int s3_storage_cleanup(char*, struct art*);
 static int s3_upload_files(char* local_root, char* s3_root, char* relative_path, int server);
+static int s3_bootstrap(char* s3_root, int server, char* local_root);
+static int s3_download_files(char* s3_root, char* local_root, int server, int compression, int encryption);
 static int s3_send_upload_request(char* local_root, char* s3_root, char* relative_path, int server);
 static int s3_list_objects(char* relative_path, char* s3_list, int server, struct deque** objects);
 static int s3_delete_all_objects(char* relative_path, char* s3_list, int server, struct art*) __attribute__((unused));
 static int s3_send_list_request(char* relative_path, char* s3_list, int server, char* continuationToken, struct http_response** response);
 static int s3_send_delete_request(char* relative_path, char* s3_list, int server, char* xml_body, struct http_response** response);
 static int s3_add_request_headers(struct http_request* request, char* auth_value, char* file_sha256, char* long_date, char* storage_class);
+static int s3_send_get_request(char* relative_path, char* s3_root, int server, long range_start, long range_end, struct http_response** response);
 
 static char* s3_get_host(int server);
 static char* s3_get_basepath(int server, char* identifier);
@@ -65,6 +74,8 @@ static int xml_s3_build_delete_key(char** xml, char* key);
 static int xml_s3_build_delete_list(char** xml, struct deque* keys, size_t max_keys);
 static int xml_parse_s3_list_truncated(char* xml, bool* is_truncated, char** continuationToken);
 static int xml_parse_s3_list(char* xml, struct deque** keys);
+
+static void do_download_file(struct worker_common* wc);
 
 struct workflow*
 pgmoneta_storage_create_s3(int workflow_type)
@@ -80,19 +91,25 @@ pgmoneta_storage_create_s3(int workflow_type)
    {
       case WORKFLOW_TYPE_BACKUP:
          wf->execute = &s3_storage_execute;
+         wf->teardown = &s3_storage_teardown;
          break;
       case WORKFLOW_TYPE_S3_LIST:
          wf->execute = &s3_storage_list;
+         wf->teardown = &s3_storage_noop_teardown;
          break;
       case WORKFLOW_TYPE_DELETE_BACKUP:
       case WORKFLOW_TYPE_S3_DELETE:
          wf->execute = &s3_storage_cleanup;
+         wf->teardown = &s3_storage_noop_teardown;
+         break;
+      case WORKFLOW_TYPE_S3_RESTORE:
+         wf->execute = &s3_storage_restore;
+         wf->teardown = &s3_storage_noop_teardown;
          break;
       default:
          break;
    }
 
-   wf->teardown = &s3_storage_teardown;
    wf->next = NULL;
 
    return wf;
@@ -439,6 +456,13 @@ s3_storage_teardown(char* name __attribute__((unused)), struct art* nodes)
 
    return 0;
 }
+
+static int
+s3_storage_noop_teardown(char* name __attribute__((unused)), struct art* nodes __attribute__((unused)))
+{
+   return 0;
+}
+
 static int
 s3_storage_cleanup(char* name __attribute__((unused)), struct art* nodes)
 {
@@ -481,7 +505,412 @@ error:
    free(s3_root);
    return 1;
 }
+static int
+s3_storage_restore(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server = -1;
+   char* label = NULL;
+   char* s3_root = NULL;
+   char* temp_label = NULL;
+   char* local_root = NULL;
+   char* final_root = NULL;
+   char* base_dir = NULL;
+   struct backup* backup = NULL;
+   struct main_configuration* config;
 
+   config = (struct main_configuration*)shmem;
+
+#ifdef DEBUG
+   pgmoneta_dump_art(nodes);
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
+   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
+#endif
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+
+   pgmoneta_log_debug("S3 storage engine (restore): %s/%s",
+                      config->common.servers[server].name, label);
+   pgmoneta_log_debug("S3 effective config: bucket=%s, region=%s, endpoint=%s",
+                      s3_get_effective_bucket(server),
+                      s3_get_effective_region(server),
+                      s3_get_effective_endpoint(server));
+
+   s3_root = s3_get_basepath(server, label);
+
+   temp_label = pgmoneta_append(temp_label, ".pgmoneta_temp_");
+   temp_label = pgmoneta_append(temp_label, label);
+   local_root = pgmoneta_get_server_backup_identifier(server, temp_label);
+
+   if (s3_bootstrap(s3_root, server, local_root))
+   {
+      goto error;
+   }
+
+   base_dir = pgmoneta_get_server_backup(server);
+
+   if (pgmoneta_load_info(base_dir, temp_label, &backup))
+   {
+      pgmoneta_log_error("S3 restore: failed to load backup.info from %s", local_root);
+      goto error;
+   }
+
+   pgmoneta_log_debug("S3 restore: compression=%d encryption=%d", backup->compression, backup->encryption);
+
+   if (s3_download_files(s3_root, local_root, server, backup->compression, backup->encryption))
+   {
+      goto error;
+   }
+
+   final_root = pgmoneta_get_server_backup_identifier(server, label);
+
+   if (rename(local_root, final_root))
+   {
+      pgmoneta_log_error("S3 restore: could not rename %s to %s", local_root, final_root);
+      goto error;
+   }
+
+   pgmoneta_log_info("S3 restore: %s/%s completed", config->common.servers[server].name, label);
+
+   free(s3_root);
+   free(temp_label);
+   free(local_root);
+   free(final_root);
+   free(base_dir);
+   free(backup);
+
+   return 0;
+
+error:
+
+   if (local_root != NULL)
+   {
+      pgmoneta_delete_directory(local_root);
+   }
+
+   free(s3_root);
+   free(temp_label);
+   free(local_root);
+   free(final_root);
+   free(base_dir);
+   free(backup);
+   return 1;
+}
+
+static int
+s3_bootstrap(char* s3_root, int server, char* local_root)
+{
+   char buffer[4096];
+   char* expected_hash = NULL;
+   char* computed_hash = NULL;
+   char* sha512_path = NULL;
+   char* info_path = NULL;
+   char* manifest_path = NULL;
+   FILE* sha512_file = NULL;
+   struct http_response* response = NULL;
+
+   pgmoneta_log_debug("S3 bootstrap: downloading root files");
+
+   // download backup.sha512 file
+
+   if (s3_send_get_request("backup.sha512", s3_root, server, -1, -1, &response))
+   {
+      pgmoneta_log_error("S3 bootstrap: failed to GET backup.sha512");
+      goto error;
+   }
+
+   if (response->status_code != 200)
+   {
+      pgmoneta_log_error("S3 bootstrap: backup.sha512 returned status %d", response->status_code);
+      goto error;
+   }
+
+   sha512_path = pgmoneta_append(sha512_path, local_root);
+   sha512_path = pgmoneta_append(sha512_path, "backup.sha512");
+
+   if (pgmoneta_append_file_chunk(sha512_path, response->payload.data, response->payload.data_size, 0))
+   {
+      pgmoneta_log_error("S3 bootstrap: failed to write backup.sha512");
+      goto error;
+   }
+
+   pgmoneta_log_debug("S3 bootstrap: downloaded backup.sha512");
+   pgmoneta_http_response_destroy(response);
+   response = NULL;
+
+   if (s3_send_get_request("backup.info", s3_root, server, -1, -1, &response))
+   {
+      pgmoneta_log_error("S3 bootstrap: failed to GET backup.info");
+      goto error;
+   }
+
+   if (response->status_code != 200)
+   {
+      pgmoneta_log_error("S3 bootstrap: backup.info returned status %d", response->status_code);
+      goto error;
+   }
+
+   info_path = pgmoneta_append(info_path, local_root);
+   info_path = pgmoneta_append(info_path, "backup.info");
+
+   if (pgmoneta_append_file_chunk(info_path, response->payload.data, response->payload.data_size, 0))
+   {
+      pgmoneta_log_error("S3 bootstrap: failed to write backup.info");
+      goto error;
+   }
+
+   pgmoneta_log_debug("S3 bootstrap: downloaded backup.info");
+   pgmoneta_http_response_destroy(response);
+   response = NULL;
+
+   // verify SHA512 of backup.info
+   sha512_file = fopen(sha512_path, "r");
+   if (sha512_file == NULL)
+   {
+      pgmoneta_log_error("S3 bootstrap: could not open %s", sha512_path);
+      goto error;
+   }
+
+   if (fgets(&buffer[0], sizeof(buffer), sha512_file) == NULL)
+   {
+      pgmoneta_log_error("S3 bootstrap: backup.sha512 is empty");
+      goto error;
+   }
+
+   fclose(sha512_file);
+   sha512_file = NULL;
+
+   expected_hash = strtok(&buffer[0], " ");
+   if (expected_hash == NULL)
+   {
+      pgmoneta_log_error("S3 bootstrap: backup.sha512 format error");
+      goto error;
+   }
+
+   if (pgmoneta_create_sha512_file(info_path, &computed_hash))
+   {
+      pgmoneta_log_error("S3 bootstrap: could not compute SHA512 of backup.info");
+      goto error;
+   }
+
+   if (strcmp(expected_hash, computed_hash))
+   {
+      pgmoneta_log_error("S3 bootstrap: backup.info SHA512 mismatch");
+      pgmoneta_log_error("S3 bootstrap: expected %s", expected_hash);
+      pgmoneta_log_error("S3 bootstrap: computed %s", computed_hash);
+      goto error;
+   }
+
+   pgmoneta_log_info("S3 bootstrap: backup.info integrity verified");
+
+   //download backup.manifest (CSV)
+   if (s3_send_get_request("backup.manifest", s3_root, server, -1, -1, &response))
+   {
+      pgmoneta_log_error("S3 bootstrap: failed to GET backup.manifest");
+      goto error;
+   }
+
+   if (response->status_code != 200)
+   {
+      pgmoneta_log_error("S3 bootstrap: backup.manifest returned status %d", response->status_code);
+      goto error;
+   }
+
+   manifest_path = pgmoneta_append(manifest_path, local_root);
+   manifest_path = pgmoneta_append(manifest_path, "backup.manifest");
+
+   if (pgmoneta_append_file_chunk(manifest_path, response->payload.data, response->payload.data_size, 0))
+   {
+      pgmoneta_log_error("S3 bootstrap: failed to write backup.manifest");
+      goto error;
+   }
+
+   pgmoneta_log_info("S3 bootstrap: downloaded backup.manifest");
+   pgmoneta_http_response_destroy(response);
+   response = NULL;
+
+   free(sha512_path);
+   free(info_path);
+   free(manifest_path);
+   free(computed_hash);
+
+   return 0;
+
+error:
+
+   if (sha512_file != NULL)
+   {
+      fclose(sha512_file);
+   }
+
+   pgmoneta_http_response_destroy(response);
+   free(sha512_path);
+   free(info_path);
+   free(manifest_path);
+   free(computed_hash);
+
+   return 1;
+}
+
+static int
+s3_download_files(char* s3_root, char* local_root, int server, int compression, int encryption)
+{
+   char** columns = NULL;
+   char* s3_path = NULL;
+   char* local_file_path = NULL;
+   char* suffix = NULL;
+   char* filename = NULL;
+   char* manifest_path = NULL;
+   int number_of_columns = 0;
+   int number_of_workers = 0;
+   struct csv_reader* csv = NULL;
+   struct workers* workers = NULL;
+   struct worker_input* payload = NULL;
+
+   manifest_path = pgmoneta_append(manifest_path, local_root);
+   manifest_path = pgmoneta_append(manifest_path, "backup.manifest");
+
+   if (pgmoneta_extraction_get_suffix(compression, encryption, &suffix))
+   {
+      pgmoneta_log_error("S3 download: failed to determine file suffix");
+      goto error;
+   }
+
+   pgmoneta_log_debug("S3 download: file suffix is '%s'", suffix != NULL ? suffix : "(none)");
+
+   number_of_workers = pgmoneta_get_number_of_workers(server);
+   if (number_of_workers > 0)
+   {
+      pgmoneta_workers_initialize(number_of_workers, &workers);
+   }
+
+   if (pgmoneta_csv_reader_init(manifest_path, &csv))
+   {
+      pgmoneta_log_error("S3 download: failed to open manifest %s", manifest_path);
+      goto error;
+   }
+
+   while (pgmoneta_csv_next_row(csv, &number_of_columns, &columns))
+   {
+      if (number_of_columns != MANIFEST_COLUMN_COUNT)
+      {
+         pgmoneta_log_error("S3 download: manifest row has %d columns, expected %d", number_of_columns, MANIFEST_COLUMN_COUNT);
+         goto error;
+      }
+
+      filename = NULL;
+      filename = pgmoneta_append(filename, columns[MANIFEST_PATH_INDEX]);
+
+      if (suffix != NULL &&
+          !pgmoneta_ends_with(columns[MANIFEST_PATH_INDEX], "backup_label") &&
+          !pgmoneta_ends_with(columns[MANIFEST_PATH_INDEX], "backup_manifest"))
+      {
+         filename = pgmoneta_append(filename, suffix);
+      }
+
+      s3_path = NULL;
+      s3_path = pgmoneta_append(s3_path, "data/");
+      s3_path = pgmoneta_append(s3_path, filename);
+
+      local_file_path = NULL;
+      local_file_path = pgmoneta_append(local_file_path, local_root);
+      local_file_path = pgmoneta_append(local_file_path, "data/");
+      local_file_path = pgmoneta_append(local_file_path, filename);
+
+      if (pgmoneta_create_worker_input(s3_root, s3_path, local_file_path, server, workers, &payload))
+      {
+         pgmoneta_log_error("S3 download: failed to create worker input");
+         goto error;
+      }
+
+      if (workers != NULL && workers->outcome)
+      {
+         pgmoneta_workers_add(workers, do_download_file, (struct worker_common*)payload);
+      }
+      else
+      {
+         do_download_file((struct worker_common*)payload);
+      }
+
+      free(filename);
+      filename = NULL;
+      free(s3_path);
+      s3_path = NULL;
+      free(local_file_path);
+      local_file_path = NULL;
+      free(columns);
+      columns = NULL;
+   }
+
+   pgmoneta_workers_wait(workers);
+   if (workers != NULL && !workers->outcome)
+   {
+      goto error;
+   }
+   pgmoneta_workers_destroy(workers);
+
+   pgmoneta_csv_reader_destroy(csv);
+   free(manifest_path);
+   free(suffix);
+
+   return 0;
+
+error:
+
+   pgmoneta_csv_reader_destroy(csv);
+   pgmoneta_workers_wait(workers);
+   pgmoneta_workers_destroy(workers);
+   free(manifest_path);
+   free(suffix);
+   free(filename);
+   free(s3_path);
+   free(local_file_path);
+   free(columns);
+
+   return 1;
+}
+static void
+do_download_file(struct worker_common* wc)
+{
+   struct worker_input* wi = (struct worker_input*)wc;
+   struct http_response* response = NULL;
+   char* s3_root = wi->directory;
+   char* s3_path = wi->from;
+   char* local_path = wi->to;
+   int server = wi->level;
+
+   if (s3_send_get_request(s3_path, s3_root, server, -1, -1, &response))
+   {
+      pgmoneta_log_error("S3 download: failed to GET %s", s3_path);
+      goto error;
+   }
+
+   if (response->status_code != 200)
+   {
+      pgmoneta_log_error("S3 download: %s returned status %d", s3_path, response->status_code);
+      goto error;
+   }
+
+   if (pgmoneta_append_file_chunk(local_path, response->payload.data, response->payload.data_size, 0))
+   {
+      pgmoneta_log_error("S3 download: failed to write %s", local_path);
+      goto error;
+   }
+
+   pgmoneta_log_debug("S3 download: %s", s3_path);
+   pgmoneta_http_response_destroy(response);
+   free(wi);
+   return;
+
+error:
+   if (wi->common.workers != NULL)
+   {
+      wi->common.workers->outcome = false;
+   }
+   pgmoneta_http_response_destroy(response);
+   free(wi);
+}
 static int
 s3_upload_files(char* local_root, char* s3_root, char* relative_path, int server)
 {
@@ -693,8 +1122,8 @@ s3_send_list_request(char* relative_path, char* s3_root, int server, char* conti
    char* effective_endpoint = s3_get_effective_endpoint(server);
    char* effective_region = s3_get_effective_region(server);
    char* effective_access_key_id = s3_get_effective_access_key_id(server);
-   char* effective_secret_access_key = s3_get_effective_secret_access_key(server);
    char* effective_bucket = s3_get_effective_bucket(server);
+   char* effective_secret_access_key = s3_get_effective_secret_access_key(server);
    int effective_port = s3_get_effective_port(server);
    bool effective_use_tls = s3_get_effective_use_tls(server);
    bool path_style = (strlen(effective_endpoint) > 0);
@@ -1181,6 +1610,273 @@ error:
    free(string_to_sign);
    free(auth_value);
    free(query_string);
+
+   if (connection != NULL)
+   {
+      pgmoneta_http_destroy(connection);
+   }
+
+   if (request != NULL)
+   {
+      pgmoneta_http_request_destroy(request);
+   }
+
+   return 1;
+}
+static int
+s3_send_get_request(char* relative_path, char* s3_root, int server,
+                    long range_start, long range_end,
+                    struct http_response** response)
+{
+   char short_date[SHORT_TIME_LENGTH];
+   char long_date[LONG_TIME_LENGTH];
+   char* canonical_request = NULL;
+   char* auth_value = NULL;
+   char* string_to_sign = NULL;
+   char* s3_host = NULL;
+   char* s3_path = NULL;
+   char* request_path = NULL;
+   char* canonical_request_sha256 = NULL;
+   char* key = NULL;
+   char* body_hash = NULL;
+   char* range_header = NULL;
+   unsigned char* date_key_hmac = NULL;
+   unsigned char* date_region_key_hmac = NULL;
+   unsigned char* date_region_service_key_hmac = NULL;
+   unsigned char* signing_key_hmac = NULL;
+   unsigned char* signature_hmac = NULL;
+   unsigned char* signature_hex = NULL;
+   int hmac_length = 0;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+
+   char* effective_endpoint = s3_get_effective_endpoint(server);
+   char* effective_region = s3_get_effective_region(server);
+   char* effective_access_key_id = s3_get_effective_access_key_id(server);
+   char* effective_secret_access_key = s3_get_effective_secret_access_key(server);
+   int effective_port = s3_get_effective_port(server);
+   bool effective_use_tls = s3_get_effective_use_tls(server);
+   bool path_style = (strlen(effective_endpoint) > 0);
+
+   s3_path = pgmoneta_append(s3_path, s3_root);
+   if (relative_path != NULL && strlen(relative_path) > 0)
+   {
+      if (!pgmoneta_ends_with(s3_root, "/"))
+      {
+         s3_path = pgmoneta_append(s3_path, "/");
+      }
+      s3_path = pgmoneta_append(s3_path, relative_path);
+   }
+
+   memset(&short_date[0], 0, sizeof(short_date));
+   memset(&long_date[0], 0, sizeof(long_date));
+
+   if (pgmoneta_get_timestamp_ISO8601_format(short_date, long_date))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_sha256_hash("", &body_hash))
+   {
+      goto error;
+   }
+
+   s3_host = s3_get_host(server);
+
+   if (range_start >= 0 && range_end > range_start)
+   {
+      char range_buf[64];
+      range_header = pgmoneta_append(range_header, "bytes=");
+      pgmoneta_snprintf(range_buf, sizeof(range_buf), "%ld-%ld", range_start, range_end);
+      range_header = pgmoneta_append(range_header, range_buf);
+   }
+
+   canonical_request = pgmoneta_append(canonical_request, "GET\n/");
+   canonical_request = pgmoneta_append(canonical_request, s3_path);
+   canonical_request = pgmoneta_append(canonical_request, "\n\n");
+
+   canonical_request = pgmoneta_append(canonical_request, "host:");
+   canonical_request = pgmoneta_append(canonical_request, s3_host);
+   canonical_request = pgmoneta_append(canonical_request, "\n");
+
+   if (range_header != NULL)
+   {
+      canonical_request = pgmoneta_append(canonical_request, "range:");
+      canonical_request = pgmoneta_append(canonical_request, range_header);
+      canonical_request = pgmoneta_append(canonical_request, "\n");
+   }
+
+   canonical_request = pgmoneta_append(canonical_request, "x-amz-content-sha256:");
+   canonical_request = pgmoneta_append(canonical_request, body_hash);
+   canonical_request = pgmoneta_append(canonical_request, "\n");
+
+   canonical_request = pgmoneta_append(canonical_request, "x-amz-date:");
+   canonical_request = pgmoneta_append(canonical_request, long_date);
+   canonical_request = pgmoneta_append(canonical_request, "\n\n");
+
+   if (range_header != NULL)
+   {
+      canonical_request = pgmoneta_append(canonical_request, "host;range;x-amz-content-sha256;x-amz-date\n");
+   }
+   else
+   {
+      canonical_request = pgmoneta_append(canonical_request, "host;x-amz-content-sha256;x-amz-date\n");
+   }
+
+   canonical_request = pgmoneta_append(canonical_request, body_hash);
+
+   pgmoneta_generate_string_sha256_hash(canonical_request, &canonical_request_sha256);
+
+   string_to_sign = pgmoneta_append(string_to_sign, "AWS4-HMAC-SHA256\n");
+   string_to_sign = pgmoneta_append(string_to_sign, long_date);
+   string_to_sign = pgmoneta_append(string_to_sign, "\n");
+   string_to_sign = pgmoneta_append(string_to_sign, short_date);
+   string_to_sign = pgmoneta_append(string_to_sign, "/");
+   string_to_sign = pgmoneta_append(string_to_sign, effective_region);
+   string_to_sign = pgmoneta_append(string_to_sign, "/s3/aws4_request\n");
+   string_to_sign = pgmoneta_append(string_to_sign, canonical_request_sha256);
+
+   key = pgmoneta_append(key, "AWS4");
+   key = pgmoneta_append(key, effective_secret_access_key);
+
+   if (pgmoneta_generate_string_hmac_sha256_hash(key, strlen(key), short_date, SHORT_TIME_LENGTH - 1, &date_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)date_key_hmac, hmac_length, effective_region, strlen(effective_region), &date_region_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)date_region_key_hmac, hmac_length, "s3", strlen("s3"), &date_region_service_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)date_region_service_key_hmac, hmac_length, "aws4_request", strlen("aws4_request"), &signing_key_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash((char*)signing_key_hmac, hmac_length, string_to_sign, strlen(string_to_sign), &signature_hmac, &hmac_length))
+   {
+      goto error;
+   }
+
+   pgmoneta_convert_base32_to_hex(signature_hmac, hmac_length, &signature_hex);
+
+   if (range_start >= 0 && range_end > range_start)
+   {
+      auth_value = pgmoneta_append(auth_value, "AWS4-HMAC-SHA256 Credential=");
+      auth_value = pgmoneta_append(auth_value, effective_access_key_id);
+      auth_value = pgmoneta_append(auth_value, "/");
+      auth_value = pgmoneta_append(auth_value, short_date);
+      auth_value = pgmoneta_append(auth_value, "/");
+      auth_value = pgmoneta_append(auth_value, effective_region);
+      auth_value = pgmoneta_append(auth_value, "/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=");
+      auth_value = pgmoneta_append(auth_value, (char*)signature_hex);
+   }
+   else
+   {
+      auth_value = pgmoneta_append(auth_value, "AWS4-HMAC-SHA256 Credential=");
+      auth_value = pgmoneta_append(auth_value, effective_access_key_id);
+      auth_value = pgmoneta_append(auth_value, "/");
+      auth_value = pgmoneta_append(auth_value, short_date);
+      auth_value = pgmoneta_append(auth_value, "/");
+      auth_value = pgmoneta_append(auth_value, effective_region);
+      auth_value = pgmoneta_append(auth_value, "/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=");
+      auth_value = pgmoneta_append(auth_value, (char*)signature_hex);
+   }
+
+   int s3_port;
+   if (effective_port != 0)
+   {
+      s3_port = effective_port;
+   }
+   else
+   {
+      s3_port = effective_use_tls ? 443 : 80;
+   }
+
+   bool use_tls = effective_use_tls;
+   if (s3_port == 443)
+   {
+      use_tls = true;
+   }
+
+   if (pgmoneta_http_create(s3_host, s3_port, use_tls, &connection))
+   {
+      goto error;
+   }
+
+   (void)path_style;
+   request_path = pgmoneta_append(request_path, "/");
+   request_path = pgmoneta_append(request_path, s3_path);
+
+   if (pgmoneta_http_request_create(PGMONETA_HTTP_GET, request_path, &request))
+   {
+      goto error;
+   }
+
+   if (s3_add_request_headers(request, auth_value, body_hash, long_date, ""))
+   {
+      goto error;
+   }
+
+   if (range_header != NULL)
+   {
+      if (pgmoneta_http_request_add_header(request, "Range", range_header))
+      {
+         goto error;
+      }
+   }
+
+   if (pgmoneta_http_invoke(connection, request, response))
+   {
+      goto error;
+   }
+
+   free(s3_host);
+   free(request_path);
+   free(range_header);
+   free(signature_hex);
+   free(signature_hmac);
+   free(signing_key_hmac);
+   free(date_region_service_key_hmac);
+   free(date_region_key_hmac);
+   free(date_key_hmac);
+   free(key);
+   free(s3_path);
+   free(body_hash);
+   free(canonical_request_sha256);
+   free(canonical_request);
+   free(string_to_sign);
+   free(auth_value);
+
+   pgmoneta_http_request_destroy(request);
+   pgmoneta_http_destroy(connection);
+
+   return 0;
+
+error:
+
+   free(s3_host);
+   free(request_path);
+   free(range_header);
+   free(signature_hex);
+   free(signature_hmac);
+   free(signing_key_hmac);
+   free(date_region_service_key_hmac);
+   free(date_region_key_hmac);
+   free(date_key_hmac);
+   free(key);
+   free(s3_path);
+   free(body_hash);
+   free(canonical_request_sha256);
+   free(canonical_request);
+   free(string_to_sign);
+   free(auth_value);
 
    if (connection != NULL)
    {

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -2020,6 +2020,48 @@ pgmoneta_delete_directory(char* path)
 
    return r;
 }
+int
+pgmoneta_append_file_chunk(const char* tmp_path, const void* data, size_t data_size, long expected_offset)
+{
+   // check if the temp path exists
+   char* parent_dir = NULL;
+   FILE* f = NULL;
+
+   parent_dir = pgmoneta_get_parent_dir(tmp_path);
+   if (parent_dir == NULL)
+   {
+      goto error;
+   }
+   // create the parent dir
+   if (pgmoneta_mkdir(parent_dir))
+      goto error;
+   // create the file with append if exists
+   f = fopen(tmp_path, "a+");
+   if (f == NULL)
+   {
+      goto error;
+   }
+   // check if the expected offset is correct
+   if (expected_offset != ftell(f))
+   {
+      goto error;
+   }
+   // write the data
+   if (fwrite(data, 1, data_size, f) != data_size)
+   {
+      goto error;
+   }
+   // close the file
+   fclose(f);
+   free(parent_dir);
+
+   return 0;
+error:
+   if (f != NULL)
+      fclose(f);
+   free(parent_dir);
+   return 1;
+}
 
 int
 pgmoneta_get_files(uint32_t file_type_mask, char* base, bool recursive, struct deque** files)

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -58,6 +58,7 @@ static struct workflow* wf_retention(void);
 static struct workflow* wf_post_rollup(struct backup* backup);
 static struct workflow* wf_list_s3_objects(void);
 static struct workflow* wf_delete_s3_objects(void);
+static struct workflow* wf_restore_s3_objects(void);
 
 static int get_error_code(int type, int flow, struct art* nodes);
 
@@ -98,6 +99,9 @@ pgmoneta_workflow_create(int workflow_type, struct backup* backup)
          break;
       case WORKFLOW_TYPE_S3_DELETE:
          w = wf_delete_s3_objects();
+         break;
+      case WORKFLOW_TYPE_S3_RESTORE:
+         w = wf_restore_s3_objects();
          break;
       case WORKFLOW_TYPE_RETENTION:
          w = wf_retention();
@@ -997,6 +1001,33 @@ wf_list_s3_objects(void)
 
    return head;
 }
+static struct workflow*
+wf_restore_s3_objects(void)
+{
+   struct workflow* head = NULL;
+   struct main_configuration* config = NULL;
+
+   config = (struct main_configuration*)shmem;
+
+   if (config->storage_engine & STORAGE_ENGINE_S3)
+   {
+      head = pgmoneta_storage_create_s3(WORKFLOW_TYPE_S3_RESTORE);
+   }
+
+#ifdef DEBUG
+   struct workflow* current = head;
+   while (current != NULL)
+   {
+      assert(current->name != NULL);
+      assert(current->setup != NULL);
+      assert(current->execute != NULL);
+      assert(current->teardown != NULL);
+      current = current->next;
+   }
+#endif
+
+   return head;
+}
 
 static struct workflow*
 wf_delete_s3_objects(void)
@@ -1207,6 +1238,26 @@ get_error_code(int type, int flow, struct art* nodes)
       else if (flow == TEARDOWN)
       {
          return MANAGEMENT_ERROR_COMBINE_TEARDOWN;
+      }
+      else
+      {
+         pgmoneta_log_error("Incorrect error code: %d/%d", type, flow);
+         return -1;
+      }
+   }
+   else if (type == WORKFLOW_TYPE_S3_RESTORE)
+   {
+      if (flow == SETUP)
+      {
+         return MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW;
+      }
+      else if (flow == EXECUTE)
+      {
+         return MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW;
+      }
+      else if (flow == TEARDOWN)
+      {
+         return MANAGEMENT_ERROR_RESTORE_S3_WORKFLOW;
       }
       else
       {

--- a/src/main.c
+++ b/src/main.c
@@ -1297,6 +1297,50 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          goto error;
       }
    }
+   else if (id == MANAGEMENT_S3_RESTORE)
+   {
+      char* prefix = NULL;
+
+      server = (char*)pgmoneta_json_get(request, MANAGEMENT_ARGUMENT_SERVER);
+      prefix = (char*)pgmoneta_json_get(request, MANAGEMENT_ARGUMENT_S3_PREFIX);
+
+      srv = -1;
+      for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
+      {
+         if (!strcmp(config->common.servers[i].name, server))
+         {
+            srv = i;
+         }
+      }
+
+      if (srv != -1)
+      {
+         pid = fork();
+         if (pid == -1)
+         {
+            pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_RESTORE_S3_NOFORK, NAME, compression, encryption, payload);
+            pgmoneta_log_error("S3 restore: No fork %s (%d)", server, MANAGEMENT_ERROR_RESTORE_S3_NOFORK);
+            goto error;
+         }
+         else if (pid == 0)
+         {
+            struct json* pyl = NULL;
+
+            shutdown_ports(false);
+
+            pgmoneta_json_clone(payload, &pyl);
+
+            pgmoneta_set_proc_title(1, ai->argv, "s3 restore", config->common.servers[srv].name);
+            pgmoneta_restore_s3_objects(client_fd, srv, prefix, compression, encryption, pyl);
+         }
+      }
+      else
+      {
+         pgmoneta_management_response_error(NULL, client_fd, server, MANAGEMENT_ERROR_RESTORE_S3_NOSERVER, NAME, compression, encryption, payload);
+         pgmoneta_log_error("S3 restore: No server %s (%d)", server, MANAGEMENT_ERROR_RESTORE_S3_NOSERVER);
+         goto error;
+      }
+   }
 
    else if (id == MANAGEMENT_DELETE)
    {


### PR DESCRIPTION
 ## Summary

  Implements `pgmoneta-cli s3 restore <server> <timestamp>` which downloads a backup
  from S3 to the local backup directory, making it available for `pgmoneta-cli restore`.

  Closes #1010

  ## Design

  The restore is a two-phase download:

  1. **Bootstrap** (`s3_bootstrap`): Downloads root-level files (`backup.sha512`,
     `backup.info`, `backup.manifest`) and verifies `backup.info` integrity via SHA512
     checksum before proceeding with the bulk download.

  2. **Bulk download** (`s3_download_files`): Parses the CSV `backup.manifest` to get
     the file listing, loads `backup.info` to determine compression/encryption type,
     and downloads each data file with the correct extension (e.g. `.zstd`, `.aes`).
     `backup_label` and `backup_manifest` are excluded from extension appending as
     they are not compressed/encrypted by PostgreSQL.

  Downloads go to a temporary directory (`.pgmoneta_temp_<label>/`) which is atomically
  renamed on success, or cleaned up on error.

  ## Known limitations / future work

  - **No per-file checksum verification**: The CSV manifest checksums are for
    uncompressed files, but files on S3 are stored compressed. Verification during
    download is not possible with current data.
  - **Sequential single-file GETs**: Each file is downloaded one at a time. Performance
    can be improved with range-based downloads and parallel GETs.
