### PR TITLE
[#1013] Add finalize workflow to prevent race conditions

### DIFF
--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -62,9 +62,19 @@ extern "C" {
 
 #define CLEANUP_TYPE_RESTORE             0
 
+#define FINALIZE_TYPE_BACKUP             0
+#define FINALIZE_TYPE_RESTORE            1
+#define FINALIZE_TYPE_VERIFY             2
+
+#define WORKFLOW_RESULT_SUCCESS          0
+#define WORKFLOW_RESULT_ERROR            1
+#define WORKFLOW_RESULT_FATAL            2
+
 #define NODE_ALL                         "all"                 /* All the files in a manifest */
 #define NODE_BACKUP                      "backup"              /* The backup structure */
 #define NODE_COMBINE_AS_IS               "combine_as_is"       /* Whether to combine the backups as is*/
+#define NODE_FINALIZE_TYPE               "finalize_type"       /* The finalize type */
+#define NODE_FINALIZE_VALUE              "finalize_value"      /* The finalize value (locked state) */
 #define NODE_COPY_WAL                    "copy_wal"            /* Whether to copy WAL */
 #define NODE_BACKUP_BASE                 "backup_base"         /* The base directory of the backup */
 #define NODE_BACKUP_DATA                 "backup_data"         /* The data directory of the backup */
@@ -86,6 +96,12 @@ extern "C" {
 #define NODE_TARGET_BASE                 "target_base"         /* The target base directory */
 #define NODE_TARGET_FILE                 "target_file"         /* The target file */
 #define NODE_TARGET_ROOT                 "target_root"         /* The target root directory */
+#define NODE_CLIENT_FD                   "client_fd"           /* The client fd */
+#define NODE_SSL                         "ssl"                 /* The SSL connection */
+#define NODE_PAYLOAD                     "payload"             /* The JSON payload */
+#define NODE_COMPRESSION                 "compression"         /* The compression type */
+#define NODE_ENCRYPTION                  "encryption"          /* The encryption type */
+#define NODE_START_TIME                  "start_time"          /* The start time */
 
 /* Supplied by the user */
 #define USER_DIRECTORY  "directory"  /* The target root directory */

--- a/src/include/workflow_funcs.h
+++ b/src/include/workflow_funcs.h
@@ -202,6 +202,14 @@ pgmoneta_create_manifest(void);
  */
 struct workflow*
 pgmoneta_create_extra(void);
+
+/**
+ * Create a workflow for the finalize step
+ * @return The workflow
+ */
+struct workflow*
+pgmoneta_create_finalize(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgmoneta/backup.c
+++ b/src/libpgmoneta/backup.c
@@ -38,32 +38,27 @@
 #include <network.h>
 #include <security.h>
 #include <utils.h>
-#include <wal.h>
 #include <workflow.h>
+#include <workflow_funcs.h>
 
 #define NAME "backup"
 
 void
 pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encryption, struct json* payload)
 {
-   bool active = false;
    char date_str[128];
    char* date = NULL;
-   char* elapsed = NULL;
    char* incremental = NULL;
    char* incremental_base = NULL;
    struct tm* time_info;
    struct timespec start_t;
-   struct timespec end_t;
    time_t curr_t;
-   double total_seconds;
    char* en = NULL;
    int ec = -1;
    int backup_index = -1;
    char* server_backup = NULL;
    char* root = NULL;
    char* d = NULL;
-   char* backup_data = NULL;
    bool backup_incremental = false;
    int number_of_backups = 0;
    struct backup** backups = NULL;
@@ -72,7 +67,6 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
    struct backup* backup = NULL;
    struct backup* child = NULL;
    struct json* req = NULL;
-   struct json* response = NULL;
    struct main_configuration* config;
 
    pgmoneta_start_logging();
@@ -92,21 +86,6 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
       pgmoneta_log_error("Backup: Server %s is not WAL streaming", config->common.servers[server].name);
       goto error;
    }
-
-   if (!atomic_compare_exchange_strong(&config->common.servers[server].repository, &active, true))
-   {
-      ec = MANAGEMENT_ERROR_BACKUP_ACTIVE;
-      pgmoneta_log_info("Backup: Server %s is active", config->common.servers[server].name);
-      pgmoneta_log_debug("Backup=%s, Restore=%s, Archive=%s, Delete=%s, Retention=%s",
-                         config->common.servers[server].active_backup ? "Yes" : "No",
-                         config->common.servers[server].active_restore ? "Yes" : "No",
-                         config->common.servers[server].active_archive ? "Yes" : "No",
-                         config->common.servers[server].active_delete ? "Yes" : "No",
-                         config->common.servers[server].active_retention ? "Yes" : "No");
-      goto error;
-   }
-
-   config->common.servers[server].active_backup = true;
 
 #ifdef HAVE_FREEBSD
    clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
@@ -129,13 +108,18 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
       goto error;
    }
 
+   pgmoneta_art_insert(nodes, NODE_FINALIZE_TYPE, (uintptr_t)FINALIZE_TYPE_BACKUP, ValueInt32);
+   pgmoneta_art_insert(nodes, NODE_CLIENT_FD, (uintptr_t)client_fd, ValueInt32);
+   pgmoneta_art_insert(nodes, NODE_PAYLOAD, (uintptr_t)payload, ValueRef);
+   pgmoneta_art_insert(nodes, NODE_COMPRESSION, (uintptr_t)compression, ValueUInt8);
+   pgmoneta_art_insert(nodes, NODE_ENCRYPTION, (uintptr_t)encryption, ValueUInt8);
+   pgmoneta_art_insert(nodes, NODE_START_TIME, (uintptr_t)&start_t, ValueRef);
+
    if (pgmoneta_workflow_nodes(server, date, nodes, &backup))
    {
       goto error;
    }
 
-   backup_data = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_DATA);
-   server_backup = (char*)pgmoneta_art_search(nodes, NODE_SERVER_BACKUP);
    root = pgmoneta_get_server_backup_identifier(server, date);
 
    if (incremental != NULL)
@@ -155,6 +139,8 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
 
    if (backup_incremental)
    {
+      server_backup = (char*)pgmoneta_art_search(nodes, NODE_SERVER_BACKUP);
+
       if (pgmoneta_load_infos(server_backup, &number_of_backups, &backups))
       {
          ec = MANAGEMENT_ERROR_BACKUP_NOBACKUPS;
@@ -226,66 +212,6 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
       goto error;
    }
 
-   backup->backup_size = pgmoneta_directory_size(backup_data);
-
-   if (pgmoneta_save_info(server_backup, backup))
-   {
-      ec = MANAGEMENT_ERROR_BACKUP_ERROR;
-      goto error;
-   }
-
-   if (pgmoneta_management_create_response(payload, server, &response))
-   {
-      ec = MANAGEMENT_ERROR_ALLOCATION;
-      goto error;
-   }
-
-   if (pgmoneta_load_info(server_backup, date, &backup))
-   {
-      ec = MANAGEMENT_ERROR_BACKUP_ERROR;
-      goto error;
-   }
-
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->common.servers[server].name, ValueString);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP, (uintptr_t)date, ValueString);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP_SIZE, (uintptr_t)backup->backup_size, ValueUInt64);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_RESTORE_SIZE, (uintptr_t)backup->restore_size, ValueUInt64);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BIGGEST_FILE_SIZE, (uintptr_t)backup->biggest_file_size, ValueUInt64);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMPRESSION, (uintptr_t)backup->compression, ValueInt32);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_ENCRYPTION, (uintptr_t)backup->encryption, ValueInt32);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_VALID, (uintptr_t)backup->valid, ValueInt8);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL, (uintptr_t)backup->type, ValueBool);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL_PARENT, (uintptr_t)backup->parent_label, ValueString);
-
-#ifdef HAVE_FREEBSD
-   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
-#else
-   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
-#endif
-
-   elapsed = pgmoneta_get_timestamp_string(start_t, end_t, &total_seconds);
-
-   backup->total_elapsed_time = total_seconds;
-   if (pgmoneta_save_info(server_backup, backup))
-   {
-      ec = MANAGEMENT_ERROR_BACKUP_ERROR;
-      goto error;
-   }
-
-   if (pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload))
-   {
-      ec = MANAGEMENT_ERROR_BACKUP_NETWORK;
-      pgmoneta_log_error("Backup: Error sending response for %s", config->common.servers[server].name);
-      goto error;
-   }
-
-   pgmoneta_log_info("Backup: %s/%s (Elapsed: %s)", config->common.servers[server].name, date, elapsed);
-
-   pgmoneta_wal_server_compress_encrypt(server, NULL, NULL);
-
-   config->common.servers[server].active_backup = false;
-   atomic_store(&config->common.servers[server].repository, false);
-
    pgmoneta_json_destroy(payload);
 
    pgmoneta_workflow_destroy(workflow);
