### PR TITLE
[#1103] Fix WAL locking race and skip temporary files in compression/…

### DIFF
--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -196,6 +196,7 @@ pgmoneta_encrypt_data(char* d, struct workers* workers, struct deque* excludes)
          if (!pgmoneta_ends_with(entry->d_name, ".aes") &&
              !pgmoneta_ends_with(entry->d_name, ".partial") &&
              !pgmoneta_ends_with(entry->d_name, ".history") &&
+             !pgmoneta_ends_with(entry->d_name, ".tmp") &&
              !pgmoneta_ends_with(entry->d_name, "backup_label") &&
              !pgmoneta_ends_with(entry->d_name, "backup_manifest"))
          {

--- a/src/libpgmoneta/compression.c
+++ b/src/libpgmoneta/compression.c
@@ -463,7 +463,9 @@ process_directory_operation(char* directory, int type, struct workers* workers, 
       else
       {
          if (pgmoneta_ends_with(entry->d_name, "backup_manifest") ||
-             pgmoneta_ends_with(entry->d_name, "backup_label"))
+             pgmoneta_ends_with(entry->d_name, "backup_label") ||
+             pgmoneta_ends_with(entry->d_name, ".tmp") ||
+             pgmoneta_ends_with(entry->d_name, ".partial"))
          {
             continue;
          }

--- a/src/libpgmoneta/wal.c
+++ b/src/libpgmoneta/wal.c
@@ -1903,6 +1903,7 @@ retry:
          pgmoneta_log_debug("WAL: Did not get WAL repository lock for server %s", config->common.servers[srv].name);
          retry_count++;
          scan = true;
+         active = false;
 
          if (retry_count < 10)
          {


### PR DESCRIPTION
resolved #1103

## Changes 

1. Fix a race condition in WAL streaming where multiple processes could bypass the `wal_repository` lock, leading to errors like “ZSTD: Could not open input file” and duplicate AES encryption.

2. Fix a retry-loop issue in `wal.c` where `atomic_compare_exchange_strong` updates the expected value on failure; without resetting `active` to `false`, stale state could cause incorrect lock acquisition and allow concurrent access.

3. Ignore temporary files like `.tmp` and `.partial` during compression directory processing in `compression.c`.

4. Apply the same check in `aes.c` to skip encrypting in-progress temporary files.