### PR TITLE
[#845] support deque sort with different data types

### DIFF
--- a/src/include/deque.h
+++ b/src/include/deque.h
@@ -50,6 +50,15 @@ struct deque_node
    struct deque_node* prev; /**< The previous pointer */
 };
 
+/**
+ * Compare two values in a deque
+ * @param a The first value
+ * @param b The second value
+ * @return Less than 0 if a should be before b, 0 if equal, otherwise greater than 0
+ */
+
+typedef int (*compare_cb)(struct value* a, struct value* b);
+
 /** @struct deque
  * Defines a deque
  */
@@ -258,9 +267,10 @@ pgmoneta_deque_list(struct deque* deque);
 /**
  * Sort the deque
  * @param deque The deque
+ * @param compare [Optional] The compare function pointer, if NULL then tag comparison is used
  */
 void
-pgmoneta_deque_sort(struct deque* deque);
+pgmoneta_deque_sort(struct deque* deque, compare_cb compare);
 
 /**
  * Convert what's inside deque to string

--- a/src/include/value.h
+++ b/src/include/value.h
@@ -190,6 +190,15 @@ pgmoneta_value_to_ref(enum value_type type);
 char*
 pgmoneta_value_type_to_string(enum value_type type);
 
+/**
+ * Compare two values based on their type
+ * @param a The first value
+ * @param b The second value
+ * @return -1 if a < b, 0 if a == b, 1 if a > b
+ */
+int
+pgmoneta_value_compare(struct value* a, struct value* b);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgmoneta/deque.c
+++ b/src/libpgmoneta/deque.c
@@ -77,10 +77,10 @@ static struct deque_node*
 get_middle(struct deque_node* node);
 
 static struct deque_node*
-deque_sort(struct deque_node* node);
+deque_sort(struct deque_node* node, compare_cb cmp);
 
 static struct deque_node*
-deque_merge(struct deque_node* node1, struct deque_node* node2);
+deque_merge(struct deque_node* node1, struct deque_node* node2, compare_cb cmp);
 
 static int
 tag_compare(char* tag1, char* tag2);
@@ -339,7 +339,7 @@ pgmoneta_deque_list(struct deque* deque)
 }
 
 void
-pgmoneta_deque_sort(struct deque* deque)
+pgmoneta_deque_sort(struct deque* deque, compare_cb compare)
 {
    deque_write_lock(deque);
    if (deque == NULL || deque->start == NULL || deque->end == NULL || deque->size <= 1)
@@ -355,7 +355,7 @@ pgmoneta_deque_sort(struct deque* deque)
    last->next = NULL;
    deque->start->next = NULL;
    deque->end->prev = NULL;
-   node = deque_sort(first);
+   node = deque_sort(first, compare);
    deque->start->next = node;
    node->prev = deque->start;
    while (node->next != NULL)
@@ -783,7 +783,7 @@ get_middle(struct deque_node* node)
 }
 
 static struct deque_node*
-deque_sort(struct deque_node* node)
+deque_sort(struct deque_node* node, compare_cb cmp)
 {
    struct deque_node* mid = NULL;
    struct deque_node* prevmid = NULL;
@@ -797,13 +797,13 @@ deque_sort(struct deque_node* node)
    prevmid = mid->prev;
    mid->prev = NULL;
    prevmid->next = NULL;
-   node1 = deque_sort(node);
-   node2 = deque_sort(mid);
-   return deque_merge(node1, node2);
+   node1 = deque_sort(node, cmp);
+   node2 = deque_sort(mid, cmp);
+   return deque_merge(node1, node2, cmp);
 }
 
 static struct deque_node*
-deque_merge(struct deque_node* node1, struct deque_node* node2)
+deque_merge(struct deque_node* node1, struct deque_node* node2, compare_cb cmp)
 {
    struct deque_node* node = NULL;
    struct deque_node* left = node1;
@@ -820,7 +820,18 @@ deque_merge(struct deque_node* node1, struct deque_node* node2)
    }
    while (left != NULL && right != NULL)
    {
-      if (tag_compare(left->tag, right->tag) <= 0)
+      int cmp_result = 0;
+
+      if (cmp != NULL)
+      {
+         cmp_result = cmp(left->data, right->data);
+      }
+      else
+      {
+         cmp_result = tag_compare(left->tag, right->tag);
+      }
+
+      if (cmp_result <= 0)
       {
          next = left->next;
          if (node == NULL)

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -1325,7 +1325,7 @@ s3_sign_request(char* method, char* canonical_uri, char* query_string,
 
    *auth_value = NULL;
 
-   pgmoneta_deque_sort(headers);
+   pgmoneta_deque_sort(headers, NULL);
 
    pgmoneta_deque_iterator_create(headers, &iter);
    while (pgmoneta_deque_iterator_next(iter))

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -2148,7 +2148,7 @@ pgmoneta_get_files(uint32_t file_type_mask, char* base, bool recursive, struct d
       }
    }
 
-   pgmoneta_deque_sort(array);
+   pgmoneta_deque_sort(array, NULL);
 
    *files = array;
 
@@ -2313,7 +2313,7 @@ pgmoneta_get_wal_files(char* base, struct deque** files)
       }
    }
 