@@ -299,7 +225,6 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
    }
    free(backups);
    free(child);
-   free(elapsed);
    free(root);
    free(incremental_base);
    free(d);
@@ -311,9 +236,6 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
    exit(0);
 
 error:
-
-   config->common.servers[server].active_backup = false;
-   atomic_store(&config->common.servers[server].repository, false);
 
    pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
                                       ec != -1 ? ec : MANAGEMENT_ERROR_BACKUP_ERROR,
@@ -337,7 +259,6 @@ error:
 
    free(date);
    free(child);
-   free(elapsed);
    free(root);
    free(incremental_base);
    free(d);

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -38,6 +38,7 @@
 #include <utils.h>
 #include <workers.h>
 #include <workflow.h>
+#include <workflow_funcs.h>
 
 /* system */
 #include <assert.h>
@@ -78,8 +79,6 @@ static char* restore_last_files_names[] = {"/global/pg_control", "/postgresql.co
 static int restore_backup_full(struct art* nodes);
 
 static int restore_backup_incremental(struct art* nodes);
-
-static int carry_out_workflow(struct workflow* workflow, struct art* nodes);
 
 static void clear_manifest_incremental_entries(struct json* manifest);
 /**
@@ -361,17 +360,12 @@ pgmoneta_is_restore_last_name(char* file_name)
 void
 pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_t encryption, struct json* payload)
 {
-   bool active = false;
-   bool locked = false;
    bool explicit_label = false;
    int ret = RESTORE_OK;
    char* identifier = NULL;
    char* position = NULL;
    char* directory = NULL;
-   char* elapsed = NULL;
    struct timespec start_t;
-   struct timespec end_t;
-   double total_seconds = 0;
    char* output = NULL;
    char* en = NULL;
    int ec = -1;
@@ -381,7 +375,6 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
    struct backup* backup = NULL;
    struct art* nodes = NULL;
    struct json* req = NULL;
-   struct json* response = NULL;
    struct main_configuration* config;
 
    pgmoneta_start_logging();
@@ -393,22 +386,6 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
 #else
    clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
 #endif
-
-   if (!atomic_compare_exchange_strong(&config->common.servers[server].repository, &active, true))
-   {
-      ec = MANAGEMENT_ERROR_RESTORE_ACTIVE;
-      pgmoneta_log_info("Restore: Server %s is active", config->common.servers[server].name);
-      pgmoneta_log_debug("Backup=%s, Restore=%s, Archive=%s, Delete=%s, Retention=%s",
-                         config->common.servers[server].active_backup ? "Yes" : "No",
-                         config->common.servers[server].active_restore ? "Yes" : "No",
-                         config->common.servers[server].active_archive ? "Yes" : "No",
-                         config->common.servers[server].active_delete ? "Yes" : "No",
-                         config->common.servers[server].active_retention ? "Yes" : "No");
-      goto error;
-   }
-
-   config->common.servers[server].active_restore = true;
-   locked = true;
 
    req = (struct json*)pgmoneta_json_get(payload, MANAGEMENT_CATEGORY_REQUEST);
    identifier = (char*)pgmoneta_json_get(req, MANAGEMENT_ARGUMENT_BACKUP);
@@ -425,6 +402,14 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
    {
       goto error;
    }
+
+   pgmoneta_art_insert(nodes, NODE_FINALIZE_TYPE, (uintptr_t)FINALIZE_TYPE_RESTORE, ValueInt32);
+   pgmoneta_art_insert(nodes, NODE_CLIENT_FD, (uintptr_t)client_fd, ValueInt32);
+   pgmoneta_art_insert(nodes, NODE_SSL, (uintptr_t)ssl, ValueRef);
+   pgmoneta_art_insert(nodes, NODE_PAYLOAD, (uintptr_t)payload, ValueRef);
+   pgmoneta_art_insert(nodes, NODE_COMPRESSION, (uintptr_t)compression, ValueUInt8);
+   pgmoneta_art_insert(nodes, NODE_ENCRYPTION, (uintptr_t)encryption, ValueUInt8);
+   pgmoneta_art_insert(nodes, NODE_START_TIME, (uintptr_t)&start_t, ValueRef);
 
    memset(&label[0], 0, sizeof(label));
 
@@ -622,42 +607,9 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
    }
 
    ret = pgmoneta_restore_backup(nodes);
-   if (ret == RESTORE_OK)
+   if (ret == RESTORE_OK || ret == 1) /* 1 = RESTORE_ERROR */
    {
-      if (pgmoneta_management_create_response(payload, server, &response))
-      {
-         ec = MANAGEMENT_ERROR_ALLOCATION;
-         goto error;
-      }
-
-      backup = (struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP);
-
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->common.servers[server].name, ValueString);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP, (uintptr_t)backup->label, ValueString);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP_SIZE, (uintptr_t)backup->backup_size, ValueUInt64);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_RESTORE_SIZE, (uintptr_t)backup->restore_size, ValueUInt64);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BIGGEST_FILE_SIZE, (uintptr_t)backup->biggest_file_size, ValueUInt64);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMMENTS, (uintptr_t)backup->comments, ValueString);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMPRESSION, (uintptr_t)backup->compression, ValueInt32);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_ENCRYPTION, (uintptr_t)backup->encryption, ValueInt32);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL, (uintptr_t)backup->type, ValueBool);
-      pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL_PARENT, (uintptr_t)backup->parent_label, ValueString);
-
-#ifdef HAVE_FREEBSD
-      clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
-#else
-      clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
-#endif
-
-      if (pgmoneta_management_response_ok(NULL, client_fd, start_t, end_t, compression, encryption, payload))
-      {
-         ec = MANAGEMENT_ERROR_RESTORE_NETWORK;
-         pgmoneta_log_error("Restore: Error sending response for %s", config->common.servers[server].name);
-         goto error;
-      }
-
-      elapsed = pgmoneta_get_timestamp_string(start_t, end_t, &total_seconds);
-      pgmoneta_log_info("Restore: %s/%s (Elapsed: %s)", config->common.servers[server].name, backup->label, elapsed);
+      /* The workflow executed, so finalize_teardown already sent the response (success or error). */
    }
    else if (ret == RESTORE_MISSING_LABEL)
    {
@@ -671,9 +623,6 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
       goto error;
    }
 
-   config->common.servers[server].active_restore = false;
-   atomic_store(&config->common.servers[server].repository, false);
-
    pgmoneta_json_destroy(payload);
 
    pgmoneta_disconnect(client_fd);
@@ -681,7 +630,6 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
    pgmoneta_stop_logging();
 
    free(backup);
-   free(elapsed);
    free(output);
    free(target_identifier);
    free(timeline_value);
@@ -700,14 +648,7 @@ error:
 
    pgmoneta_stop_logging();
 
-   if (locked)
-   {
-      config->common.servers[server].active_restore = false;
-      atomic_store(&config->common.servers[server].repository, false);
-   }
-
    free(backup);
-   free(elapsed);
    free(output);
    free(target_identifier);
    free(timeline_value);
