### PR TITLE
[#1080] Add fast fail support to worker pool

### DIFF
--- a/src/include/workers.h
+++ b/src/include/workers.h
@@ -37,8 +37,7 @@ extern "C" {
 #include <deque.h>
 
 #include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdatomic.h>
 
 struct worker_common;
 
@@ -58,6 +57,7 @@ struct semaphore
 struct worker_task
 {
    void (*function)(struct worker_common*); /**< The task function */
+   void (*destroy)(struct worker_common*);  /**< The task destroy function */
    struct worker_common* wc;                /**< Pointer to the common data */
 };
 
@@ -80,7 +80,9 @@ struct workers
    volatile int number_of_working; /**< The number of workers */
    pthread_mutex_t worker_lock;    /**< The worker lock */
    pthread_cond_t worker_all_idle; /**< Are workers idle */
-   bool outcome;                   /**< Outcome of the workers */
+   atomic_bool fast_fail;          /**< fast fail to the workers*/
+   atomic_bool outcome;            /**< Outcome of the workers*/
+   atomic_bool queue_drained;      /**< Queued tasks have been canceled */
    struct deque* queue;            /**< The task queue using deque */
    struct semaphore* has_tasks;    /**< Semaphore for tasks dispatching*/
 };
@@ -115,7 +117,7 @@ struct worker_input
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_workers_initialize(int num, struct workers** workers);
+pgmoneta_workers_initialize(int num, bool fast_fail, struct workers** workers);
 
 /**
  * Add work to the queue
@@ -126,6 +128,17 @@ pgmoneta_workers_initialize(int num, struct workers** workers);
  */
 int
 pgmoneta_workers_add(struct workers* workers, void (*function)(struct worker_common*), struct worker_common* wc);
+
+/**
+ * Add work to the queue 
+ * @param workers The workers
+ * @param function The function pointer
+ * @param wc The argument
+ * @param destroy The destroy function pointer
+ * @return 0 upon success, otherwise 1.
+ */
+int
+pgmoneta_workers_add_with_destroy(struct workers* workers, void (*function)(struct worker_common*), struct worker_common* wc, void (*destroy)(struct worker_common*));
 
 /**
  * Wait for all queued work units to finish
@@ -161,6 +174,20 @@ pgmoneta_get_number_of_workers(int server);
 int
 pgmoneta_create_worker_input(char* directory, char* from, char* to, int level,
                              struct workers* workers, struct worker_input** wi);
+
+/**
+ * mark the task as a failure
+ * @param workers The workers
+ */
+void
+pgmoneta_workers_mark_failure(struct workers* workers);
+
+/**
+ * get the workers outcome 
+ * @param workers The workers
+ */
+bool
+pgmoneta_workers_outcome(struct workers* workers);
 
 #ifdef __cplusplus
 }

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -860,7 +860,7 @@ pgmoneta_combine_backups(int server, char* label, char* base, char* input_dir, c
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    pgmoneta_deque_iterator_create(prior_labels, &iter);

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -856,7 +856,7 @@ s3_download_files(char* s3_root, char* local_root, int server, int compression, 
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_manifest_get_paths(manifest_path, &paths))
@@ -1035,7 +1035,7 @@ s3_upload_files(char* local_root, char* s3_root, int server, int compression, in
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_manifest_get_paths(manifest_path, &paths))

--- a/src/libpgmoneta/wf_bzip2.c
+++ b/src/libpgmoneta/wf_bzip2.c
@@ -129,7 +129,7 @@ bzip2_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       number_of_workers = pgmoneta_get_number_of_workers(server);
       if (number_of_workers > 0)
       {
-         pgmoneta_workers_initialize(number_of_workers, &workers);
+         pgmoneta_workers_initialize(number_of_workers, false, &workers);
       }
 
       backup_base = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_BASE);
@@ -288,7 +288,7 @@ bzip2_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_decompress_directory(base, COMPRESSION_CLIENT_BZIP2, workers, NULL))

