### PR TITLE
Add unit test cases for ART prefix search

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,7 +118,15 @@ if (check)
   target_include_directories(pgmoneta-test PRIVATE
     ${CMAKE_SOURCE_DIR}/src/include
     ${CMAKE_SOURCE_DIR}/test/include
-    ${CMAKE_SOURCE_DIR}/test/libpgmonetatest)
+    ${CMAKE_SOURCE_DIR}/test/libpgmonetatest
+    ${LIBEV_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIR}
+    ${CURSES_INCLUDE_DIRS}
+    ${LIBYAML_INCLUDE_DIRS}
+    ${LIBSSH_INCLUDE_DIRS}
+    ${ZSTD_INCLUDE_DIRS}
+    ${LZ4_INCLUDE_DIRS}
+    ${LibArchive_INCLUDE_DIRS})
 
   if(EXISTS "/etc/debian_version")
     target_link_libraries(pgmoneta-test pthread rt m pgmoneta)

--- a/test/testcases/test_art.c
+++ b/test/testcases/test_art.c
@@ -665,6 +665,284 @@ cleanup:
    MCTF_FINISH();
 }
 
+MCTF_TEST(test_art_prefix_search)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgmoneta_test_setup();
+
+   pgmoneta_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "apple", 1, ValueInt32), cleanup, "Insert apple failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "applet", 2, ValueInt32), cleanup, "Insert applet failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "apply", 3, ValueInt32), cleanup, "Insert apply failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "ball", 4, ValueInt32), cleanup, "Insert ball failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "bat", 5, ValueInt32), cleanup, "Insert bat failed");
+
+   count = pgmoneta_art_prefix_search(t, "app", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 3, cleanup, "Prefix search 'app' should return 3 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "First match mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Second match mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "apply", cleanup, "Third match mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "cat", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 0, cleanup, "Prefix search 'cat' should return 0 matches");
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "apple", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix search 'apple' should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "First match mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Second match mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 5, cleanup, "Empty prefix should return all matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Match 1 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "apply", cleanup, "Match 2 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[3], "ball", cleanup, "Match 3 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[4], "bat", cleanup, "Match 4 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "app", &matches, 2);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Max matches should limit results to 2");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "applet", cleanup, "Match 1 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "applet", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 1, cleanup, "Prefix search 'applet' should return exactly 1 match");
+   MCTF_ASSERT_STR_EQ(matches[0], "applet", cleanup, "Exact match mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   MCTF_ASSERT(!pgmoneta_art_delete(t, "applet"), cleanup, "Delete applet failed");
+   count = pgmoneta_art_prefix_search(t, "app", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix search 'app' after delete should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "apple", cleanup, "Match 0 mismatch after delete");
+   MCTF_ASSERT_STR_EQ(matches[1], "apply", cleanup, "Match 1 mismatch after delete");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(NULL, "app", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, -1, cleanup, "Prefix search with NULL tree should return -1");
+
+   count = pgmoneta_art_prefix_search(t, "app", NULL, 10);
+   MCTF_ASSERT_INT_EQ(count, -1, cleanup, "Prefix search with NULL matches pointer should return -1");
+
+   count = pgmoneta_art_prefix_search(t, "app", &matches, 0);
+   MCTF_ASSERT_INT_EQ(count, -1, cleanup, "Prefix search with 0 max_matches should return -1");
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgmoneta_art_destroy(t);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_art_prefix_search_nested)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgmoneta_test_setup();
+   pgmoneta_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "api.foo.bar", 1, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "api.foo.baz", 2, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "api.foe.fum", 3, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "abc.123.456", 4, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "api.foo", 5, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "api", 6, ValueInt32), cleanup, "Insert failed");
+
+   count = pgmoneta_art_prefix_search(t, "api", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 5, cleanup, "Prefix 'api' should return 5 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "api", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "api.foe.fum", cleanup, "Match 1 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "api.foo", cleanup, "Match 2 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[3], "api.foo.bar", cleanup, "Match 3 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[4], "api.foo.baz", cleanup, "Match 4 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "a", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 6, cleanup, "Prefix 'a' should return 6 matches");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "b", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 0, cleanup, "Prefix 'b' should return 0 matches");
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "api.", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 4, cleanup, "Prefix 'api.' should return 4 matches");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "api.foo.ba", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix 'api.foo.ba' should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "api.foo.bar", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "api.foo.baz", cleanup, "Match 1 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+   count = pgmoneta_art_prefix_search(t, "api.end", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 0, cleanup, "Prefix 'api.end' should return 0 matches");
+   free(matches);
+   matches = NULL;
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgmoneta_art_destroy(t);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_art_prefix_search_long_prefix)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgmoneta_test_setup();
+   pgmoneta_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "this:key:has:a:long:prefix:3", 3, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "this:key:has:a:long:common:prefix:2", 2, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "this:key:has:a:long:common:prefix:1", 1, ValueInt32), cleanup, "Insert failed");
+
+   count = pgmoneta_art_prefix_search(t, "this:key:has", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 3, cleanup, "Prefix 'this:key:has' should return 3 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "this:key:has:a:long:common:prefix:1", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "this:key:has:a:long:common:prefix:2", cleanup, "Match 1 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[2], "this:key:has:a:long:prefix:3", cleanup, "Match 2 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgmoneta_art_destroy(t);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_art_prefix_search_max_prefix_len)
+{
+   struct art* t = NULL;
+   char** matches = NULL;
+   int count = 0;
+
+   pgmoneta_test_setup();
+   pgmoneta_art_create(&t);
+   MCTF_ASSERT_PTR_NONNULL(t, cleanup, "ART creation failed");
+
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "foobarbaz1-test1-foo", 1, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "foobarbaz1-test1-bar", 2, ValueInt32), cleanup, "Insert failed");
+   MCTF_ASSERT(!pgmoneta_art_insert(t, "foobarbaz1-test2-foo", 3, ValueInt32), cleanup, "Insert failed");
+
+   count = pgmoneta_art_prefix_search(t, "foobarbaz1-test1", &matches, 10);
+   MCTF_ASSERT_INT_EQ(count, 2, cleanup, "Prefix 'foobarbaz1-test1' should return 2 matches");
+   MCTF_ASSERT_STR_EQ(matches[0], "foobarbaz1-test1-bar", cleanup, "Match 0 mismatch");
+   MCTF_ASSERT_STR_EQ(matches[1], "foobarbaz1-test1-foo", cleanup, "Match 1 mismatch");
+   for (int i = 0; i < count; i++)
+   {
+      free(matches[i]);
+   }
+   free(matches);
+   matches = NULL;
+
+cleanup:
+   if (matches)
+   {
+      for (int i = 0; i < count; i++)
+      {
+         free(matches[i]);
+      }
+      free(matches);
+   }
+   pgmoneta_art_destroy(t);
+   pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
 MCTF_TEST(test_art_insert_index_out_of_range)
 {
    struct art* t = NULL;


### PR DESCRIPTION
This PR adds comprehensive unit testing to the `pgmoneta_art_prefix_search` implementation.