@@ -1015,6 +956,8 @@ error:
 int
 pgmoneta_rollup_backups(int server, char* newest_label, char* oldest_label)
 {
+   char* en = NULL;
+   int ec = -1;
    struct art* nodes = NULL;
    struct backup* newest_backup = NULL;
    struct backup* oldest_backup = NULL;
@@ -1117,7 +1060,7 @@ pgmoneta_rollup_backups(int server, char* newest_label, char* oldest_label)
    }
 
    workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_POST_ROLLUP, tmp_backup);
-   if (carry_out_workflow(workflow, nodes) != RESTORE_OK)
+   if (pgmoneta_workflow_execute(workflow, nodes, &en, &ec))
    {
       goto error;
    }
@@ -2384,6 +2327,8 @@ clear_manifest_incremental_entries(struct json* manifest)
 static int
 restore_backup_full(struct art* nodes)
 {
+   char* en = NULL;
+   int ec = -1;
    int ret = RESTORE_OK;
    int server = -1;
    char* directory = NULL;
@@ -2479,8 +2424,9 @@ restore_backup_full(struct art* nodes)
    }
 
    workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_RESTORE, backup);
-   if ((ret = carry_out_workflow(workflow, nodes) != RESTORE_OK))
+   if (pgmoneta_workflow_execute(workflow, nodes, &en, &ec))
    {
+      ret = RESTORE_MISSING_LABEL;
       goto error;
    }
 
@@ -2503,6 +2449,8 @@ error:
 static int
 restore_backup_incremental(struct art* nodes)
 {
+   char* en = NULL;
+   int ec = -1;
    int ret = RESTORE_OK;
    int server = -1;
    bool combine_as_is = false;
@@ -2615,8 +2563,9 @@ restore_backup_incremental(struct art* nodes)
       workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_COMBINE_AS_IS, backup);
    }
 
-   if ((ret = carry_out_workflow(workflow, nodes) != RESTORE_OK))
+   if (pgmoneta_workflow_execute(workflow, nodes, &en, &ec))
    {
+      ret = RESTORE_MISSING_LABEL;
       goto error;
    }
 
@@ -2685,52 +2634,6 @@ error:
    {
       ret = RESTORE_ERROR;
    }
-   return ret;
-}
-
-static int
-carry_out_workflow(struct workflow* workflow, struct art* nodes)
-{
-   struct workflow* current = NULL;
-   int ret = RESTORE_OK;
-   current = workflow;
-   while (current != NULL)
-   {
-      if (current->setup(current->name(), nodes))
-      {
-         ret = RESTORE_MISSING_LABEL;
-         pgmoneta_log_error("setup/%s", current->name());
-         goto error;
-      }
-      current = current->next;
-   }
-
-   current = workflow;
-   while (current != NULL)
-   {
-      if (current->execute(current->name(), nodes))
-      {
-         ret = RESTORE_MISSING_LABEL;
-         pgmoneta_log_error("execute/%s", current->name());
-         goto error;
-      }
-      current = current->next;
-   }
-
-   current = workflow;
-   while (current != NULL)
-   {
-      if (current->teardown(current->name(), nodes))
-      {
-         ret = RESTORE_MISSING_LABEL;
-         pgmoneta_log_error("teardown/%s", current->name());
-         goto error;
-      }
-      current = current->next;
-   }
-
-   return ret;
-error:
    return ret;
 }
 

--- a/src/libpgmoneta/se_azure.c
+++ b/src/libpgmoneta/se_azure.c
@@ -171,7 +171,7 @@ error:
    free(local_root);
    free(azure_root);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -314,7 +314,7 @@ error:
 
    free(local_path);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -582,7 +582,7 @@ error:
       fclose(file);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*
