### PR TITLE
[#1110] fixed missing openssl-devel in Dockerfiles

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,4 @@ Jozef Hernández <jozefhdez2@gmail.com>
 Tarun Wadhwa <tarunwadhwa85@gmail.com>
 Pranav Prajapati <pranavprajapati586@gmail.com>
 Som Shegokar <akashshegokar2186@gmail.com>
+Ameen Sakr <ameensakr623@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -59,6 +59,7 @@ Jozef Hernández <jozefhdez2@gmail.com>
 Tarun Wadhwa <tarunwadhwa85@gmail.com>
 Pranav Prajapati <pranavprajapati586@gmail.com>
 Som Shegokar <akashshegokar2186@gmail.com>
+Ameen Sakr <ameensakr623@gmail.com>
 ```
 
 ## Committers

--- a/test/postgresql/src/postgresql14/Dockerfile
+++ b/test/postgresql/src/postgresql14/Dockerfile
@@ -49,7 +49,7 @@ RUN dnf makecache
 # Install dependencies
 RUN dnf -y install git gcc cmake make postgresql14-devel
 RUN dnf -y install procps wget iputils net-tools
-RUN dnf -y install postgresql14 postgresql14-server postgresql14-contrib postgresql14-libs 
+RUN dnf -y install postgresql14 postgresql14-server postgresql14-contrib postgresql14-libs openssl-devel
 
 # Build and Install pgmoneta_ext
 WORKDIR /tmp/pg_extension

--- a/test/postgresql/src/postgresql15/Dockerfile
+++ b/test/postgresql/src/postgresql15/Dockerfile
@@ -49,7 +49,7 @@ RUN dnf makecache
 # Install dependencies
 RUN dnf -y install git gcc cmake make postgresql15-devel
 RUN dnf -y install procps wget iputils net-tools
-RUN dnf -y install postgresql15 postgresql15-server postgresql15-contrib postgresql15-libs 
+RUN dnf -y install postgresql15 postgresql15-server postgresql15-contrib postgresql15-libs openssl-devel
 
 # Build and Install pgmoneta_ext
 WORKDIR /tmp/pg_extension

--- a/test/postgresql/src/postgresql17/Dockerfile
+++ b/test/postgresql/src/postgresql17/Dockerfile
@@ -48,7 +48,7 @@ RUN dnf makecache
 # Install dependencies
 RUN dnf -y install git gcc cmake make postgresql17-devel
 RUN dnf -y install procps wget iputils net-tools
-RUN dnf -y install postgresql17 postgresql17-server postgresql17-contrib postgresql17-libs
+RUN dnf -y install postgresql17 postgresql17-server postgresql17-contrib postgresql17-libs openssl-devel
 
 # Build and Install pgmoneta_ext
 WORKDIR /tmp/pg_extension


### PR DESCRIPTION
# Changes

- Added `openssl-devel` to the `dnf install` command in the test environment Dockerfiles (`test/postgresql/src/postgresql*/Dockerfile`)