--- a/src/libpgmoneta/wf_delete.c
+++ b/src/libpgmoneta/wf_delete.c
@@ -299,7 +299,7 @@ delete_backup(int server, int index, struct backup* backup __attribute__((unused
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_is_backup_struct_valid(server, backups[index]))

--- a/src/libpgmoneta/wf_encryption.c
+++ b/src/libpgmoneta/wf_encryption.c
@@ -137,7 +137,7 @@ encryption_execute(char* name __attribute__((unused)), struct art* nodes)
       number_of_workers = pgmoneta_get_number_of_workers(server);
       if (number_of_workers > 0)
       {
-         pgmoneta_workers_initialize(number_of_workers, &workers);
+         pgmoneta_workers_initialize(number_of_workers, false, &workers);
       }
 
       if (pgmoneta_deque_create(true, &excludes))
@@ -302,7 +302,7 @@ decryption_execute(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    pgmoneta_decrypt_directory(base, workers, NULL);

--- a/src/libpgmoneta/wf_gzip.c
+++ b/src/libpgmoneta/wf_gzip.c
@@ -131,7 +131,7 @@ gzip_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       number_of_workers = pgmoneta_get_number_of_workers(server);
       if (number_of_workers > 0)
       {
-         pgmoneta_workers_initialize(number_of_workers, &workers);
+         pgmoneta_workers_initialize(number_of_workers, false, &workers);
       }
 
       backup_base = (char*)pgmoneta_art_search(nodes, NODE_BACKUP_BASE);
@@ -281,7 +281,7 @@ gzip_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_decompress_directory(base, COMPRESSION_SERVER_GZIP, workers, NULL))

--- a/src/libpgmoneta/wf_hot_standby.c
+++ b/src/libpgmoneta/wf_hot_standby.c
@@ -157,7 +157,7 @@ hot_standby_execute(char* name __attribute__((unused)), struct art* nodes)
          {
             if (number_of_workers > 0 && workers == NULL)
             {
-               pgmoneta_workers_initialize(number_of_workers, &workers);
+               pgmoneta_workers_initialize(number_of_workers, false, &workers);
             }
 
             if (source == NULL)
@@ -297,7 +297,7 @@ hot_standby_execute(char* name __attribute__((unused)), struct art* nodes)
             }
             if (number_of_workers > 0 && workers == NULL)
             {
-               pgmoneta_workers_initialize(number_of_workers, &workers);
+               pgmoneta_workers_initialize(number_of_workers, false, &workers);
             }
 
             if (pgmoneta_exists(destination))

--- a/src/libpgmoneta/wf_link.c
+++ b/src/libpgmoneta/wf_link.c
@@ -155,7 +155,7 @@ link_execute(char* name __attribute__((unused)), struct art* nodes)
 
          if (number_of_workers > 0)
          {
-            pgmoneta_workers_initialize(number_of_workers, &workers);
+            pgmoneta_workers_initialize(number_of_workers, false, &workers);
          }
 
          from = pgmoneta_get_server_backup_identifier(server, label);

--- a/src/libpgmoneta/wf_lz4.c
+++ b/src/libpgmoneta/wf_lz4.c
@@ -134,7 +134,7 @@ lz4_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       number_of_workers = pgmoneta_get_number_of_workers(server);
       if (number_of_workers > 0)
       {
-         pgmoneta_workers_initialize(number_of_workers, &workers);
+         pgmoneta_workers_initialize(number_of_workers, false, &workers);
       }
 
       if (pgmoneta_deque_create(true, &excludes))
@@ -281,7 +281,7 @@ lz4_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_decompress_directory(base, COMPRESSION_SERVER_LZ4, workers, NULL))

--- a/src/libpgmoneta/wf_restore.c
+++ b/src/libpgmoneta/wf_restore.c
@@ -215,7 +215,7 @@ restore_execute(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_copy_postgresql_restore(from, to, directory, config->common.servers[server].name, label, backup, workers))
@@ -752,7 +752,7 @@ copy_wal_execute(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -133,7 +133,7 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_is_binary_file(manifest_file))

--- a/src/libpgmoneta/wf_zstd.c
+++ b/src/libpgmoneta/wf_zstd.c
@@ -136,7 +136,7 @@ zstd_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       number_of_workers = pgmoneta_get_number_of_workers(server);
       if (number_of_workers > 0)
       {
-         pgmoneta_workers_initialize(number_of_workers, &workers);
+         pgmoneta_workers_initialize(number_of_workers, false, &workers);
       }
 
       if (pgmoneta_deque_create(true, &excludes))
@@ -282,7 +282,7 @@ zstd_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    number_of_workers = pgmoneta_get_number_of_workers(server);
    if (number_of_workers > 0)
    {
-      pgmoneta_workers_initialize(number_of_workers, &workers);
+      pgmoneta_workers_initialize(number_of_workers, false, &workers);
    }
 
    if (pgmoneta_decompress_directory(base, COMPRESSION_SERVER_ZSTD, workers, NULL))

--- a/src/libpgmoneta/workers.c
+++ b/src/libpgmoneta/workers.c
@@ -27,6 +27,7 @@
  */
 
 #include <pgmoneta.h>
+#include <pthread.h>
 #include <security.h>
 #include <utils.h>
 #include <deque.h>
@@ -35,15 +36,13 @@
 #include <value.h>
 #include <aes.h>
 
-#include <errno.h>
-#include <signal.h>
 #include <time.h>
 #include <unistd.h>
 #ifdef HAVE_LINUX
 #include <sys/sysinfo.h>
 #endif
 
-static volatile int worker_keepalive;
+static atomic_int worker_keepalive;
 
 static int worker_init(struct workers* workers, struct worker** worker);
 static void* worker_do(struct worker* worker);
@@ -54,15 +53,17 @@ static void semaphore_post(struct semaphore* semaphore);
 static void semaphore_post_all(struct semaphore* semaphore);
 static void semaphore_wait(struct semaphore* semaphore);
 static void destroy_task_wrapper(uintptr_t data);
+static void drain_pending_tasks(struct workers* workers);
+static bool pgmoneta_workers_should_accept(struct workers* workers);
 
 int
-pgmoneta_workers_initialize(int num, struct workers** workers)
+pgmoneta_workers_initialize(int num, bool fast_fail, struct workers** workers)
 {
    struct workers* w = NULL;
 
    *workers = NULL;
 
-   worker_keepalive = 1;
+   atomic_init(&worker_keepalive, 1);
 
    if (num < 1)
    {
@@ -78,7 +79,10 @@ pgmoneta_workers_initialize(int num, struct workers** workers)
 
    w->number_of_alive = 0;
    w->number_of_working = 0;
-   w->outcome = true;
+
+   atomic_init(&w->outcome, true);
+   atomic_store(&w->fast_fail, fast_fail);
+   atomic_init(&w->queue_drained, false);
 
    if (pgmoneta_deque_create(true, &w->queue))
    {
@@ -152,6 +156,40 @@ pgmoneta_workers_add(struct workers* workers, void (*function)(struct worker_com
 
       task->function = function;
       task->wc = wc;
+      task->destroy = NULL;
+
+      config.destroy_data = destroy_task_wrapper;
+
+      pgmoneta_deque_add_with_config(workers->queue, NULL, (uintptr_t)task, &config);
+
+      semaphore_post(workers->has_tasks);
+
+      return 0;
+   }
+
+error:
+
+   return 1;
+}
+
+int
+pgmoneta_workers_add_with_destroy(struct workers* workers, void (*function)(struct worker_common*), struct worker_common* wc, void (*destroy)(struct worker_common* wc))
+{
+   struct worker_task* task = NULL;
+   struct value_config config = {0};
+
+   if (workers != NULL)
+   {
+      task = (struct worker_task*)malloc(sizeof(struct worker_task));
+      if (task == NULL)
+      {
+         pgmoneta_log_error("Could not allocate memory for task");
+         goto error;
+      }
+
+      task->function = function;
+      task->wc = wc;
+      task->destroy = destroy;
 
       config.destroy_data = destroy_task_wrapper;
 
@@ -196,7 +234,7 @@ pgmoneta_workers_destroy(struct workers* workers)
    if (workers != NULL)
    {
       worker_total = workers->number_of_alive;
-      worker_keepalive = 0;
+      atomic_store(&worker_keepalive, 0);
 
       time(&start);
       while (tpassed < timeout && workers->number_of_alive)
@@ -346,39 +384,52 @@ error:
 static void*
 worker_do(struct worker* worker)
 {
-   struct worker_task* task;
+   struct worker_task* task = NULL;
    struct workers* workers = worker->workers;
 
    pthread_mutex_lock(&workers->worker_lock);
    workers->number_of_alive += 1;
    pthread_mutex_unlock(&workers->worker_lock);
-
-   while (worker_keepalive)
+   while (atomic_load(&worker_keepalive))
    {
       semaphore_wait(workers->has_tasks);
 
-      if (worker_keepalive)
+      pthread_mutex_lock(&workers->worker_lock);
+      if (!atomic_load(&worker_keepalive))
       {
-         pthread_mutex_lock(&workers->worker_lock);
-         workers->number_of_working++;
          pthread_mutex_unlock(&workers->worker_lock);
-
-         task = (struct worker_task*)pgmoneta_deque_poll(workers->queue, NULL);
-
-         if (task)
-         {
-            task->function(task->wc);
-            free(task);
-         }
-
-         pthread_mutex_lock(&workers->worker_lock);
-         workers->number_of_working--;
-         if (!workers->number_of_working)
-         {
-            pthread_cond_signal(&workers->worker_all_idle);
-         }
-         pthread_mutex_unlock(&workers->worker_lock);
+         continue;
       }
+      if (!pgmoneta_workers_should_accept(workers))
+      {
+         drain_pending_tasks(workers);
+         pthread_mutex_unlock(&workers->worker_lock);
+         continue;
+      }
+
+      task = (struct worker_task*)pgmoneta_deque_poll(workers->queue, NULL);
+      if (task != NULL)
+      {
+         workers->number_of_working++;
+      }
+      pthread_mutex_unlock(&workers->worker_lock);
+
+      if (task == NULL)
+      {
+         continue;
+      }
+
+      task->function(task->wc);
+      free(task);
+      task = NULL;
+
+      pthread_mutex_lock(&workers->worker_lock);
+      workers->number_of_working--;
+      if (!workers->number_of_working)
+      {
+         pthread_cond_signal(&workers->worker_all_idle);
+      }
+      pthread_mutex_unlock(&workers->worker_lock);
    }
    pthread_mutex_lock(&workers->worker_lock);
    workers->number_of_alive--;
@@ -450,4 +501,71 @@ destroy_task_wrapper(uintptr_t data)
 {
    struct worker_task* task = (struct worker_task*)data;
    free(task);
+}
+
+static void
+drain_pending_tasks(struct workers* workers)
+{
+   struct worker_task* task = NULL;
+
+   if (workers == NULL || atomic_exchange(&workers->queue_drained, true))
+   {
+      return;
+   }
+
+   while (pgmoneta_deque_size(workers->queue) > 0)
+   {
+      task = (struct worker_task*)pgmoneta_deque_poll(workers->queue, NULL);
+      if (task != NULL)
+      {
+         if (task->destroy != NULL)
+         {
+            task->destroy(task->wc);
+         }
+      }
+      free(task);
+   }
+
+   if (!workers->number_of_working)
+   {
+      pthread_cond_signal(&workers->worker_all_idle);
+   }
+}
+
+void
+pgmoneta_workers_mark_failure(struct workers* workers)
+{
+   if (workers == NULL)
+   {
+      return;
+   }
+
+   atomic_store(&workers->outcome, false);
+}
+
+bool
+pgmoneta_workers_outcome(struct workers* workers)
+{
+   if (workers == NULL)
+   {
+      return true;
+   }
+
+   return atomic_load(&workers->outcome);
+}
+
+bool
+pgmoneta_workers_should_accept(struct workers* workers)
+{
+   if (workers == NULL)
+   {
+      return false;
+   }
+
+   if (!atomic_load(&workers->fast_fail))
+   {
+      return true;
+   }
+
+   return atomic_load(&workers->outcome);
 }


### PR DESCRIPTION
Add fast fail support to the worker pool. When enabled, workers stop picking up new tasks once a failure is detected. Enabled for verify, S3 download, and S3 upload workers.

**Note**: The task caller is responsible for setting `workers->outcome = false` on failure. maybe a cahnge to switch task functions to return int so worker_do can manage outcome automatically along with the retery policy etc for the worker pool.