@@ -624,22 +624,22 @@ azure_add_request_headers(struct http_request* request, char* auth_value, char* 
 {
    if (pgmoneta_http_request_add_header(request, "Authorization", auth_value))
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    if (pgmoneta_http_request_add_header(request, "x-ms-blob-type", "BlockBlob"))
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    if (pgmoneta_http_request_add_header(request, "x-ms-date", utc_date))
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    if (pgmoneta_http_request_add_header(request, "x-ms-version", "2021-08-06"))
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    return 0;

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -389,7 +389,7 @@ error:
    free(base_dir);
    free(s3_root);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -435,7 +435,7 @@ s3_storage_list(char* name __attribute__((unused)), struct art* nodes)
 error:
    free(s3_root);
    pgmoneta_deque_destroy(objects);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -515,7 +515,7 @@ s3_storage_cleanup(char* name __attribute__((unused)), struct art* nodes)
 
 error:
    free(s3_root);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 static int
 s3_storage_restore(char* name __attribute__((unused)), struct art* nodes)
@@ -654,7 +654,7 @@ error:
    free(sha512_final);
    free(info_tmp);
    free(info_final);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -824,7 +824,7 @@ error:
    free(manifest_path);
    free(computed_hash);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -939,7 +939,7 @@ error:
    free(s3_path);
    free(local_file_path);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 static void
 do_download_file(struct worker_common* wc)
@@ -1136,7 +1136,7 @@ error:
    free(manifest_path);
    free(suffix);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 static int
 s3_list_objects(char* relative_path, char* s3_root, int server, struct deque** objects)
@@ -1174,7 +1174,7 @@ s3_list_objects(char* relative_path, char* s3_root, int server, struct deque** o
 error:
    pgmoneta_http_response_destroy(response);
    free(continuationToken);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1249,7 +1249,7 @@ error:
    pgmoneta_deque_destroy(objects);
    free(delete_xml);
    free(continuation_token);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 static int
 s3_build_signing_key(char* secret_access_key, char* short_date, char* region,
@@ -1629,7 +1629,7 @@ error:
       pgmoneta_http_request_destroy(request);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1832,7 +1832,7 @@ error:
       pgmoneta_http_request_destroy(request);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 static int
 s3_send_get_request(char* relative_path, char* s3_root, int server,
@@ -1980,7 +1980,7 @@ error:
       pgmoneta_http_request_destroy(request);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -2210,7 +2210,7 @@ error:
       fclose(file);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*
@@ -2319,14 +2319,14 @@ xml_extract_tag(char* xml, char* tag, struct deque** values)
 
    if (xml == NULL || tag == NULL || values == NULL)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    if (*values == NULL)
    {
       if (pgmoneta_deque_create(false, values))
       {
-         return 1;
+         return WORKFLOW_RESULT_ERROR;
       }
    }
 
@@ -2343,7 +2343,7 @@ xml_extract_tag(char* xml, char* tag, struct deque** values)
          char* val = malloc(len + 1);
          if (val == NULL)
          {
-            return 1;
+            return WORKFLOW_RESULT_ERROR;
          }
          memcpy(val, ptr, len);
          val[len] = '\0';
@@ -2374,7 +2374,7 @@ xml_parse_s3_list_truncated(char* xml, bool* is_truncated, char** continuation_t
 
    if (xml == NULL || is_truncated == NULL || continuation_token == NULL)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    *is_truncated = false;
@@ -2417,7 +2417,7 @@ xml_parse_s3_delete_result(char* xml, bool* has_fatal_error)
 
    if (xml == NULL || has_fatal_error == NULL)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    *has_fatal_error = false;
@@ -2437,7 +2437,7 @@ xml_parse_s3_delete_result(char* xml, bool* has_fatal_error)
 
       if (end == NULL)
       {
-         return 1;
+         return WORKFLOW_RESULT_ERROR;
       }
 
       end += strlen("</Error>");
@@ -2446,7 +2446,7 @@ xml_parse_s3_delete_result(char* xml, bool* has_fatal_error)
       error_block = (char*)malloc(block_len + 1);
       if (error_block == NULL)
       {
-         return 1;
+         return WORKFLOW_RESULT_ERROR;
       }
       memcpy(error_block, cursor, block_len);
       error_block[block_len] = '\0';
@@ -2454,20 +2454,20 @@ xml_parse_s3_delete_result(char* xml, bool* has_fatal_error)
       if (xml_extract_tag(error_block, "Key", &key_values))
       {
          free(error_block);
-         return 1;
+         return WORKFLOW_RESULT_ERROR;
       }
       if (xml_extract_tag(error_block, "Code", &code_values))
       {
          pgmoneta_deque_destroy(key_values);
          free(error_block);
-         return 1;
+         return WORKFLOW_RESULT_ERROR;
       }
       if (xml_extract_tag(error_block, "Message", &message_values))
       {
          pgmoneta_deque_destroy(key_values);
          pgmoneta_deque_destroy(code_values);
          free(error_block);
-         return 1;
+         return WORKFLOW_RESULT_ERROR;
       }
 
       key = key_values != NULL && pgmoneta_deque_size(key_values) > 0 ? (char*)pgmoneta_deque_peek(key_values, NULL) : "unknown";
@@ -2500,7 +2500,7 @@ xml_s3_build_delete_key(char** xml, char* key)
 
    if (xml == NULL || key == NULL)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    *xml = pgmoneta_append(*xml, open_tag);
@@ -2545,5 +2545,5 @@ xml_s3_build_delete_list(char** xml, struct deque* keys, size_t max_keys)
    return 0;
 
 error:
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/se_ssh.c
+++ b/src/libpgmoneta/se_ssh.c
@@ -271,7 +271,7 @@ error:
 
    ssh_disconnect(session);
    ssh_free(session);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -430,7 +430,7 @@ error:
    free(remote_root);
    free(local_root);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -476,7 +476,7 @@ error:
    free(remote_root);
    free(local_root);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -595,7 +595,7 @@ sftp_make_directory(char* local_dir, char* remote_dir)
    return 0;
 
 error:
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -678,7 +678,7 @@ error:
    free(from);
    free(to);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -794,7 +794,7 @@ error:
       free(latest_backup_path);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -805,7 +805,7 @@ sftp_wal_prepare(sftp_file* file, int segsize)
 
    if (file == NULL || *file == NULL)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    while (written < (size_t)segsize)
@@ -816,7 +816,7 @@ sftp_wal_prepare(sftp_file* file, int segsize)
    if (sftp_seek(*file, 0) < 0)
    {
       pgmoneta_log_error("WAL error: %s", ssh_get_error(session));
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
    return 0;
 }
@@ -880,7 +880,7 @@ error:
       fclose(file);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*
@@ -1005,7 +1005,7 @@ error:
       sftp_close(*file);
    }
    free(path);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 int
@@ -1019,7 +1019,7 @@ pgmoneta_sftp_wal_close(int server, char* filename, bool partial, sftp_file* fil
 
    if (file == NULL || *file == NULL || root == NULL || filename == NULL || strlen(root) == 0 || strlen(filename) == 0)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    if (partial)
@@ -1051,7 +1051,7 @@ pgmoneta_sftp_wal_close(int server, char* filename, bool partial, sftp_file* fil
 
 error:
    sftp_close(*file);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 static bool
 sftp_exists(char* path)
@@ -1097,7 +1097,7 @@ error:
    {
       sftp_attributes_free(attributes);
    }
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1109,7 +1109,7 @@ sftp_permission(char* path, int user, int group, int all)
    ret = sftp_chmod(sftp, path, mode);
    if (ret != 0)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
 
    return 0;

--- a/src/libpgmoneta/verify.c
+++ b/src/libpgmoneta/verify.c
@@ -36,9 +36,11 @@
 #include <security.h>
 #include <utils.h>
 #include <workflow.h>
+#include <workflow_funcs.h>
 
 /* system */
 #include <errno.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -47,28 +49,17 @@
 void
 pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_t encryption, struct json* payload)
 {
+   char* en = NULL;
+   int ec = -1;
    char* identifier = NULL;
    char* directory = NULL;
    char* real_directory = NULL;
    char* files = NULL;
-   char* elapsed = NULL;
    struct timespec start_t;
-   struct timespec end_t;
-   double total_seconds;
-   char* label = NULL;
    struct backup* backup = NULL;
    struct workflow* workflow = NULL;
-   struct workflow* current = NULL;
    struct art* nodes = NULL;
-   struct deque* f = NULL;
-   struct deque* a = NULL;
-   struct deque_iterator* fiter = NULL;
-   struct deque_iterator* aiter = NULL;
-   struct json* failed = NULL;
-   struct json* all = NULL;
    struct json* req = NULL;
-   struct json* response = NULL;
-   struct json* filesj = NULL;
    struct main_configuration* config;
 
    pgmoneta_start_logging();
@@ -90,6 +81,14 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
    {
       goto error;
    }
+
+   pgmoneta_art_insert(nodes, NODE_FINALIZE_TYPE, (uintptr_t)FINALIZE_TYPE_VERIFY, ValueInt32);
+   pgmoneta_art_insert(nodes, NODE_CLIENT_FD, (uintptr_t)client_fd, ValueInt32);
+   pgmoneta_art_insert(nodes, NODE_SSL, (uintptr_t)ssl, ValueRef);
+   pgmoneta_art_insert(nodes, NODE_PAYLOAD, (uintptr_t)payload, ValueRef);
+   pgmoneta_art_insert(nodes, NODE_COMPRESSION, (uintptr_t)compression, ValueUInt8);
+   pgmoneta_art_insert(nodes, NODE_ENCRYPTION, (uintptr_t)encryption, ValueUInt8);
+   pgmoneta_art_insert(nodes, NODE_START_TIME, (uintptr_t)&start_t, ValueRef);
 
    if (pgmoneta_art_insert(nodes, USER_POSITION, (uintptr_t)"", ValueString))
    {
@@ -144,131 +143,12 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
 
    workflow = pgmoneta_workflow_create(WORKFLOW_TYPE_VERIFY, backup);
 
-   current = workflow;
-   while (current != NULL)
-   {
-      if (current->setup(current->name(), nodes))
-      {
-         goto error;
-      }
-      current = current->next;
-   }
-
-   current = workflow;
-   while (current != NULL)
-   {
-      if (current->execute(current->name(), nodes))
-      {
-         goto error;
-      }
-      current = current->next;
-   }
-
-   current = workflow;
-   while (current != NULL)
-   {
-      if (current->teardown(current->name(), nodes))
-      {
-         goto error;
-      }
-      current = current->next;
-   }
-
-   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
-
-   f = (struct deque*)pgmoneta_art_search(nodes, NODE_FAILED);
-   a = (struct deque*)pgmoneta_art_search(nodes, NODE_ALL);
-
-   if (pgmoneta_json_create(&failed))
+   if (pgmoneta_workflow_execute(workflow, nodes, &en, &ec))
    {
       goto error;
    }
-
-   if (pgmoneta_deque_iterator_create(f, &fiter))
-   {
-      goto error;
-   }
-
-   while (pgmoneta_deque_iterator_next(fiter))
-   {
-      struct json* j = NULL;
-
-      if (pgmoneta_json_clone((struct json*)pgmoneta_value_data(fiter->value), &j))
-      {
-         goto error;
-      }
-
-      pgmoneta_json_append(failed, (uintptr_t)j, ValueJSON);
-   }
-
-   if (files != NULL && !strcasecmp(files, "all"))
-   {
-      pgmoneta_json_create(&all);
-
-      if (pgmoneta_deque_iterator_create(a, &aiter))
-      {
-         goto error;
-      }
-
-      while (pgmoneta_deque_iterator_next(aiter))
-      {
-         struct json* j = NULL;
-
-         if (pgmoneta_json_clone((struct json*)pgmoneta_value_data(aiter->value), &j))
-         {
-            goto error;
-         }
-
-         pgmoneta_json_append(all, (uintptr_t)j, ValueJSON);
-      }
-   }
-
-   if (pgmoneta_management_create_response(payload, server, &response))
-   {
-      pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_ALLOCATION, NAME, compression, encryption, payload);
-
-      goto error;
-   }
-
-   if (pgmoneta_json_create(&filesj))
-   {
-      pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_ALLOCATION, NAME, compression, encryption, payload);
-
-      goto error;
-   }
-
-   pgmoneta_json_put(filesj, MANAGEMENT_ARGUMENT_FAILED, (uintptr_t)failed, ValueJSON);
-   failed = NULL;
-   pgmoneta_json_put(filesj, MANAGEMENT_ARGUMENT_ALL, (uintptr_t)all, ValueJSON);
-   all = NULL;
-
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP, (uintptr_t)label, ValueString);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->common.servers[server].name, ValueString);
-   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_FILES, (uintptr_t)filesj, ValueJSON);
-   filesj = NULL;
 
    pgmoneta_delete_directory((char*)pgmoneta_art_search(nodes, NODE_TARGET_BASE));
-
-#ifdef HAVE_FREEBSD
-   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
-#else
-   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
-#endif
-
-   if (pgmoneta_management_response_ok(ssl, client_fd, start_t, end_t, compression, encryption, payload))
-   {
-      pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_VERIFY_NETWORK, NAME, compression, encryption, payload);
-      pgmoneta_log_error("Verify: Error sending response for %s/%s", config->common.servers[server].name, identifier);
-
-      goto error;
-   }
-
-   elapsed = pgmoneta_get_timestamp_string(start_t, end_t, &total_seconds);
-
-   pgmoneta_log_info("Verify: %s/%s (Elapsed: %s)", config->common.servers[server].name, label, elapsed);
-
-   pgmoneta_deque_iterator_destroy(fiter);
-   pgmoneta_deque_iterator_destroy(aiter);
 
    pgmoneta_art_destroy(nodes);
 
@@ -281,22 +161,16 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
    pgmoneta_stop_logging();
 
    free(real_directory);
-   free(elapsed);
 
    exit(0);
 
 error:
 
+   pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name,
+                                      ec != -1 ? ec : MANAGEMENT_ERROR_VERIFY_ERROR,
+                                      en != NULL ? en : NAME, compression, encryption, payload);
+
    pgmoneta_delete_directory((char*)pgmoneta_art_search(nodes, NODE_TARGET_BASE));
-
-   pgmoneta_deque_iterator_destroy(fiter);
-   pgmoneta_deque_iterator_destroy(aiter);
-
-   pgmoneta_art_destroy(nodes);
-
-   pgmoneta_json_destroy(filesj);
-   pgmoneta_json_destroy(failed);
-   pgmoneta_json_destroy(all);
 
    pgmoneta_json_destroy(payload);
 
@@ -307,7 +181,6 @@ error:
    pgmoneta_stop_logging();
 
    free(real_directory);
-   free(elapsed);
 
    exit(1);
 }

