### PR TITLE
Fix heap buffer overflow in verify command for malformed manifest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Chen Shen <scisbeloved23@gmail.com>
 Jozef Hernández <jozefhdez2@gmail.com>
 Tarun Wadhwa <tarunwadhwa85@gmail.com>
+Pranav Prajapati <pranavprajapati586@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -57,6 +57,7 @@ Sakshi Aggarwal <sakshiaggarwal2706@gmail.com>
 Chen Shen <scisbeloved23@gmail.com>
 Jozef Hernández <jozefhdez2@gmail.com>
 Tarun Wadhwa <tarunwadhwa85@gmail.com>
+Pranav Prajapati <pranavprajapati586@gmail.com>
 ```
 
 ## Committers

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -852,6 +852,14 @@ bool
 pgmoneta_is_file(char* file);
 
 /**
+ * Check if a file is binary (contains null bytes)
+ * @param path The file path
+ * @return true if binary, false if text
+ */
+bool
+pgmoneta_is_binary_file(char* path);
+
+/**
  * Parse an LSN string
  * @param lsn The LSN string (e.g., "0/16B0938")
  * @return The LSN, or 0 on error

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -103,7 +103,6 @@ static int write_config_value(char* buffer, char* config_key, size_t buffer_size
 static bool is_valid_config_key(const char* config_key, struct config_key_info* key_info);
 static bool is_empty_string(char* s);
 static int remove_leading_whitespace_and_comments(char* s, char** trimmed_line);
-static bool pgmoneta_is_binary_file(const char* path);
 
 static void split_extra(char* extra, char res[MAX_EXTRA][MAX_EXTRA_PATH], int* count);
 
@@ -6167,39 +6166,4 @@ split_extra(char* extra, char res[MAX_EXTRA][MAX_EXTRA_PATH], int* count)
    }
 
    *count = i;
-}
-
-static bool
-pgmoneta_is_binary_file(const char* path)
-{
-   FILE* fp = NULL;
-   unsigned char buffer[1024];
-   size_t bytes;
-   int error;
-
-   fp = fopen(path, "rb");
-   if (fp == NULL)
-   {
-      goto error;
-   }
-
-   while ((bytes = fread(buffer, 1, sizeof(buffer), fp)) > 0)
-   {
-      for (size_t i = 0; i < bytes; i++)
-      {
-         if (buffer[i] == '\0')
-         {
-            fclose(fp);
-            goto error;
-         }
-      }
-   }
-
-   error = ferror(fp);
-   fclose(fp);
-
-   return error != 0;
-
-error:
-   return true;
 }

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -2958,6 +2958,46 @@ pgmoneta_is_file(char* file)
 }
 
 bool
+pgmoneta_is_binary_file(char* path)
+{
+   FILE* fp = NULL;
+   unsigned char buffer[1024];
+   size_t bytes;
+   int error;
+
+   fp = fopen(path, "rb");
+   if (fp == NULL)
+   {
+      goto error;
+   }
+
+   while ((bytes = fread(buffer, 1, sizeof(buffer), fp)) > 0)
+   {
+      for (size_t i = 0; i < bytes; i++)
+      {
+         unsigned char c = buffer[i];
+         /* Allow printable chars, newline, tab, carriage return */
+         if (!isprint(c) && c != '\n' && c != '\t' && c != '\r')
+         {
+            goto error;
+         }
+      }
+   }
+
+   error = ferror(fp);
+   fclose(fp);
+
+   return error != 0;
+
+error:
+   if (fp != NULL)
+   {
+      fclose(fp);
+   }
+   return true;
+}
+
+bool
 pgmoneta_compare_files(char* f1, char* f2)
 {
    FILE* fp1 = NULL;

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -136,15 +136,40 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
       pgmoneta_workers_initialize(number_of_workers, &workers);
    }
 
+   if (pgmoneta_is_binary_file(manifest_file))
+   {
+      pgmoneta_log_error("Verify: Manifest file is not a text file");
+      goto error;
+   }
+
    if (pgmoneta_csv_reader_init(manifest_file, &csv))
    {
       goto error;
    }
 
+   int line_number = 0;
+
    while (pgmoneta_csv_next_row(csv, &number_of_columns, &columns))
    {
       struct worker_input* payload = NULL;
       struct json* j = NULL;
+
+      line_number++;
+
+      /* Column check - heap buffer overflow prevention */
+      if (number_of_columns != 2)
+      {
+         pgmoneta_log_error("Verify: Invalid manifest at line %d", line_number);
+         goto error;
+      }
+
+      /* Empty filename or hash */
+      if (columns[0] == NULL || strlen(columns[0]) == 0 ||
+          columns[1] == NULL || strlen(columns[1]) == 0)
+      {
+         pgmoneta_log_error("Verify: Invalid manifest at line %d", line_number);
+         goto error;
+      }
 
       if (pgmoneta_create_worker_input(NULL, NULL, NULL, -1, workers, &payload))
       {
@@ -216,6 +241,7 @@ error:
 
    pgmoneta_csv_reader_destroy(csv);
 
+   free(columns);
    free(base);
    free(manifest_file);
 


### PR DESCRIPTION
Fixes issue #1040 

- Fix heap buffer overflow in `wf_verify.c` when processing malformed backup manifest
  files
 - Add bounds check before accessing CSV columns to prevent out-of-bounds read, as format of the csv will always be 

```csv
relative/path/to/file,sha512_checksum_hash
base/1/1234,abc123def456789...
global/pg_control,fedcba987654321...
pg_hba.conf,111222333444555...
```

This fix let's verify command to fail gracefully with error, without causing heap buffer overflow

```bash
2026-03-18 09:22:14 ERROR wf_verify.c:151 Verify: Invalid manifest format - expected at least 2 columns, got 1
```

