### PR TITLE
#922 docs: add management port to example configuration files

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -62,6 +62,41 @@ Commands:
   verify                   Verify a backup from a server
 ```
 
+## Configuration file
+
+The `-c` flag accepts a dedicated `pgmoneta_cli.conf` file — **not** the main `pgmoneta.conf` server configuration file.
+
+Passing `pgmoneta.conf` directly to `pgmoneta-cli` via `-c` will cause the CLI to read the PostgreSQL server port (`5432`) instead of the management port, and the connection will fail.
+
+To connect to a running pgmoneta instance, use one of the following methods:
+
+**Option 1: Use a dedicated CLI config file (`pgmoneta_cli.conf`)**
+
+```ini
+host = localhost
+port = 5001
+```
+
+Then run:
+
+```sh
+pgmoneta-cli -c pgmoneta_cli.conf status
+```
+
+**Option 2: Use `-h` and `-p` flags directly**
+
+```sh
+pgmoneta-cli -h localhost -p 5001 status
+```
+
+**Option 3: Use Unix Domain Socket (local only)**
+
+Set `unix_socket_dir` in `pgmoneta.conf` and run without any flags:
+
+```sh
+pgmoneta-cli status
+```
+
 ## backup
 
 Backup a server

--- a/doc/manual/en/05-cli.md
+++ b/doc/manual/en/05-cli.md
@@ -69,6 +69,41 @@ pgmoneta: https://pgmoneta.github.io/
 Report bugs: https://github.com/pgmoneta/pgmoneta/issues
 ```
 
+## Configuration file
+
+The `-c` flag accepts a dedicated `pgmoneta_cli.conf` file — **not** the main `pgmoneta.conf` server configuration file.
+
+Passing `pgmoneta.conf` directly to `pgmoneta-cli` via `-c` will cause the CLI to read the PostgreSQL server port (`5432`) instead of the management port, and the connection will fail.
+
+To connect to a running pgmoneta instance, use one of the following methods:
+
+**Option 1: Use a dedicated CLI config file (`pgmoneta_cli.conf`)**
+
+``` ini
+host = localhost
+port = 5001
+```
+
+Then run:
+
+``` sh
+pgmoneta-cli -c pgmoneta_cli.conf status
+```
+
+**Option 2: Use `-h` and `-p` flags directly**
+
+``` sh
+pgmoneta-cli -h localhost -p 5001 status
+```
+
+**Option 3: Use Unix Domain Socket (local only)**
+
+Set `unix_socket_dir` in `pgmoneta.conf` and run without any flags:
+
+``` sh
+pgmoneta-cli status
+```
+
 ## backup
 
 Backup a server

--- a/doc/manual/es/05-cli.md
+++ b/doc/manual/es/05-cli.md
@@ -69,6 +69,41 @@ pgmoneta: https://pgmoneta.github.io/
 Report bugs: https://github.com/pgmoneta/pgmoneta/issues
 ```
 
+## Archivo de configuración
+
+El flag `-c` acepta un archivo dedicado `pgmoneta_cli.conf` — **no** el archivo de configuración principal `pgmoneta.conf` del servidor.
+
+Pasar `pgmoneta.conf` directamente a `pgmoneta-cli` mediante `-c` hará que el CLI lea el puerto del servidor PostgreSQL (`5432`) en lugar del puerto de gestión, y la conexión fallará.
+
+Para conectarse a una instancia de pgmoneta en ejecución, usa uno de los siguientes métodos:
+
+**Opción 1: Usar un archivo de configuración CLI dedicado (`pgmoneta_cli.conf`)**
+
+``` ini
+host = localhost
+port = 5001
+```
+
+Luego ejecuta:
+
+``` sh
+pgmoneta-cli -c pgmoneta_cli.conf status
+```
+
+**Opción 2: Usar los flags `-h` y `-p` directamente**
+
+``` sh
+pgmoneta-cli -h localhost -p 5001 status
+```
+
+**Opción 3: Usar Unix Domain Socket (solo local)**
+
+Configura `unix_socket_dir` en `pgmoneta.conf` y ejecuta sin flags:
+
+``` sh
+pgmoneta-cli status
+```
+
 ## backup
 
 Hacer backup de un servidor

--- a/src/config.c
+++ b/src/config.c
@@ -280,6 +280,7 @@ config_init(const char* output_path, bool quiet, bool force)
    char base_dir[MAX_PATH];
    char unix_socket_dir[MISC_LENGTH];
    char metrics[MISC_LENGTH];
+   char management[MISC_LENGTH];
    char compression[MISC_LENGTH];
    char retention[MISC_LENGTH];
    char log_type[MISC_LENGTH];
@@ -325,6 +326,7 @@ config_init(const char* output_path, bool quiet, bool force)
       pgmoneta_snprintf(host, sizeof(host), "*");
       pgmoneta_snprintf(base_dir, sizeof(base_dir), "/tmp/pgmoneta/");
       pgmoneta_snprintf(unix_socket_dir, sizeof(unix_socket_dir), "/tmp/");
+      pgmoneta_snprintf(management, sizeof(management), "0");
       pgmoneta_snprintf(metrics, sizeof(metrics), "5001");
       pgmoneta_snprintf(compression, sizeof(compression), "zstd");
       pgmoneta_snprintf(retention, sizeof(retention), "7");
@@ -354,6 +356,11 @@ config_init(const char* output_path, bool quiet, bool force)
       if (prompt_input("Unix socket directory", "/tmp/", unix_socket_dir, sizeof(unix_socket_dir)))
       {
          warnx("Invalid input for unix_socket_dir");
+         goto error;
+      }
+      if (prompt_input("Management port (0 to disable)", "0", management, sizeof(management)))
+      {
+         warnx("Invalid input for management");
          goto error;
       }
 
@@ -405,7 +412,14 @@ config_init(const char* output_path, bool quiet, bool force)
    /* Write [pgmoneta] section */
    write_section(file, "pgmoneta");
    write_key_value(file, "host", host);
-   write_key_value(file, "metrics", metrics);
+   if (atoi(metrics) > 0)
+   {
+      write_key_value(file, "metrics", metrics);
+   }
+   if (atoi(management) > 0)
+   {
+      write_key_value(file, "management", management);
+   }
    fprintf(file, "\n");
    write_key_value(file, "base_dir", base_dir);
    fprintf(file, "\n");


### PR DESCRIPTION
Add missing management = 0 to all example pgmoneta.conf snippets in documentation. Without this key, users passing pgmoneta.conf via -c flag to pgmoneta-cli would not have the management port set, causing connection failures.

Fixes #922