--- a/src/libpgmoneta/wf_archive.c
+++ b/src/libpgmoneta/wf_archive.c
@@ -146,7 +146,7 @@ error:
    free(src);
    free(dst);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int

--- a/src/libpgmoneta/wf_backup.c
+++ b/src/libpgmoneta/wf_backup.c
@@ -460,7 +460,7 @@ error:
       atomic_store(&config->common.servers[server].backup_progress.state, BACKUP_PROGRESS_NONE);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static unsigned long

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -646,7 +646,7 @@ error:
    pgmoneta_free_query_response(response);
    pgmoneta_brt_destroy(summarized_brt);
    pgmoneta_memory_destroy();
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1024,7 +1024,7 @@ error:
    free(tag);
    free(wal);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1088,7 +1088,7 @@ compare_block_numbers(const void* a, const void* b)
    }
    else if (aa > bb)
    {
-      return 1;
+      return WORKFLOW_RESULT_ERROR;
    }
    return 0;
 }
@@ -1127,7 +1127,7 @@ error:
       free(paths);
    }
    pgmoneta_free_query_response(qr);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static void
@@ -1235,7 +1235,7 @@ error:
       fclose(prev_label_file);
    }
    free(write_buffer);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1376,7 +1376,7 @@ error:
    free_string_array(results, count);
    free(relation_file);
    free(base_directory_path);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1517,7 +1517,7 @@ error:
       fflush(file);
       fclose(file);
    }
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1586,7 +1586,7 @@ error:
       fflush(file);
       fclose(file);
    }
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1618,7 +1618,7 @@ write_padding(FILE* file, size_t padding_length, size_t* bw)
 
    return 0;
 error:
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char**
@@ -1778,7 +1778,7 @@ error:
    free(dst_file);
    free(src_file);
    free(pg_wal_dir);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1831,7 +1831,7 @@ wait_for_wal_switch(char* wal_dir, char* wal_file)
 error:
    pgmoneta_deque_destroy(files);
    pgmoneta_deque_iterator_destroy(it);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1851,7 +1851,7 @@ send_upload_manifest(SSL* ssl, int socket)
 
 error:
    pgmoneta_free_message(msg);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -1891,5 +1891,5 @@ error:
    {
       fclose(manifest);
    }
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_bzip2.c
+++ b/src/libpgmoneta/wf_bzip2.c
@@ -228,7 +228,7 @@ error:
 
    free(d);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -325,5 +325,5 @@ error:
       pgmoneta_workers_destroy(workers);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_delete.c
+++ b/src/libpgmoneta/wf_delete.c
@@ -244,7 +244,7 @@ error:
    atomic_store(&config->common.servers[server].repository, false);
    pgmoneta_log_trace("Delete is ready for %s", config->common.servers[server].name);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -436,5 +436,5 @@ error:
    free(d);
    free(from);
    free(to);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_encryption.c
+++ b/src/libpgmoneta/wf_encryption.c
@@ -246,7 +246,7 @@ error:
    free(d);
    free(enc_file);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int

