### PR TITLE
docs: add S3 verify limitation note to 17-s3.md and 05-cli.md

### DIFF
--- a/doc/manual/en/05-cli.md
+++ b/doc/manual/en/05-cli.md
@@ -204,6 +204,8 @@ Command
 pgmoneta-cli verify <server> <directory> [failed|all]
 ```
 
+
+> **Note:** When using S3 as the storage engine, run `pgmoneta-cli s3 restore` first to download the backup locally before running `pgmoneta-cli verify`.
 Example
 
 ``` sh

--- a/doc/manual/en/17-s3.md
+++ b/doc/manual/en/17-s3.md
@@ -109,3 +109,12 @@ pgmoneta-cli s3 restore primary <label>
 `pgmoneta-cli s3 restore` downloads all files from S3 for the given backup label into the local backup directory.
 
 Metadata files (`backup.info`, `backup.sha512`, `backup.manifest`) are downloaded as temporary files first, then renamed in order after all data files are restored. `backup.info` is renamed last and its presence marks a complete restore.
+
+## Verify
+
+Direct S3 verification via `pgmoneta-cli verify` is not yet supported.
+To verify a backup stored in S3, first restore it locally using
+`pgmoneta-cli s3 restore`, then run `pgmoneta-cli verify` against
+the local backup directory.
+
+Full S3 verification support is being tracked in [GitHub issue #1070](https://github.com/pgmoneta/pgmoneta/issues/1070).


### PR DESCRIPTION
Closes #1074

Added documentation noting that direct S3 verification via 
`pgmoneta-cli verify` is not yet supported.

Changes:
- doc/manual/en/17-s3.md: Added a Verify section explaining 
  users should run `pgmoneta-cli s3 restore` first, then verify locally
- doc/manual/en/05-cli.md: Added a note under the verify command 
  section for S3 users

Full S3 verification support is being tracked in #1070.