-   pgmoneta_deque_sort(array);
+   pgmoneta_deque_sort(array, NULL);
 
    *files = array;
 

--- a/src/libpgmoneta/value.c
+++ b/src/libpgmoneta/value.c
@@ -28,6 +28,7 @@
 /* pgmoneta */
 #include <art.h>
 #include <json.h>
+#include <logging.h>
 #include <utils.h>
 
 /* System */
@@ -643,4 +644,85 @@ mem_to_string_cb(uintptr_t data, int32_t format __attribute__((unused)), char* t
    ret = pgmoneta_append(ret, buf);
 
    return ret;
+}
+
+int
+pgmoneta_value_compare(struct value* a, struct value* b)
+{
+   if (a == NULL && b == NULL)
+   {
+      return 0;
+   }
+   if (a == NULL)
+   {
+      return -1;
+   }
+   if (b == NULL)
+   {
+      return 1;
+   }
+   return 0;
+
+   if (a->type != b->type)
+   {
+      pgmoneta_log_warn("Value: Type mismatch %s vs %s", pgmoneta_value_type_to_string(a->type), pgmoneta_value_type_to_string(b->type));
+      return (a->type < b->type) ? -1 : 1;
+   }
+
+   switch (a->type)
+   {
+      case ValueString:
+      case ValueStringRef:
+      case ValueBASE64:
+      case ValueBASE64Ref:
+      {
+         char* val_a = (char*)a->data;
+         char* val_b = (char*)b->data;
+         if (val_a == NULL && val_b == NULL)
+         {
+            return 0;
+         }
+         if (val_a == NULL)
+         {
+            return -1;
+         }
+         if (val_b == NULL)
+         {
+            return 1;
+         }
+         return strcmp(val_a, val_b);
+      }
+
+      case ValueFloat:
+      {
+         float val_a = pgmoneta_value_to_float(a->data);
+         float val_b = pgmoneta_value_to_float(b->data);
+
+         if (val_a < val_b)
+         {
+            return -1;
+         }
+         if (val_a > val_b)
+         {
+            return 1;
+         }
+         return 0;
+      }
+      case ValueDouble:
+      {
+         double val_a = pgmoneta_value_to_double(a->data);
+         double val_b = pgmoneta_value_to_double(b->data);
+         return (val_a > val_b) - (val_a < val_b);
+      }
+      default:
+         if (a->data < b->data)
+         {
+            return -1;
+         }
+         if (a->data > b->data)
+         {
+            return 1;
+         }
+         return 0;
+   }
 }

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -828,7 +828,7 @@ wal_interactive_get_first_wal_path(const char* dir, char** first_wal_path)
       goto error;
    }
 
-   pgmoneta_deque_sort(files);
+   pgmoneta_deque_sort(files, NULL);
 
    if (pgmoneta_deque_iterator_create(files, &iter) != 0)
    {
@@ -4158,7 +4158,7 @@ show_previous_wal_file(struct ui_state* state)
       return;
    }
 
-   pgmoneta_deque_sort(files);
+   pgmoneta_deque_sort(files, NULL);
 
    int num_files = pgmoneta_deque_size(files);
    char** file_list = malloc(num_files * sizeof(char*));
@@ -4271,7 +4271,7 @@ show_next_wal_file(struct ui_state* state)
       return;
    }
 
-   pgmoneta_deque_sort(files);
+   pgmoneta_deque_sort(files, NULL);
 
    int num_files = pgmoneta_deque_size(files);
    char** file_list = malloc(num_files * sizeof(char*));

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -417,8 +417,9 @@ mctf_get_results(size_t* count);
  * When no arguments: selects MCTF_SKIP_IMPL_0 which passes NULL as format.
  * When arguments provided: selects MCTF_SKIP_IMPL_1 which uses first arg as format.
  */