--- a/src/libpgmoneta/wf_extra.c
+++ b/src/libpgmoneta/wf_extra.c
@@ -230,5 +230,5 @@ error:
    }
    pgmoneta_memory_destroy();
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_finalize.c
+++ b/src/libpgmoneta/wf_finalize.c
@@ -1,0 +1,441 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* pgmoneta */
+#include <art.h>
+#include <deque.h>
+#include <info.h>
+#include <json.h>
+#include <logging.h>
+#include <management.h>
+#include <network.h>
+#include <pgmoneta.h>
+#include <security.h>
+#include <utils.h>
+#include <value.h>
+#include <workflow.h>
+
+/* system */
+#include <assert.h>
+#include <stdlib.h>
+
+static char* finalize_name(void);
+static int finalize_setup(char*, struct art*);
+static int finalize_execute(char*, struct art*);
+static int finalize_teardown(char*, struct art*);
+
+static int finalize_backup_response(int server, struct art* nodes);
+static int finalize_restore_response(int server, struct art* nodes);
+static int finalize_verify_response(int server, struct art* nodes);
+
+struct workflow*
+pgmoneta_create_finalize(void)
+{
+   struct workflow* wf = NULL;
+
+   wf = (struct workflow*)malloc(sizeof(struct workflow));
+
+   if (wf == NULL)
+   {
+      return NULL;
+   }
+
+   wf->name = &finalize_name;
+   wf->setup = &finalize_setup;
+   wf->execute = &finalize_execute;
+   wf->teardown = &finalize_teardown;
+   wf->next = NULL;
+
+   return wf;
+}
+
+static char*
+finalize_name(void)
+{
+   return "Finalize";
+}
+
+static int
+finalize_setup(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server = -1;
+   int type = -1;
+   bool active = false;
+   struct main_configuration* config;
+
+   if (!pgmoneta_art_contains_key(nodes, NODE_FINALIZE_TYPE))
+   {
+      return 0;
+   }
+
+   config = (struct main_configuration*)shmem;
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   type = (int)pgmoneta_art_search(nodes, NODE_FINALIZE_TYPE);
+
+   if (!atomic_compare_exchange_strong(&config->common.servers[server].repository, &active, true))
+   {
+      pgmoneta_log_info("Finalize: Server %s is active", config->common.servers[server].name);
+      pgmoneta_log_debug("Backup=%s, Restore=%s, Archive=%s, Delete=%s, Retention=%s",
+                         config->common.servers[server].active_backup ? "Yes" : "No",
+                         config->common.servers[server].active_restore ? "Yes" : "No",
+                         config->common.servers[server].active_archive ? "Yes" : "No",
+                         config->common.servers[server].active_delete ? "Yes" : "No",
+                         config->common.servers[server].active_retention ? "Yes" : "No");
+      return WORKFLOW_RESULT_FATAL;
+   }
+
+   switch (type)
+   {
+      case FINALIZE_TYPE_BACKUP:
+         config->common.servers[server].active_backup = true;
+         break;
+      case FINALIZE_TYPE_RESTORE:
+         config->common.servers[server].active_restore = true;
+         break;
+      case FINALIZE_TYPE_VERIFY:
+         break;
+      default:
+         break;
+   }
+
+   pgmoneta_art_insert(nodes, NODE_FINALIZE_VALUE, (uintptr_t)true, ValueBool);
+
+   pgmoneta_log_debug("Finalize (setup): %s", config->common.servers[server].name);
+
+   return 0;
+}
+
+static int
+finalize_execute(char* name __attribute__((unused)), struct art* nodes __attribute__((unused)))
+{
+   return 0;
+}
+
+static int
+finalize_teardown(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server = -1;
+   int type = -1;
+   int client_fd = -1;
+   uint8_t compression = 0;
+   uint8_t encryption = 0;
+   SSL* ssl = NULL;
+   struct json* payload = NULL;
+   struct timespec start_t;
+   struct timespec end_t;
+   struct main_configuration* config;
+
+   if (!pgmoneta_art_contains_key(nodes, NODE_FINALIZE_TYPE))
+   {
+      return 0;
+   }
+
+   config = (struct main_configuration*)shmem;
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   type = (int)pgmoneta_art_search(nodes, NODE_FINALIZE_TYPE);
+
+   /* Assert mandatory nodes */
+   assert(pgmoneta_art_contains_key(nodes, NODE_CLIENT_FD));
+   assert(pgmoneta_art_contains_key(nodes, NODE_PAYLOAD));
+   assert(pgmoneta_art_contains_key(nodes, NODE_COMPRESSION));
+   assert(pgmoneta_art_contains_key(nodes, NODE_ENCRYPTION));
+   assert(pgmoneta_art_contains_key(nodes, NODE_START_TIME));
+
+   client_fd = (int)pgmoneta_art_search(nodes, NODE_CLIENT_FD);
+   ssl = (SSL*)pgmoneta_art_search(nodes, NODE_SSL);
+   payload = (struct json*)pgmoneta_art_search(nodes, NODE_PAYLOAD);
+   compression = (uint8_t)(uintptr_t)pgmoneta_art_search(nodes, NODE_COMPRESSION);
+   encryption = (uint8_t)(uintptr_t)pgmoneta_art_search(nodes, NODE_ENCRYPTION);
+   start_t = *(struct timespec*)pgmoneta_art_search(nodes, NODE_START_TIME);
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
+#endif
+
+   double total_seconds = 0.0;
+   char* elapsed = pgmoneta_get_timestamp_string(start_t, end_t, &total_seconds);
+
+   /* Send the recorded result */
+   if (pgmoneta_art_contains_key(nodes, NODE_ERROR_CODE))
+   {
+      int ec = (int)pgmoneta_art_search(nodes, NODE_ERROR_CODE);
+
+      pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name,
+                                         ec, finalize_name(),
+                                         compression, encryption, payload);
+   }
+   else
+   {
+      if (type == FINALIZE_TYPE_BACKUP && pgmoneta_art_contains_key(nodes, NODE_BACKUP))
+      {
+         struct backup* b = (struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP);
+         b->total_elapsed_time = total_seconds;
+      }
+
+      switch (type)
+      {
+         case FINALIZE_TYPE_BACKUP:
+            finalize_backup_response(server, nodes);
+            pgmoneta_log_info("Backup: %s/%s (Elapsed: %s)", config->common.servers[server].name, (char*)pgmoneta_art_search(nodes, NODE_LABEL), elapsed);
+            break;
+         case FINALIZE_TYPE_RESTORE:
+            finalize_restore_response(server, nodes);
+            pgmoneta_log_info("Restore: %s/%s (Elapsed: %s)", config->common.servers[server].name, ((struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP))->label, elapsed);
+            break;
+         case FINALIZE_TYPE_VERIFY:
+            finalize_verify_response(server, nodes);
+            pgmoneta_log_info("Verify: %s/%s (Elapsed: %s)", config->common.servers[server].name, (char*)pgmoneta_art_search(nodes, NODE_LABEL), elapsed);
+            break;
+         default:
+            break;
+      }
+
+      pgmoneta_management_response_ok(ssl, client_fd, start_t, end_t, compression, encryption, payload);
+   }
+
+   free(elapsed);
+
+   if ((bool)pgmoneta_art_search(nodes, NODE_FINALIZE_VALUE))
+   {
+      switch (type)
+      {
+         case FINALIZE_TYPE_BACKUP:
+            config->common.servers[server].active_backup = false;
+            atomic_store(&config->common.servers[server].repository, false);
+            break;
+         case FINALIZE_TYPE_RESTORE:
+            config->common.servers[server].active_restore = false;
+            atomic_store(&config->common.servers[server].repository, false);
+            break;
+         case FINALIZE_TYPE_VERIFY:
+            atomic_store(&config->common.servers[server].repository, false);
+            break;
+         default:
+            break;
+      }
+
+      pgmoneta_art_insert(nodes, NODE_FINALIZE_VALUE, (uintptr_t)false, ValueBool);
+
+      pgmoneta_log_debug("Finalize (teardown): %s", config->common.servers[server].name);
+   }
+
+   return 0;
+}
+
+static int
+finalize_backup_response(int server, struct art* nodes)
+{
+   char* backup_data = NULL;
+   char* server_backup = NULL;
+   char* label = NULL;
+   struct backup* backup = NULL;
+   struct json* payload = NULL;
+   struct json* response = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP));
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP_DATA));
+   assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_BACKUP));
+   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
+   assert(pgmoneta_art_contains_key(nodes, NODE_PAYLOAD));
+
+   backup = (struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP);
+   backup_data = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_DATA);
+   server_backup = (char*)pgmoneta_art_search(nodes, NODE_SERVER_BACKUP);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+   payload = (struct json*)pgmoneta_art_search(nodes, NODE_PAYLOAD);
+
+   backup->backup_size = pgmoneta_directory_size(backup_data);
+   pgmoneta_save_info(server_backup, backup);
+
+   if (pgmoneta_management_create_response(payload, server, &response))
+   {
+      return 1;
+   }
+
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->common.servers[server].name, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP, (uintptr_t)label, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP_SIZE, (uintptr_t)backup->backup_size, ValueUInt64);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_RESTORE_SIZE, (uintptr_t)backup->restore_size, ValueUInt64);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BIGGEST_FILE_SIZE, (uintptr_t)backup->biggest_file_size, ValueUInt64);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMPRESSION, (uintptr_t)backup->compression, ValueInt32);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_ENCRYPTION, (uintptr_t)backup->encryption, ValueInt32);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_VALID, (uintptr_t)backup->valid, ValueInt8);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL, (uintptr_t)backup->type, ValueBool);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL_PARENT, (uintptr_t)backup->parent_label, ValueString);
+
+   return 0;
+}
+
+static int
+finalize_restore_response(int server, struct art* nodes)
+{
+   struct backup* backup = NULL;
+   struct json* payload = NULL;
+   struct json* response = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_BACKUP));
+   assert(pgmoneta_art_contains_key(nodes, NODE_PAYLOAD));
+
+   backup = (struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP);
+   payload = (struct json*)pgmoneta_art_search(nodes, NODE_PAYLOAD);
+
+   if (pgmoneta_management_create_response(payload, server, &response))
+   {
+      return 1;
+   }
+
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->common.servers[server].name, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP, (uintptr_t)backup->label, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP_SIZE, (uintptr_t)backup->backup_size, ValueUInt64);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_RESTORE_SIZE, (uintptr_t)backup->restore_size, ValueUInt64);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BIGGEST_FILE_SIZE, (uintptr_t)backup->biggest_file_size, ValueUInt64);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMMENTS, (uintptr_t)backup->comments, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_COMPRESSION, (uintptr_t)backup->compression, ValueInt32);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_ENCRYPTION, (uintptr_t)backup->encryption, ValueInt32);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL, (uintptr_t)backup->type, ValueBool);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_INCREMENTAL_PARENT, (uintptr_t)backup->parent_label, ValueString);
+
+   return 0;
+}
+
+static int
+finalize_verify_response(int server, struct art* nodes)
+{
+   char* label = NULL;
+   struct json* payload = NULL;
+   struct json* response = NULL;
+   struct json* filesj = NULL;
+   struct json* failed = NULL;
+   struct json* all = NULL;
+   struct deque* f = NULL;
+   struct deque* a = NULL;
+   struct deque_iterator* fiter = NULL;
+   struct deque_iterator* aiter = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
+   assert(pgmoneta_art_contains_key(nodes, NODE_FAILED));
+   assert(pgmoneta_art_contains_key(nodes, NODE_PAYLOAD));
+
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+   f = (struct deque*)pgmoneta_art_search(nodes, NODE_FAILED);
+   payload = (struct json*)pgmoneta_art_search(nodes, NODE_PAYLOAD);
+
+   if (pgmoneta_art_contains_key(nodes, NODE_ALL))
+   {
+      a = (struct deque*)pgmoneta_art_search(nodes, NODE_ALL);
+   }
+
+   if (pgmoneta_json_create(&failed))
+   {
+      return 1;
+   }
+
+   if (pgmoneta_deque_iterator_create(f, &fiter))
+   {
+      return 1;
+   }
+
+   while (pgmoneta_deque_iterator_next(fiter))
+   {
+      struct json* j = NULL;
+
+      if (pgmoneta_json_clone((struct json*)pgmoneta_value_data(fiter->value), &j))
+      {
+         pgmoneta_deque_iterator_destroy(fiter);
+         return 1;
+      }
+
+      pgmoneta_json_append(failed, (uintptr_t)j, ValueJSON);
+   }
+
+   pgmoneta_deque_iterator_destroy(fiter);
+
+   if (a != NULL)
+   {
+      if (pgmoneta_json_create(&all))
+      {
+         return 1;
+      }
+
+      if (pgmoneta_deque_iterator_create(a, &aiter))
+      {
+         return 1;
+      }
+
+      while (pgmoneta_deque_iterator_next(aiter))
+      {
+         struct json* j = NULL;
+
+         if (pgmoneta_json_clone((struct json*)pgmoneta_value_data(aiter->value), &j))
+         {
+            pgmoneta_deque_iterator_destroy(aiter);
+            return 1;
+         }
+
+         pgmoneta_json_append(all, (uintptr_t)j, ValueJSON);
+      }
+
+      pgmoneta_deque_iterator_destroy(aiter);
+   }
+
+   if (pgmoneta_management_create_response(payload, server, &response))
+   {
+      return 1;
+   }
+
+   if (pgmoneta_json_create(&filesj))
+   {
+      return 1;
+   }
+
+   pgmoneta_json_put(filesj, MANAGEMENT_ARGUMENT_FAILED, (uintptr_t)failed, ValueJSON);
+   pgmoneta_json_put(filesj, MANAGEMENT_ARGUMENT_ALL, (uintptr_t)all, ValueJSON);
+
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_BACKUP, (uintptr_t)label, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_SERVER, (uintptr_t)config->common.servers[server].name, ValueString);
+   pgmoneta_json_put(response, MANAGEMENT_ARGUMENT_FILES, (uintptr_t)filesj, ValueJSON);
+
+   return 0;
+}

