### PR TITLE
[#871] Add HTTP DELETE method for S3 storage engine

### DIFF
--- a/src/include/http.h
+++ b/src/include/http.h
@@ -47,6 +47,7 @@ extern "C" {
 #define PGMONETA_HTTP_GET  0
 #define PGMONETA_HTTP_POST 1
 #define PGMONETA_HTTP_PUT  2
+#define PGMONETA_HTTP_DELETE 3
 
 /* HTTP status codes */
 #define PGMONETA_HTTP_STATUS_OK    0

--- a/src/libpgmoneta/http.c
+++ b/src/libpgmoneta/http.c
@@ -1041,6 +1041,8 @@ http_method_to_string(int method)
          return "POST";
       case PGMONETA_HTTP_PUT:
          return "PUT";
+      case PGMONETA_HTTP_DELETE:
+         return "DELETE";   
       default:
          return NULL;
    }


### PR DESCRIPTION
Add PGMONETA_HTTP_DELETE definition to support S3 delete operations. This is part of the Storage Engine Operations Parity work to enable list/read/delete operations for remote backends.

Changes:
- Add PGMONETA_HTTP_DELETE (3) to http.h
- Add DELETE case to http_method_to_string() in http.c