### PR TITLE
feat: add streaming callbacks to http_request and http_response

### DIFF
--- a/src/include/http.h
+++ b/src/include/http.h
@@ -69,9 +69,11 @@ struct http_payload
  */
 struct http_request
 {
-   struct http_payload payload; /**< Request payload */
-   int method;                  /**< HTTP method */
-   char* path;                  /**< Request path */
+   struct http_payload payload;                                  /**< Request payload */
+   int method;                                                   /**< HTTP method */
+   char* path;                                                   /**< Request path */
+   size_t (*read_cb)(void* buffer, size_t size, void* userdata); /**< Read callback for streaming upload */
+   void* read_userdata;                                          /**< User data for read callback */
 };
 
 /** @struct http_response
@@ -79,8 +81,10 @@ struct http_request
  */
 struct http_response
 {
-   struct http_payload payload; /**< Response payload */
-   int status_code;             /**< HTTP status code */
+   struct http_payload payload;                                   /**< Response payload */
+   int status_code;                                               /**< HTTP status code */
+   size_t (*write_cb)(void* buffer, size_t size, void* userdata); /**< Write callback for streaming download */
+   void* write_userdata;                                          /**< User data for write callback */
 };
 
 /** @struct http

--- a/src/libpgmoneta/http.c
+++ b/src/libpgmoneta/http.c
@@ -391,15 +391,24 @@ pgmoneta_http_invoke(struct http* connection, struct http_request* request, stru
       goto error;
    }
 
+   bool response_owned = false;
    pgmoneta_log_trace("Invoking HTTP request");
 
-   http_response = (struct http_response*)malloc(sizeof(struct http_response));
-   if (http_response == NULL)
+   if (*response != NULL)
    {
-      pgmoneta_log_error("Failed to allocate HTTP response structure");
-      goto error;
+      http_response = *response;
    }
-   memset(http_response, 0, sizeof(struct http_response));
+   else
+   {
+      http_response = (struct http_response*)malloc(sizeof(struct http_response));
+      if (http_response == NULL)
+      {
+         pgmoneta_log_error("Failed to allocate HTTP response structure");
+         goto error;
+      }
+      memset(http_response, 0, sizeof(struct http_response));
+      response_owned = true;
+   }
 
    if (http_build_request(connection, request, &full_request, &full_request_size))
    {
@@ -419,6 +428,30 @@ pgmoneta_http_invoke(struct http* connection, struct http_request* request, stru
    msg_request->length = full_request_size;
 
    error = 0;
+   if (request->read_cb != NULL)
+   {
+      char stream_buffer[8192];
+      struct message stream_msg;
+      ssize_t n;
+
+      memset(&stream_msg, 0, sizeof(struct message));
+      if (pgmoneta_write_message(connection->ssl, connection->socket, msg_request) != MESSAGE_STATUS_OK)
+      {
+         pgmoneta_log_error("Failed to send HTTP headers for streaming request");
+         goto error;
+      }
+      while ((n = (ssize_t)request->read_cb(stream_buffer, sizeof(stream_buffer), request->read_userdata)) > 0)
+      {
+         stream_msg.data = stream_buffer;
+         stream_msg.length = n;
+         if (pgmoneta_write_message(connection->ssl, connection->socket, &stream_msg) != MESSAGE_STATUS_OK)
+         {
+            pgmoneta_log_error("Failed to stream HTTP request body");
+            goto error;
+         }
+      }
+      goto response;
+   }
 req:
    if (error < 5)
    {
@@ -436,6 +469,7 @@ req:
       goto error;
    }
 
+response:
    status = http_read_response_header(connection->ssl, connection->socket, &header_text, http_response);
    if (status != MESSAGE_STATUS_OK)
    {
@@ -467,7 +501,7 @@ error:
    free(full_request);
    free(header_text);
    free(msg_request);
-   if (http_response != NULL)
+   if (http_response != NULL && response_owned)
    {
       pgmoneta_http_response_destroy(http_response);
    }
@@ -616,7 +650,6 @@ http_read_response_header(SSL* ssl, int socket,
       {
          goto error;
       }
-
       memcpy(http_response->payload.data, header_str + header_len, extra);
       ((char*)http_response->payload.data)[extra] = '\0';
       http_response->payload.data_size = extra;
@@ -727,8 +760,16 @@ http_read_chunked_body(SSL* ssl, int socket, struct http_response* http_response
          if (bytes_read <= 0)
             goto error;
 
-         http_response->payload.data = pgmoneta_append_bytes(http_response->payload.data, buffer, bytes_read, http_response->payload.data_size);
-         http_response->payload.data_size += bytes_read;
+         if (http_response->write_cb != NULL)
+         {
+            if (http_response->write_cb(buffer, bytes_read, http_response->write_userdata) != (size_t)bytes_read)
+               goto error;
+         }
+         else
+         {
+            http_response->payload.data = pgmoneta_append_bytes(http_response->payload.data, buffer, bytes_read, http_response->payload.data_size);
+            http_response->payload.data_size += bytes_read;
+         }
          chunk_read += bytes_read;
       }
       // the chunk size must match
@@ -775,7 +816,30 @@ http_read_content_length_body(SSL* ssl, int socket, struct http_response* http_r
 {
    char buffer[8192];
    ssize_t bytes_read;
-   size_t remaining = content_length - http_response->payload.data_size;
+   char* prefetched = (char*)http_response->payload.data;
+   size_t prefetched_size = http_response->payload.data_size;
+   size_t remaining;
+
+   if (prefetched_size > content_length)
+   {
+      goto error;
+   }
+
+   if (http_response->write_cb != NULL && prefetched_size > 0)
+   {
+      if (http_response->write_cb(prefetched, prefetched_size, http_response->write_userdata) != prefetched_size)
+      {
+         free(prefetched);
+         http_response->payload.data = NULL;
+         http_response->payload.data_size = 0;
+         goto error;
+      }
+      free(prefetched);
+      http_response->payload.data = NULL;
+      http_response->payload.data_size = 0;
+   }
+
+   remaining = content_length - prefetched_size;
 
    while (remaining > 0)
    {
@@ -785,8 +849,16 @@ http_read_content_length_body(SSL* ssl, int socket, struct http_response* http_r
       if (bytes_read <= 0)
          goto error;
 
-      http_response->payload.data = pgmoneta_append_bytes(http_response->payload.data, buffer, bytes_read, http_response->payload.data_size);
-      http_response->payload.data_size += bytes_read;
+      if (http_response->write_cb != NULL)
+      {
+         if (http_response->write_cb(buffer, bytes_read, http_response->write_userdata) != (size_t)bytes_read)
+            goto error;
+      }
+      else
+      {
+         http_response->payload.data = pgmoneta_append_bytes(http_response->payload.data, buffer, bytes_read, http_response->payload.data_size);
+         http_response->payload.data_size += bytes_read;
+      }
       remaining -= bytes_read;
    }
 
@@ -800,6 +872,20 @@ http_read_EOF_body(SSL* ssl, int socket, struct http_response* http_response)
    char buffer[8192];
    ssize_t bytes_read;
 
+   if (http_response->write_cb != NULL && http_response->payload.data_size > 0)
+   {
+      if (http_response->write_cb(http_response->payload.data, http_response->payload.data_size, http_response->write_userdata) != http_response->payload.data_size)
+      {
+         free(http_response->payload.data);
+         http_response->payload.data = NULL;
+         http_response->payload.data_size = 0;
+         goto error;
+      }
+      free(http_response->payload.data);
+      http_response->payload.data = NULL;
+      http_response->payload.data_size = 0;
+   }
+
    while (1)
    {
       size_t to_read = sizeof(buffer) - 1;
@@ -810,8 +896,16 @@ http_read_EOF_body(SSL* ssl, int socket, struct http_response* http_response)
       if (bytes_read == 0)
          break;
 
-      http_response->payload.data = pgmoneta_append_bytes(http_response->payload.data, buffer, bytes_read, http_response->payload.data_size);
-      http_response->payload.data_size += bytes_read;
+      if (http_response->write_cb != NULL)
+      {
+         if (http_response->write_cb(buffer, bytes_read, http_response->write_userdata) != (size_t)bytes_read)
+            goto error;
+      }
+      else
+      {
+         http_response->payload.data = pgmoneta_append_bytes(http_response->payload.data, buffer, bytes_read, http_response->payload.data_size);
+         http_response->payload.data_size += bytes_read;
+      }
    }
 
    return MESSAGE_STATUS_OK;
@@ -972,10 +1066,13 @@ http_build_request(struct http* connection, struct http_request* request, char**
 
    headers = pgmoneta_append(headers, "Connection: close\r\n");
 
-   sprintf(content_length, "%zu", request->payload.data_size);
-   headers = pgmoneta_append(headers, "Content-Length: ");
-   headers = pgmoneta_append(headers, content_length);
-   headers = pgmoneta_append(headers, "\r\n");
+   if (request->read_cb == NULL)
+   {
+      sprintf(content_length, "%zu", request->payload.data_size);
+      headers = pgmoneta_append(headers, "Content-Length: ");
+      headers = pgmoneta_append(headers, content_length);
+      headers = pgmoneta_append(headers, "\r\n");
+   }
 
    if (request->payload.headers != NULL && !pgmoneta_deque_empty(request->payload.headers))
    {
@@ -996,7 +1093,7 @@ http_build_request(struct http* connection, struct http_request* request, char**
    headers = pgmoneta_append(headers, "\r\n");
 
    header_len = strlen(request_line) + strlen(headers);
-   total_len = header_len + request->payload.data_size;
+   total_len = header_len + (request->read_cb == NULL ? request->payload.data_size : 0);
 
    *full_request = malloc(total_len + 1);
    if (*full_request == NULL)
@@ -1008,7 +1105,7 @@ http_build_request(struct http* connection, struct http_request* request, char**
    memcpy(*full_request, request_line, strlen(request_line));
    memcpy(*full_request + strlen(request_line), headers, strlen(headers));
 
-   if (request->payload.data_size > 0)
+   if (request->read_cb == NULL && request->payload.data_size > 0)
    {
       memcpy(*full_request + header_len, request->payload.data, request->payload.data_size);
    }

--- a/test/testcases/test_http.c
+++ b/test/testcases/test_http.c
@@ -39,6 +39,7 @@
 #include <sys/select.h>
 #include <sys/time.h>
 #include <stdio.h>
+#include <string.h>
 
 struct echo_server
 {
@@ -374,6 +375,142 @@ MCTF_TEST(test_pgmoneta_http_header_operations)
 cleanup:
    pgmoneta_http_request_destroy(request);
    pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+struct write_cb_context
+{
+   char data[64];
+   size_t data_size;
+};
+
+static size_t
+collect_write_cb(void* buffer, size_t size, void* userdata)
+{
+   struct write_cb_context* context = (struct write_cb_context*)userdata;
+
+   if (context == NULL || context->data_size + size > sizeof(context->data))
+   {
+      return 0;
+   }
+
+   memcpy(context->data + context->data_size, buffer, size);
+   context->data_size += size;
+
+   return size;
+}
+
+MCTF_TEST(test_pgmoneta_http_cb_fields_initialize)
+{
+   struct http_request* request = NULL;
+   struct http_response* response = NULL;
+   pgmoneta_test_setup();
+   MCTF_ASSERT(!pgmoneta_http_request_create(PGMONETA_HTTP_GET, "/test", &request), cleanup, "failed to create request");
+   response = (struct http_response*)calloc(1, sizeof(struct http_response));
+   MCTF_ASSERT_PTR_NONNULL(response, cleanup, "failed to alloc response");
+   MCTF_ASSERT_PTR_NULL((void*)request->read_cb, cleanup, "read_cb should be NULL initially");
+   MCTF_ASSERT_PTR_NULL((void*)response->write_cb, cleanup, "write_cb should be NULL initially");
+   MCTF_ASSERT_PTR_NULL(request->read_userdata, cleanup, "read_userdata should be NULL initially");
+   MCTF_ASSERT_PTR_NULL(response->write_userdata, cleanup, "write_userdata should be NULL initially");
+   response->write_cb = collect_write_cb;
+   response->write_userdata = response;
+   MCTF_ASSERT_PTR_NONNULL((void*)response->write_cb, cleanup, "write_cb should be set");
+   MCTF_ASSERT(response->write_userdata == response, cleanup, "write_userdata should be set");
+cleanup:
+   pgmoneta_http_request_destroy(request);
+   free(response);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_pgmoneta_http_write_cb_content_length)
+{
+   int status;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+   struct http_response* response = NULL;
+   struct write_cb_context write_context = {0};
+
+   const char* hostname = "localhost";
+   int port = 9999;
+   bool secure = false;
+
+   char* response_text =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 13\r\n"
+      "\r\n"
+      "Hello, World!";
+
+   setup_echo_server(response_text);
+
+   response = (struct http_response*)calloc(1, sizeof(struct http_response));
+   MCTF_ASSERT(response != NULL, cleanup, "failed to allocate response");
+
+   response->write_cb = collect_write_cb;
+   response->write_userdata = &write_context;
+
+   MCTF_ASSERT(!pgmoneta_http_create((char*)hostname, port, secure, &connection), cleanup, "failed to establish connection");
+   MCTF_ASSERT(!pgmoneta_http_request_create(PGMONETA_HTTP_GET, "/test", &request), cleanup, "failed to create request");
+
+   status = pgmoneta_http_invoke(connection, request, &response);
+   MCTF_ASSERT_INT_EQ(status, PGMONETA_HTTP_STATUS_OK, cleanup, "HTTP request failed");
+   MCTF_ASSERT_INT_EQ(write_context.data_size, 13, cleanup, "write_cb should receive content-length body");
+   MCTF_ASSERT_STR_EQ(write_context.data, "Hello, World!", cleanup, "write_cb content-length body mismatch");
+   MCTF_ASSERT(response->payload.data_size == 0, cleanup, "write_cb should prevent buffering in payload");
+
+cleanup:
+   pgmoneta_http_request_destroy(request);
+   pgmoneta_http_response_destroy(response);
+   pgmoneta_http_destroy(connection);
+   teardown_echo_server();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_pgmoneta_http_write_cb_chunked)
+{
+   int status;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+   struct http_response* response = NULL;
+   struct write_cb_context write_context = {0};
+
+   const char* hostname = "localhost";
+   int port = 9999;
+   bool secure = false;
+
+   char* response_text =
+      "HTTP/1.1 200 OK\r\n"
+      "Transfer-Encoding: chunked\r\n"
+      "\r\n"
+      "5\r\n"
+      "Hello\r\n"
+      "8\r\n"
+      ", World!\r\n"
+      "0\r\n"
+      "\r\n";
+
+   setup_echo_server(response_text);
+
+   response = (struct http_response*)calloc(1, sizeof(struct http_response));
+   MCTF_ASSERT(response != NULL, cleanup, "failed to allocate response");
+
+   response->write_cb = collect_write_cb;
+   response->write_userdata = &write_context;
+
+   MCTF_ASSERT(!pgmoneta_http_create((char*)hostname, port, secure, &connection), cleanup, "failed to establish connection");
+   MCTF_ASSERT(!pgmoneta_http_request_create(PGMONETA_HTTP_GET, "/test", &request), cleanup, "failed to create request");
+
+   status = pgmoneta_http_invoke(connection, request, &response);
+   MCTF_ASSERT_INT_EQ(status, PGMONETA_HTTP_STATUS_OK, cleanup, "HTTP chunked request failed");
+   MCTF_ASSERT_INT_EQ(write_context.data_size, 13, cleanup, "write_cb should receive chunked body");
+   MCTF_ASSERT_STR_EQ(write_context.data, "Hello, World!", cleanup, "write_cb chunked body mismatch");
+   MCTF_ASSERT(response->payload.data_size == 0, cleanup, "write_cb should prevent buffering for chunked response");
+
+cleanup:
+   pgmoneta_http_request_destroy(request);
+   pgmoneta_http_response_destroy(response);
+   pgmoneta_http_destroy(connection);
+   teardown_echo_server();
    MCTF_FINISH();
 }
 


### PR DESCRIPTION
Closes #1105

Add streaming callback support to the HTTP layer:

- read_cb + read_userdata added to http_request for streaming upload (CURLOPT_READFUNCTION-style)
- write_cb + write_userdata added to http_response for streaming download
- pgmoneta_http_invoke calls write_cb with response data when set, falling back to existing buffered path otherwise — no existing callers affected

Build verified clean with make -j4.

cc @bassamadnan @Amr-Shams