--- a/src/libpgmoneta/wf_gzip.c
+++ b/src/libpgmoneta/wf_gzip.c
@@ -226,7 +226,7 @@ error:
 
    free(d);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -311,5 +311,5 @@ error:
       pgmoneta_workers_destroy(workers);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_link.c
+++ b/src/libpgmoneta/wf_link.c
@@ -248,5 +248,5 @@ error:
    pgmoneta_art_destroy(added_files);
    pgmoneta_art_destroy(deleted_files);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_lz4.c
+++ b/src/libpgmoneta/wf_lz4.c
@@ -226,7 +226,7 @@ error:
 
    free(d);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -311,5 +311,5 @@ error:
       pgmoneta_workers_destroy(workers);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_manifest.c
+++ b/src/libpgmoneta/wf_manifest.c
@@ -214,5 +214,5 @@ error:
    free(manifest);
    free(manifest_orig);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_permissions.c
+++ b/src/libpgmoneta/wf_permissions.c
@@ -193,7 +193,7 @@ permissions_execute_archive(char* name __attribute__((unused)), struct art* node
       if (pgmoneta_extraction_get_suffix(config->compression_type, config->encryption, &suffix))
       {
          free(path);
-         return 1;
+         return WORKFLOW_RESULT_ERROR;
       }
       if (suffix != NULL)
       {

--- a/src/libpgmoneta/wf_restore.c
+++ b/src/libpgmoneta/wf_restore.c
@@ -250,7 +250,7 @@ error:
    free(waldir);
    free(waltarget);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*
@@ -349,7 +349,7 @@ combine_incremental_execute(char* name __attribute__((unused)), struct art* node
 
 error:
    free(input_dir);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*
@@ -709,7 +709,7 @@ error:
    free(t);
    free(path);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*
@@ -792,7 +792,7 @@ error:
    free(origwal);
    free(waldir);
    free(waltarget);
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*
@@ -889,7 +889,7 @@ error:
    free(to);
    free(suffix);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -971,7 +971,7 @@ error:
    free(to);
    free(suffix);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static char*

--- a/src/libpgmoneta/wf_sha256.c
+++ b/src/libpgmoneta/wf_sha256.c
@@ -135,7 +135,7 @@ error:
    free(root);
    free(d);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -219,5 +219,5 @@ error:
 
    free(dir_path);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_sha512.c
+++ b/src/libpgmoneta/wf_sha512.c
@@ -174,7 +174,7 @@ error:
    free(root);
    free(d);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -258,7 +258,7 @@ error:
 
    free(dir_path);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 int
@@ -413,5 +413,5 @@ error:
    free(new_sha512);
    free(new_line);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -245,7 +245,7 @@ error:
    free(base);
    free(manifest_file);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static void

--- a/src/libpgmoneta/wf_zstd.c
+++ b/src/libpgmoneta/wf_zstd.c
@@ -227,7 +227,7 @@ error:
    }
    free(d);
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }
 
 static int
@@ -312,5 +312,5 @@ error:
       pgmoneta_workers_destroy(workers);
    }
 
