### PR TITLE
#1082 Fix binary characters in log file when log_mode = create

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,3 +53,4 @@ Tarun Wadhwa <tarunwadhwa85@gmail.com>
 Pranav Prajapati <pranavprajapati586@gmail.com>
 Som Shegokar <akashshegokar2186@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
+Harshit Shaw <shawharshit116@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -60,6 +60,7 @@ Tarun Wadhwa <tarunwadhwa85@gmail.com>
 Pranav Prajapati <pranavprajapati586@gmail.com>
 Som Shegokar <akashshegokar2186@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
+Harshit Shaw <shawharshit116@gmail.com>
 ```
 
 ## Committers

--- a/src/libpgmoneta/logging.c
+++ b/src/libpgmoneta/logging.c
@@ -687,7 +687,7 @@ log_file_open(void)
          log_rotation_disable();
       }
 
-      log_file = fopen(current_log_path, config->log_mode == PGMONETA_LOGGING_MODE_APPEND ? "a" : "w");
+      log_file = fopen(current_log_path, (config->log_mode == PGMONETA_LOGGING_MODE_CREATE && log_file == NULL) ? "w" : "a");
 
       if (!log_file)
       {


### PR DESCRIPTION
When log_mode = create, log_file_open() used fopen(..., 'w') which truncates the file on every open. Child processes created via fork() (backup, WAL, retention, etc.) each call pgmoneta_start_logging(), causing repeated truncation and garbled/binary content in the log.

Fix: use 'w' only when log_mode = create AND log_file is NULL (first open by main process). Child processes inherit the file descriptor via fork and should always append.

Fixes #1082