-#define MCTF_SKIP(...) \
-   MCTF_SKIP_GET_HELPER(, ##__VA_ARGS__, MCTF_SKIP_IMPL_1, MCTF_SKIP_IMPL_1, MCTF_SKIP_IMPL_1, MCTF_SKIP_IMPL_0, dummy)(__VA_ARGS__)
+#define MCTF_SKIP(...)                                                                                                  \
+   MCTF_SKIP_GET_HELPER(, ##__VA_ARGS__, MCTF_SKIP_IMPL_1, MCTF_SKIP_IMPL_1, MCTF_SKIP_IMPL_1, MCTF_SKIP_IMPL_0, dummy) \
+   (__VA_ARGS__)
 
 /**
  * Finish a test function - returns mctf_errno

--- a/test/testcases/test_deque.c
+++ b/test/testcases/test_deque.c
@@ -355,7 +355,7 @@ MCTF_TEST(test_deque_sort)
       MCTF_ASSERT(!pgmoneta_deque_add(dq, tag, index[i], ValueInt32), cleanup, "add failed");
    }
 
-   pgmoneta_deque_sort(dq);
+   pgmoneta_deque_sort(dq, NULL);
 
    MCTF_ASSERT(!pgmoneta_deque_iterator_create(dq, &iter), cleanup, "iterator creation failed");
 
@@ -366,6 +366,82 @@ MCTF_TEST(test_deque_sort)
       MCTF_ASSERT_STR_EQ(iter->tag, tag, cleanup, "sorted tag mismatch");
       cnt++;
    }
+
+cleanup:
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(dq);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_deque_custom_sort_values)
+{
+   struct deque* dq = NULL;
+   struct deque_iterator* iter = NULL;
+   int cnt = 0;
+
+   int index[6] = {2, 1, 3, 5, 4, 0};
+
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(!pgmoneta_deque_create(false, &dq), cleanup, "custom deque creation failed");
+
+   for (int i = 0; i < 6; i++)
+   {
+      MCTF_ASSERT(!pgmoneta_deque_add(dq, NULL, index[i], ValueInt32), cleanup, "add failed");
+   }
+
+   pgmoneta_deque_sort(dq, pgmoneta_value_compare);
+
+   MCTF_ASSERT(!pgmoneta_deque_iterator_create(dq, &iter), cleanup, "iterator creation failed");
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      MCTF_ASSERT_INT_EQ(pgmoneta_value_data(iter->value), cnt, cleanup, "sorted value mismatch");
+      cnt++;
+   }
+
+cleanup:
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(dq);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_deque_sort_mixed_and_edge_cases)
+{
+   struct deque* dq = NULL;
+   struct deque_iterator* iter = NULL;
+
+   pgmoneta_test_setup();
+
+   MCTF_ASSERT(!pgmoneta_deque_create(false, &dq), cleanup, "custom deque creation failed");
+
+   pgmoneta_deque_add(dq, "tag1", (uintptr_t)100, ValueInt32);
+   pgmoneta_deque_add(dq, "tag2", (uintptr_t)"zebra", ValueString);
+   pgmoneta_deque_add(dq, "tag3", (uintptr_t)5, ValueInt32);
+   pgmoneta_deque_add(dq, "tag4", (uintptr_t)"apple", ValueString);
+
+   pgmoneta_deque_add(dq, NULL, (uintptr_t)50, ValueInt32);
+
+   pgmoneta_deque_sort(dq, pgmoneta_value_compare);
+
+   MCTF_ASSERT(!pgmoneta_deque_iterator_create(dq, &iter), cleanup, "iterator creation failed");
+
+   pgmoneta_deque_iterator_next(iter);
+   MCTF_ASSERT_INT_EQ(pgmoneta_value_data(iter->value), 5, cleanup, "Mixed sort failed: expected 5");
+
+   pgmoneta_deque_iterator_next(iter);
+   MCTF_ASSERT_INT_EQ(pgmoneta_value_data(iter->value), 50, cleanup, "Mixed sort failed: expected 50");
+
+   pgmoneta_deque_iterator_next(iter);
+   MCTF_ASSERT_INT_EQ(pgmoneta_value_data(iter->value), 100, cleanup, "Mixed sort failed: expected 100");
+
+   pgmoneta_deque_iterator_next(iter);
+   MCTF_ASSERT_STR_EQ((char*)pgmoneta_value_data(iter->value), "apple", cleanup, "Mixed sort failed: expected apple");
+
+   pgmoneta_deque_iterator_next(iter);
+   MCTF_ASSERT_STR_EQ((char*)pgmoneta_value_data(iter->value), "zebra", cleanup, "Mixed sort failed: expected zebra");
 
 cleanup:
    pgmoneta_deque_iterator_destroy(iter);


### PR DESCRIPTION
[#845] resolved

# Changes
1. Added a comparator for each data type depending on the deque value.
2. Handled cases where there are mixed data types.