-   return 1;
+   return WORKFLOW_RESULT_ERROR;
 }

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -42,6 +42,7 @@
 /* system */
 #include <assert.h>
 #include <dirent.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -312,7 +313,10 @@ pgmoneta_workflow_execute(struct workflow* workflow, struct art* nodes,
 {
    char* en = NULL;
    int ec = -1;
+   int ret = 0;
+   int count = 0;
    struct workflow* current = NULL;
+   struct workflow** chain = NULL;
 
    *error_name = en;
    *error_code = ec;
@@ -320,10 +324,41 @@ pgmoneta_workflow_execute(struct workflow* workflow, struct art* nodes,
    current = workflow;
    while (current != NULL)
    {
-      if (current->setup(current->name(), nodes))
+      count++;
+      current = current->next;
+   }
+
+   chain = (struct workflow**)malloc(count * sizeof(struct workflow*));
+   if (chain == NULL)
+   {
+      goto error;
+   }
+
+   current = workflow;
+   for (int i = 0; i < count; i++)
+   {
+      chain[i] = current;
+      current = current->next;
+   }
+
+   current = workflow;
+   while (current != NULL)
+   {
+      ret = current->setup(current->name(), nodes);
+      if (ret != WORKFLOW_RESULT_SUCCESS)
       {
          en = current->name();
          ec = get_error_code(current->type, SETUP, nodes);
+
+         if (ret == WORKFLOW_RESULT_FATAL)
+         {
+            pgmoneta_log_warn("setup/%s", current->name());
+         }
+         else
+         {
+            pgmoneta_log_debug("setup/%s", current->name());
+         }
+
          goto error;
       }
       current = current->next;
@@ -332,34 +367,75 @@ pgmoneta_workflow_execute(struct workflow* workflow, struct art* nodes,
    current = workflow;
    while (current != NULL)
    {
-      if (current->execute(current->name(), nodes))
+      ret = current->execute(current->name(), nodes);
+      if (ret != WORKFLOW_RESULT_SUCCESS)
       {
          en = current->name();
          ec = get_error_code(current->type, EXECUTE, nodes);
+
+         if (ret == WORKFLOW_RESULT_FATAL)
+         {
+            pgmoneta_log_warn("execute/%s", current->name());
+         }
+         else
+         {
+            pgmoneta_log_debug("execute/%s", current->name());
+         }
+
          goto error;
       }
       current = current->next;
    }
 
-   current = workflow;
-   while (current != NULL)
+   /* Teardown in reverse order */
+   for (int i = count - 1; i >= 0; i--)
    {
-      if (current->teardown(current->name(), nodes))
+      ret = chain[i]->teardown(chain[i]->name(), nodes);
+      if (ret != WORKFLOW_RESULT_SUCCESS)
       {
-         en = current->name();
-         ec = get_error_code(current->type, TEARDOWN, nodes);
-         goto error;
+         if (en == NULL)
+         {
+            en = chain[i]->name();
+            ec = get_error_code(chain[i]->type, TEARDOWN, nodes);
+         }
+
+         if (ret == WORKFLOW_RESULT_FATAL)
+         {
+            pgmoneta_log_warn("teardown/%s", chain[i]->name());
+         }
+         else
+         {
+            pgmoneta_log_debug("teardown/%s", chain[i]->name());
+         }
       }
-      current = current->next;
    }
 
+   if (en != NULL)
+   {
+      *error_name = en;
+      *error_code = ec;
+
+      free(chain);
+      return 1;
+   }
+
+   free(chain);
    return 0;
 
 error:
 
+   pgmoneta_art_insert(nodes, NODE_ERROR_CODE, (uintptr_t)ec, ValueInt32);
+
+   /* Teardown in reverse order */
+   for (int i = count - 1; i >= 0; i--)
+   {
+      chain[i]->teardown(chain[i]->name(), nodes);
+   }
+
    *error_name = en;
    *error_code = ec;
 
+   free(chain);
    return 1;
 }
 
@@ -394,6 +470,14 @@ pgmoneta_common_setup(char* name, struct art* nodes)
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
+
+   /* Guard: if finalize is part of this workflow but lock was not acquired, skip */
+   if (pgmoneta_art_contains_key(nodes, NODE_FINALIZE_TYPE) &&
+       (!pgmoneta_art_contains_key(nodes, NODE_FINALIZE_VALUE) ||
+        !(bool)pgmoneta_art_search(nodes, NODE_FINALIZE_VALUE)))
+   {
+      return 0;
+   }
 
 #ifdef DEBUG
    pgmoneta_dump_art(nodes);
@@ -445,8 +529,11 @@ wf_backup(void)
 
    config = (struct main_configuration*)shmem;
 
-   head = pgmoneta_create_basebackup();
+   head = pgmoneta_create_finalize();
    current = head;
+
+   current->next = pgmoneta_create_basebackup();
+   current = current->next;
 
    current->next = pgmoneta_create_manifest();
    current = current->next;
@@ -519,8 +606,11 @@ wf_restore(struct backup* backup)
    struct workflow* head = NULL;
    struct workflow* current = NULL;
 
-   head = pgmoneta_create_restore();
+   head = pgmoneta_create_finalize();
    current = head;
+
+   current->next = pgmoneta_create_restore();
+   current = current->next;
 
    if (backup->encryption != ENCRYPTION_NONE)
    {
@@ -584,8 +674,11 @@ wf_combine(bool combine_as_is)
    struct workflow* head = NULL;
    struct workflow* current = NULL;
 
-   head = pgmoneta_create_combine_incremental();
+   head = pgmoneta_create_finalize();
    current = head;
+
+   current->next = pgmoneta_create_combine_incremental();
+   current = current->next;
 
    if (!combine_as_is)
    {
@@ -722,8 +815,11 @@ wf_incremental_backup(void)
 
    config = (struct main_configuration*)shmem;
 
-   head = pgmoneta_create_incremental_backup();
+   head = pgmoneta_create_finalize();
    current = head;
+
+   current->next = pgmoneta_create_incremental_backup();
+   current = current->next;
 
    current->next = pgmoneta_create_manifest();
    current = current->next;
@@ -814,8 +910,11 @@ wf_verify(struct backup* backup)
    struct workflow* head = NULL;
    struct workflow* current = NULL;
 
-   head = pgmoneta_create_restore();
+   head = pgmoneta_create_finalize();
    current = head;
+
+   current->next = pgmoneta_create_restore();
+   current = current->next;
 
    if (backup->encryption != ENCRYPTION_NONE)
    {

--- a/test/testcases/test_finalize.c
+++ b/test/testcases/test_finalize.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pgmoneta.h>
+#include <management.h>
+#include <mctf.h>
+#include <tsclient.h>
+#include <tscommon.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+MCTF_TEST_NEGATIVE(test_pgmoneta_finalize_backup_lock_released)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_backup("primary", NULL, 0) == 0, cleanup,
+               "first backup failed");
+
+   MCTF_ASSERT(pgmoneta_tsclient_backup("primary", NULL, 0) == 0, cleanup,
+               "second backup failed — repository lock may not have been released");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_pgmoneta_finalize_restore_lock_released)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_test_add_backup() == 0, cleanup,
+               "backup failed during setup");
+
+   MCTF_ASSERT(pgmoneta_tsclient_restore("primary", "newest", "current", 0) == 0, cleanup,
+               "first restore failed");
+
+   MCTF_ASSERT(pgmoneta_tsclient_restore("primary", "newest", "current", 0) == 0, cleanup,
+               "second restore failed — repository lock may not have been released");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_pgmoneta_finalize_verify_lock_released)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_test_add_backup() == 0, cleanup,
+               "backup failed during setup");
+
+   MCTF_ASSERT(pgmoneta_tsclient_verify("primary", "newest", TEST_RESTORE_DIR, NULL, NULL, 0) == 0, cleanup,
+               "first verify failed");
+
+   MCTF_ASSERT(pgmoneta_tsclient_verify("primary", "newest", TEST_RESTORE_DIR, NULL, NULL, 0) == 0, cleanup,
+               "second verify failed — repository lock may not have been released");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_pgmoneta_finalize_backup_restore_verify_sequence)
+{
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(pgmoneta_tsclient_backup("primary", NULL, 0) == 0, cleanup,
+               "backup failed");
+
+   MCTF_ASSERT(pgmoneta_tsclient_restore("primary", "newest", "current", 0) == 0, cleanup,
+               "restore failed after backup");
+
+   MCTF_ASSERT(pgmoneta_tsclient_verify("primary", "newest", TEST_RESTORE_DIR, NULL, NULL, 0) == 0, cleanup,
+               "verify failed after restore");
+
+cleanup:
+   pgmoneta_test_basedir_cleanup();
+   MCTF_FINISH();
+}


### PR DESCRIPTION
resolved #1013 

## Changes
1. Added a `Finalize` workflow step to guarantee repository locks are released.
2. Replaced shared global variables with ART nodes to pass data directly and prevent race conditions.
3. Centralized client responses to ensure they are sent only after cleanup finishes.
