### PR TITLE
Fix #632: free filepath in pgmoneta-admin main() to prevent memory leak

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -320,9 +320,13 @@ main(int argc, char** argv)
       }
    }
 
+   free(filepath);
+
    exit(0);
 
 error:
+
+   free(filepath);
 
    exit(1);
 }


### PR DESCRIPTION
## Problem
In `main()` of `pgmoneta-admin`, the `filepath` variable allocated 
by `cmd_parse()` was never freed before `exit(0)` or `exit(1)`, 
causing a memory leak detected by LeakSanitizer (ASAN).
## Fix
Added `free(filepath)` before both exit points in `main()`:
- Before `exit(0)` (success path)
- Before `exit(1)` (error path)
Fixes #632
