### PR TITLE
[#1136] support postgres-19

### DIFF
--- a/doc/TEST.md
+++ b/doc/TEST.md
@@ -350,6 +350,6 @@ cleanup:
 ```
 and replace `pgmoneta_test_generate_check_point_shutdown_v17` with the function you implemented in step 1.
 
-If the record type you are adding has differences between versions of PostgreSQL (13-17), you will need to implement a generate function per version (`generate_rec_x` -> `generate_rec_x_v16`, `generate_rec_x_v17`, etc.).
+If the record type you are adding has differences between versions of PostgreSQL (13-19), you will need to implement a generate function per version (`generate_rec_x` -> `generate_rec_x_v16`, `generate_rec_x_v17`, etc.).
 
 For the sake of simplicity, please create one test suite per postgres version where the implementation resides in `test/libpgmonetatest/tswalutils/tswalutils_<version>.c` and the testcases in `test/testcases/test_wal_utils.c` and add testcase per record type within this version. You can take a look at [this testcase](../../../test/testcases/test_wal_utils.c) for reference.

--- a/doc/manual/en/76-test.md
+++ b/doc/manual/en/76-test.md
@@ -346,6 +346,6 @@ cleanup:
 ```
 and replace `pgmoneta_test_generate_check_point_shutdown_v17` with the function you implemented in step 1.
 
-If the record type you are adding has differences between versions of PostgreSQL (13-17), you will need to implement a generate function per version (`generate_rec_x` -> `generate_rec_x_v16`, `generate_rec_x_v17`, etc.).
+If the record type you are adding has differences between versions of PostgreSQL (13-19), you will need to implement a generate function per version (`generate_rec_x` -> `generate_rec_x_v16`, `generate_rec_x_v17`, etc.).
 
 For the sake of simplicity, please create one test suite per postgres version where the implementation resides in `test/libpgmonetatest/tswalutils/tswalutils_<version>.c` and the testcases in `test/testcases/test_wal_utils.c` and add testcase per record type within this version. You can take a look at [this testcase](../../../../../test/testcases/test_wal_utils.c) for reference.

--- a/doc/manual/en/78-wal.md
+++ b/doc/manual/en/78-wal.md
@@ -399,9 +399,11 @@ In the `rmgr.h` header file, the resource managers are declared as an enum, with
 
 Each resource manager implements the `rm_desc` function, which provides a description of the record type associated with that resource manager. In the future, they will be extended to implement the `rm_redo` function to apply the changes to another server.
 
-**Supporting Various WAL Structures in PostgreSQL Versions 13 to 17**
+**Supporting Various WAL Structures in PostgreSQL Versions 13 to 19**
 
-The WAL structure has evolved across PostgreSQL versions 13 to 17, requiring different handling for each version. To accommodate these differences, we have implemented a wrapper-based approach, such as the factory pattern, to handle varying WAL structures.
+The WAL structure has evolved across PostgreSQL versions 13 to 19, requiring different handling for each version. To accommodate these differences, we have implemented a wrapper-based approach, such as the factory pattern, to handle varying WAL structures.
+
+**PostgreSQL 19 support**: pgmoneta supports the official PostgreSQL 19 WAL format, identified by magic `0xD121`. Development-only PostgreSQL 19 WAL magic values are not supported.
 
 Below are the commit hashes for the officially supported magic values in each PostgreSQL version:
 
@@ -411,6 +413,7 @@ Below are the commit hashes for the officially supported magic values in each Po
 4. PostgreSQL 16 - [0xD113][D113]
 5. PostgreSQL 17 - [0xD116][D116]
 6. PostgreSQL 18 - [0xD118][D118]
+7. PostgreSQL 19 - [0xD121][D121]
 
 
 `xl_end_of_recovery` is an example of how we handle different versions of structures with a wrapper struct and a factory pattern.
@@ -1066,6 +1069,24 @@ typedef struct xl_xact_parsed_commit
 	TimestampTz origin_timestamp;
 } xl_xact_parsed_commit;
 ```
+
+**xl_running_xacts**
+
+PostgreSQL 19's official `0xD121` WAL format uses the same running-transactions record layout as PostgreSQL 18:
+
+```c
+struct xl_running_xacts_v18 {
+   int xcnt;                                   /* Number of transaction IDs in xids[] */
+   int subxcnt;                                /* Number of subtransaction IDs in xids[] */
+   bool subxid_overflow;                       /* Indicates if snapshot overflowed and subxids are missing */
+   transaction_id next_xid;                    /* Next transaction ID from TransamVariables->next_xid */
+   transaction_id oldest_running_xid;          /* Oldest running transaction ID (not oldestXmin) */
+   transaction_id latest_completed_xid;        /* Latest completed transaction ID to set xmax */
+   transaction_id xids[FLEXIBLE_ARRAY_MEMBER]; /* Array of transaction IDs */
+};
+```
+
+The D121 heap WAL updates can register visibility-map blocks in addition to heap blocks. pgmoneta handles these through its generic registered-block decoding and WAL-summary paths.
 
 **xl_xact_parsed_abort**
 

--- a/doc/manual/en/99-references.md
+++ b/doc/manual/en/99-references.md
@@ -55,6 +55,7 @@
 [D113]: https://github.com/postgres/postgres/commit/6af1793954e8c5e753af83c3edb37ed3267dd179
 [D116]: https://github.com/postgres/postgres/commit/402b586d0a9caae9412d25fcf1b91dae45375833
 [D118]: https://github.com/postgres/postgres/commit/243e9b40f1b2dd09d6e5bf91ebf6e822a2cd3704
+[D121]: https://github.com/postgres/postgres/commit/b01c31eef9c3a83d0bd9f30656cedaa6722890ee
 
 [cmake_txt]: https://github.com/pgmoneta/pgmoneta/blob/main/CMakeLists.txt
 [src/cmake_txt]: https://github.com/pgmoneta/pgmoneta/blob/main/src/CMakeLists.txt

--- a/src/include/walfile/rm_heap.h
+++ b/src/include/walfile/rm_heap.h
@@ -144,6 +144,7 @@ typedef uint32_t command_id;
 #define XLH_TRUNCATE_RESTART_SEQS (1 << 1)
 
 #define SizeOfHeapPruneV17        (offsetof(struct xl_heap_prune_v17, flags) + sizeof(uint8_t))
+#define SizeOfHeapPruneV19        (offsetof(struct xl_heap_prune_v19, flags) + sizeof(uint16_t))
 
 // Struct definitions
 /**
@@ -253,6 +254,20 @@ struct xl_heap_prune_v17
 };
 
 /**
+ * @struct xl_heap_prune_v19
+ * @brief Represents a prune operation in the heap (PostgreSQL 19).
+ *
+ * From PostgreSQL 19 (WAL magic >= 0xD119), the main xl_heap_prune record
+ * contains a 16-bit flags field (no "reason" byte). If XLHP_HAS_CONFLICT_HORIZON
+ * is set, snapshot_conflict_horizon follows immediately after flags, unaligned.
+ */
+struct xl_heap_prune_v19
+{
+   uint16_t flags; /**< Flags for prune/freeze/vacuum cleanup record. */
+   /* If XLHP_HAS_CONFLICT_HORIZON is set, the conflict horizon XID follows, unaligned */
+};
+
+/**
  * @struct xl_heap_prune_v16
  * @brief Represents a prune operation in the heap (version 16).
  *
@@ -322,6 +337,7 @@ struct xl_heap_prune
    char* (*format)(struct xl_heap_prune* wrapper, char* buf); /**< Function pointer to format the record */
    union
    {
+      struct xl_heap_prune_v19 v19; /**< Prune operation for version 19 */
       struct xl_heap_prune_v17 v17; /**< Prune operation for version 17 */
       struct xl_heap_prune_v16 v16; /**< Prune operation for version 16 */
       struct xl_heap_prune_v15 v15; /**< Prune operation for version 15 */
@@ -504,6 +520,7 @@ struct xl_heap_prune* create_xl_heap_prune(void);
  * @param rec The record to parse.
  */
 void xl_heap_prune_parse_v17(struct xl_heap_prune* wrapper, void* rec);
+void xl_heap_prune_parse_v19(struct xl_heap_prune* wrapper, void* rec);
 
 /**
  * @brief Parses a version 16 prune record.
@@ -545,6 +562,7 @@ void xl_heap_prune_parse_v13(struct xl_heap_prune* wrapper, void* rec);
  * @return A pointer to the formatted string.
  */
 char* xl_heap_prune_format_v17(struct xl_heap_prune* wrapper, char* buf);
+char* xl_heap_prune_format_v19(struct xl_heap_prune* wrapper, char* buf);
 
 /**
  * @brief Formats a version 16 prune record.
@@ -615,7 +633,7 @@ char* pgmoneta_wal_heap2_desc(char* buf, struct decoded_xlog_record* record);
  * @param nunused Pointer to store the number of unused items.
  * @param nowunused Pointer to store the unused items array.
  */
-void heap_xlog_deserialize_prune_and_freeze(char* cursor, uint8_t flags,
+void heap_xlog_deserialize_prune_and_freeze(char* cursor, uint16_t flags,
                                             int* nplans, struct xlhp_freeze_plan** plans,
                                             offset_number** frz_offsets,
                                             int* nredirected, offset_number** redirected,

--- a/src/include/walfile/rm_standby.h
+++ b/src/include/walfile/rm_standby.h
@@ -70,14 +70,14 @@ struct xl_standby_locks
 };
 
 /**
- * @struct xl_running_xacts
- * @brief Represents running transactions data in XLOG.
+ * @struct xl_running_xacts_v18
+ * @brief Represents running transactions data in XLOG for PostgreSQL 18 and earlier.
  *
  * Contains information about currently running transactions,
  * including the next transaction ID, the oldest running transaction ID,
  * and the latest completed transaction ID.
  */
-struct xl_running_xacts
+struct xl_running_xacts_v18
 {
    int xcnt;                                   /**< Number of transaction IDs in xids[]. */
    int subxcnt;                                /**< Number of subtransaction IDs in xids[]. */
@@ -86,6 +86,22 @@ struct xl_running_xacts
    transaction_id oldest_running_xid;          /**< Oldest running transaction ID (not oldestXmin). */
    transaction_id latest_completed_xid;        /**< Latest completed transaction ID to set xmax. */
    transaction_id xids[FLEXIBLE_ARRAY_MEMBER]; /**< Array of transaction IDs. */
+};
+
+/**
+ * @struct xl_running_xacts
+ * @brief Wrapper structure to handle different versions of running transactions data.
+ *
+ * Fields:
+ * - data: Running transactions data.
+ * - parse: Function pointer to parse the record.
+ * - format: Function pointer to format the record.
+ */
+struct xl_running_xacts
+{
+   void (*parse)(struct xl_running_xacts* wrapper, void* rec);   /**< Function pointer to parse the record */
+   char* (*format)(struct xl_running_xacts* wrapper, char* buf); /**< Function pointer to format the record */
+   struct xl_running_xacts_v18 data;                             /**< Running transactions data */
 };
 
 /**
@@ -129,6 +145,33 @@ pgmoneta_wal_standby_desc(char* buf, struct decoded_xlog_record* record);
 char*
 pgmoneta_wal_standby_desc_invalidations(char* buf, int nmsgs, union shared_invalidation_message* msgs, oid dbId, oid tsId,
                                         bool rel_cache_init_file_inval);
+
+/**
+ * @brief Creates a new xl_running_xacts structure.
+ *
+ * @return A pointer to the newly created xl_running_xacts structure.
+ */
+struct xl_running_xacts*
+create_xl_running_xacts(void);
+
+/**
+ * @brief Parses a version 18 running transactions record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param rec The record to parse.
+ */
+void
+xl_running_xacts_parse_v18(struct xl_running_xacts* wrapper, void* rec);
+
+/**
+ * @brief Formats a version 18 running transactions record.
+ *
+ * @param wrapper The wrapper structure containing the record data.
+ * @param buf The buffer to store the formatted string.
+ * @return A pointer to the formatted string.
+ */
+char*
+xl_running_xacts_format_v18(struct xl_running_xacts* wrapper, char* buf);
 
 #ifdef __cplusplus
 }

--- a/src/include/walfile/rm_xlog.h
+++ b/src/include/walfile/rm_xlog.h
@@ -40,6 +40,13 @@
 #define INTpgmoneta_wal_64CONST(x) (x##L)
 #define USECS_PER_SEC              INTpgmoneta_wal_64CONST(1000000)
 
+/*
+ * PostgreSQL 19:
+ * XLOG_GIST_ASSIGN_LSN (RM_GIST_ID, 0x70) was replaced by XLOG_ASSIGN_LSN
+ * (RM_XLOG_ID, 0xC0).
+ */
+#define XLOG_ASSIGN_LSN 0xC0
+
 /**
  * @struct xl_parameter_change
  * @brief Structure representing a change in parameters important for Hot Standby.

--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -59,12 +59,21 @@ typedef oid rel_file_number;
 typedef int64_t timestamp_tz;
 
 /* #define variables */
-#define MAXIMUM_ALIGNOF           8 // TODO: double check this value
-#define ALIGNOF_SHORT             2 // TODO: double check this value
-#define InvalidXLogRecPtr         0
-#define InvalidBlockNumber        ((uint32_t)0xFFFFFFFF)
-#define InvalidBuffer             0
-#define XLOG_PAGE_MAGIC           0xD10D // WAL version indicator
+#define MAXIMUM_ALIGNOF    8 // TODO: double check this value
+#define ALIGNOF_SHORT      2 // TODO: double check this value
+#define InvalidXLogRecPtr  0
+#define InvalidBlockNumber ((uint32_t)0xFFFFFFFF)
+#define InvalidBuffer      0
+#define XLOG_PAGE_MAGIC    WAL_MAGIC_V14 /**< WAL version indicator */
+
+/* WAL Magic Numbers */
+#define WAL_MAGIC_V13             0xD106 /**< PostgreSQL 13 WAL magic number */
+#define WAL_MAGIC_V14             0xD10D /**< PostgreSQL 14 WAL magic number */
+#define WAL_MAGIC_V15             0xD110 /**< PostgreSQL 15 WAL magic number */
+#define WAL_MAGIC_V16             0xD113 /**< PostgreSQL 16 WAL magic number */
+#define WAL_MAGIC_V17             0xD116 /**< PostgreSQL 17 WAL magic number */
+#define WAL_MAGIC_V18             0xD118 /**< PostgreSQL 18 WAL magic number */
+#define WAL_MAGIC_V19             0xD121 /**< PostgreSQL 19 WAL magic number */
 #define InvalidOid                ((oid)0)
 #define FLEXIBLE_ARRAY_MEMBER     /* empty */
 #define INVALID_REP_ORIGIN_ID     0
@@ -103,14 +112,11 @@ typedef int64_t timestamp_tz;
 /* This flag indicates a "long" page header */
 #define XLP_LONG_HEADER 0x0002
 
-/* This flag indicates backup blocks starting in this page are optional */
-#define XLP_BKP_REMOVABLE 0x0004
-
 /* Replaces a missing contrecord; see CreateOverwriteContrecordRecord */
-#define XLP_FIRST_IS_OVERWRITE_CONTRECORD 0x0008
+#define XLP_FIRST_IS_OVERWRITE_CONTRECORD 0x0004
 
 /* All defined flag bits in xlp_info (used for validity checking of header) */
-#define XLP_ALL_FLAGS 0x000F
+#define XLP_ALL_FLAGS 0x0007
 
 #define XLogRecHasBlockRef(record, block_id) \
    ((record->max_block_id >= (block_id)) &&  \
@@ -431,6 +437,14 @@ struct xid_timestamp_map
 
 /* External variables */
 extern struct server* server_config;
+
+/**
+ * Track the WAL magic value currently being displayed/decoded.
+ * This is used for version-gated decode/format logic in RMGR descriptions,
+ * especially for intra-major WAL format bumps like PostgreSQL 19.
+ */
+void pgmoneta_wal_set_current_magic(uint16_t magic_value);
+uint16_t pgmoneta_wal_get_current_magic(void);
 
 /* Function definitions */
 

--- a/src/libpgmoneta/walfile/rm_gist.c
+++ b/src/libpgmoneta/walfile/rm_gist.c
@@ -29,6 +29,7 @@
 #include <walfile/rm.h>
 #include <walfile/rm_gist.h>
 #include <walfile/transaction.h>
+#include <walfile/wal_reader.h>
 #include <utils.h>
 #include <wal.h>
 

--- a/src/libpgmoneta/walfile/rm_heap.c
+++ b/src/libpgmoneta/walfile/rm_heap.c
@@ -225,13 +225,78 @@ pgmoneta_wal_heap2_desc(char* buf, struct decoded_xlog_record* record)
 {
    char* rec = record->main_data;
    uint8_t info = record->header.xl_info & ~XLR_INFO_MASK;
+   uint16_t magic_value = pgmoneta_wal_get_current_magic();
    char* dbname = NULL;
    char* relname = NULL;
    char* spcname = NULL;
 
    info &= XLOG_HEAP_OPMASK;
 
-   if ((server_config->version >= 17) && (info == XLOG_HEAP2_PRUNE_ON_ACCESS || info == XLOG_HEAP2_PRUNE_VACUUM_SCAN || info == XLOG_HEAP2_PRUNE_VACUUM_CLEANUP))
+   if ((server_config->version >= 19) && (info == XLOG_HEAP2_PRUNE_ON_ACCESS || info == XLOG_HEAP2_PRUNE_VACUUM_SCAN || info == XLOG_HEAP2_PRUNE_VACUUM_CLEANUP))
+   {
+      struct xl_heap_prune_v19* xlrec = (struct xl_heap_prune_v19*)rec;
+
+      if (xlrec->flags & XLHP_HAS_CONFLICT_HORIZON)
+      {
+         transaction_id conflict_xid;
+
+         memcpy(&conflict_xid, rec + SizeOfHeapPruneV19, sizeof(transaction_id));
+
+         buf = pgmoneta_format_and_append(buf, "snapshot_conflict_horizon_id: %u", conflict_xid);
+      }
+
+      buf = pgmoneta_format_and_append(buf, ", is_catalog_rel: %c", xlrec->flags & XLHP_IS_CATALOG_REL ? 'T' : 'F');
+
+      if (XLogRecHasBlockData(record, 0))
+      {
+         offset_number* redirected;
+         offset_number* nowdead;
+         offset_number* nowunused;
+         int nredirected;
+         int nunused;
+         int ndead;
+         int nplans;
+         struct xlhp_freeze_plan* plans;
+         offset_number* frz_offsets;
+
+         struct decoded_bkp_block bkpb = record->blocks[0];
+         char* cursor = bkpb.data;
+
+         heap_xlog_deserialize_prune_and_freeze(cursor, xlrec->flags,
+                                                &nplans, &plans, &frz_offsets,
+                                                &nredirected, &redirected,
+                                                &ndead, &nowdead,
+                                                &nunused, &nowunused);
+
+         buf = pgmoneta_format_and_append(buf, ", nplans: %u, nredirected: %u, ndead: %u, nunused: %u",
+                                          nplans, nredirected, ndead, nunused);
+
+         if (nplans > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", plans:");
+            buf = pgmoneta_wal_array_desc(buf, plans, sizeof(struct xlhp_freeze_plan), nplans);
+         }
+
+         if (nredirected > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", redirected:");
+            buf = pgmoneta_wal_array_desc(buf, redirected, sizeof(offset_number) * 2, nredirected);
+         }
+
+         if (ndead > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", dead:");
+            buf = pgmoneta_wal_array_desc(buf, nowdead, sizeof(offset_number), ndead);
+         }
+
+         if (nunused > 0)
+         {
+            buf = pgmoneta_format_and_append(buf, ", unused:");
+            buf = pgmoneta_wal_array_desc(buf, nowunused, sizeof(offset_number), nunused);
+         }
+      }
+   }
+   else if ((server_config->version >= 17) && (info == XLOG_HEAP2_PRUNE_ON_ACCESS || info == XLOG_HEAP2_PRUNE_VACUUM_SCAN || info == XLOG_HEAP2_PRUNE_VACUUM_CLEANUP))
    {
       struct xl_heap_prune_v17* xlrec = (struct xl_heap_prune_v17*)rec;
 
@@ -319,10 +384,13 @@ pgmoneta_wal_heap2_desc(char* buf, struct decoded_xlog_record* record)
    }
    else if (info == XLOG_HEAP2_VISIBLE)
    {
-      struct xl_heap_visible* xlrec = (struct xl_heap_visible*)rec;
+      if (magic_value < WAL_MAGIC_V19)
+      {
+         struct xl_heap_visible* xlrec = (struct xl_heap_visible*)rec;
 
-      buf = pgmoneta_format_and_append(buf, "cutoff xid %u flags 0x%02X",
-                                       xlrec->cutoff_xid, xlrec->flags);
+         buf = pgmoneta_format_and_append(buf, "cutoff xid %u flags 0x%02X",
+                                          xlrec->cutoff_xid, xlrec->flags);
+      }
    }
    else if (info == XLOG_HEAP2_MULTI_INSERT)
    {
@@ -380,7 +448,7 @@ error:
    return NULL;
 }
 void
-heap_xlog_deserialize_prune_and_freeze(char* cursor, uint8_t flags,
+heap_xlog_deserialize_prune_and_freeze(char* cursor, uint16_t flags,
                                        int* nplans, struct xlhp_freeze_plan** plans,
                                        offset_number** frz_offsets,
                                        int* nredirected, offset_number** redirected,

--- a/src/libpgmoneta/walfile/rm_standby.c
+++ b/src/libpgmoneta/walfile/rm_standby.c
@@ -28,39 +28,42 @@
 
 #include <wal.h>
 #include <walfile/rm_standby.h>
+#include <walfile/wal_reader.h>
 #include <utils.h>
 
-static char*
-standby_desc_running_xacts(char* buf, struct xl_running_xacts* xlrec)
+/* system */
+#include <stdlib.h>
+#include <string.h>
+
+struct xl_running_xacts*
+create_xl_running_xacts(void)
 {
-   int i;
+   struct xl_running_xacts* wrapper = malloc(sizeof(struct xl_running_xacts));
+
+   wrapper->parse = xl_running_xacts_parse_v18;
+   wrapper->format = xl_running_xacts_format_v18;
+
+   return wrapper;
+}
+
+void
+xl_running_xacts_parse_v18(struct xl_running_xacts* wrapper, void* rec)
+{
+   struct xl_running_xacts_v18* xlrec_v18 = &wrapper->data;
+
+   /* Parse PostgreSQL 18 structure without dbid field */
+   memcpy(xlrec_v18, rec, sizeof(struct xl_running_xacts_v18));
+}
+
+char*
+xl_running_xacts_format_v18(struct xl_running_xacts* wrapper, char* buf)
+{
+   struct xl_running_xacts_v18* xlrec_v18 = &wrapper->data;
 
    buf = pgmoneta_format_and_append(buf, "next_xid %u latest_completed_xid %u oldest_running_xid %u",
-                                    xlrec->next_xid,
-                                    xlrec->latest_completed_xid,
-                                    xlrec->oldest_running_xid);
-   if (xlrec->xcnt > 0)
-   {
-      buf = pgmoneta_format_and_append(buf, "; %d xacts:", xlrec->xcnt);
-      for (i = 0; i < xlrec->xcnt; i++)
-      {
-         buf = pgmoneta_format_and_append(buf, " %u", xlrec->xids[i]);
-      }
-   }
-
-   if (xlrec->subxid_overflow)
-   {
-      buf = pgmoneta_format_and_append(buf, "; subxid overflowed");
-   }
-
-   if (xlrec->subxcnt > 0)
-   {
-      buf = pgmoneta_format_and_append(buf, "; %d subxacts:", xlrec->subxcnt);
-      for (i = 0; i < xlrec->subxcnt; i++)
-      {
-         buf = pgmoneta_format_and_append(buf, " %u", xlrec->xids[xlrec->xcnt + i]);
-      }
-   }
+                                    xlrec_v18->next_xid,
+                                    xlrec_v18->latest_completed_xid,
+                                    xlrec_v18->oldest_running_xid);
    return buf;
 }
 
@@ -163,9 +166,15 @@ pgmoneta_wal_standby_desc(char* buf, struct decoded_xlog_record* record)
    }
    else if (info == XLOG_RUNNING_XACTS)
    {
-      struct xl_running_xacts* xlrec = (struct xl_running_xacts*)rec;
+      struct xl_running_xacts* wrapper = create_xl_running_xacts();
 
-      buf = standby_desc_running_xacts(buf, xlrec);
+      /* Parse the record based on version */
+      wrapper->parse(wrapper, rec);
+
+      /* Format the record */
+      buf = wrapper->format(wrapper, buf);
+
+      free(wrapper);
    }
    else if (info == XLOG_INVALIDATIONS)
    {

--- a/src/libpgmoneta/walfile/rm_xlog.c
+++ b/src/libpgmoneta/walfile/rm_xlog.c
@@ -316,7 +316,7 @@ pgmoneta_wal_xlog_desc(char* buf, struct decoded_xlog_record* record)
 
       buf = pgmoneta_format_and_append(buf, xlrec->rp_name);
    }
-   else if (info == XLOG_FPI || info == XLOG_FPI_FOR_HINT)
+   else if (info == XLOG_FPI || info == XLOG_FPI_FOR_HINT || info == XLOG_ASSIGN_LSN)
    {
       /* no further information to print */
    }

--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -52,6 +52,19 @@
 #include <string.h>
 
 struct server* server_config;
+static uint16_t current_wal_magic = 0;
+
+void
+pgmoneta_wal_set_current_magic(uint16_t magic_value)
+{
+   current_wal_magic = magic_value;
+}
+
+uint16_t
+pgmoneta_wal_get_current_magic(void)
+{
+   return current_wal_magic;
+}
 
 static int decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlog_record* record, uint32_t block_size, uint16_t magic_value, xlog_rec_ptr lsn);
 static void record_json(struct decoded_xlog_record* record, uint8_t magic_value, struct xid_timestamp_map* xid_ts_map, struct value** value);
@@ -93,18 +106,20 @@ magic_value_to_postgres_version(uint16_t magic_value)
 {
    switch (magic_value)
    {
-      case 0xD106:
+      case WAL_MAGIC_V13:
          return 13;
-      case 0xD10D:
+      case WAL_MAGIC_V14:
          return 14;
-      case 0xD110:
+      case WAL_MAGIC_V15:
          return 15;
-      case 0xD113:
+      case WAL_MAGIC_V16:
          return 16;
-      case 0xD116:
+      case WAL_MAGIC_V17:
          return 17;
-      case 0xD118:
+      case WAL_MAGIC_V18:
          return 18;
+      case WAL_MAGIC_V19:
+         return 19;
       default:
          return -1;
    }
@@ -1558,6 +1573,7 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
          backup_str[0] = '\0';
       }
 
+      pgmoneta_wal_set_current_magic(magic_value);
       rm_desc = rmgr_table[record->header.xl_rmid].rm_desc(rm_desc, record);
       backup_str = get_record_block_ref_info(backup_str, record, false, true, &fpi_len, magic_value);
       char* record_desc = pgmoneta_format_and_append(NULL, "%s %s", rm_desc, backup_str);

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -6062,6 +6062,11 @@ describe_walfile_internal(char* path, enum value_type type, FILE* out, bool quie
    to = pgmoneta_append(to, "/tmp/");
    to = pgmoneta_append(to, basename(path));
 
+   if (pgmoneta_exists(to))
+   {
+      pgmoneta_delete_file(to, NULL);
+   }
+
    if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, NULL, &to))
    {
       pgmoneta_log_error("Failed to extract WAL file from %s to %s", from, to);

--- a/test/include/tswalutils.h
+++ b/test/include/tswalutils.h
@@ -100,3 +100,20 @@ pgmoneta_test_generate_check_point_shutdown_v17(void);
  */
 struct walfile*
 pgmoneta_test_generate_mixed_heap_wal_v17(void);
+
+/**
+ * Generate a PostgreSQL 19 WAL file with CHECKPOINT_SHUTDOWN record.
+ * Uses the official PostgreSQL 19 WAL magic number (0xD121) and XLP flags.
+ * @return The generated walfile, or NULL on failure
+ */
+struct walfile*
+pgmoneta_test_generate_check_point_shutdown_v19(void);
+
+/**
+ * Generate a PostgreSQL 19 WAL file with 3 records: CHECKPOINT_SHUTDOWN, HEAP INSERT, HEAP DELETE.
+ * The INSERT has XID 100, the DELETE has XID 200.
+ * Uses the official PostgreSQL 19 WAL magic number (0xD121) and XLP flags.
+ * @return The generated walfile, or NULL on failure
+ */
+struct walfile*
+pgmoneta_test_generate_mixed_heap_wal_v19(void);

--- a/test/libpgmonetatest/tswalutils/tswalutils_19.c
+++ b/test/libpgmonetatest/tswalutils/tswalutils_19.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* pgmoneta */
+#include <pgmoneta.h>
+#include <configuration.h>
+#include <deque.h>
+#include <walfile/pg_control.h>
+#include <walfile/rm_heap.h>
+#include <walfile/rmgr.h>
+#include <utils.h>
+#include <value.h>
+#include <tsclient.h>
+#include <walfile.h>
+#include <tswalutils.h>
+
+/* system */
+#include <err.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+
+/* PostgreSQL 19 specific values */
+#define RANDOM_MAGIC_19 0xD121 /* Official PostgreSQL 19 WAL magic number */
+#define RANDOM_INFO_19  0x0007 /* XLP_ALL_FLAGS for PG19 (no BKP_REMOVABLE) */
+
+static struct decoded_xlog_record*
+create_record(uint8_t rmid, uint8_t info, transaction_id xid,
+              void* main_data_src, uint32_t main_data_len)
+{
+   struct decoded_xlog_record* rec = NULL;
+   uint32_t total_length = 0;
+
+   rec = (struct decoded_xlog_record*)malloc(sizeof(struct decoded_xlog_record));
+   if (rec == NULL)
+   {
+      goto error;
+   }
+
+   memset(rec, 0, sizeof(struct decoded_xlog_record));
+
+   rec->main_data_len = main_data_len;
+   rec->max_block_id = RANDOM_MAX_BLOCK_ID;
+   rec->oversized = RANDOM_OVERSIZED;
+   rec->record_origin = RANDOM_RECORD_ORIGIN;
+   rec->toplevel_xid = RANDOM_TOPLEVEL_XID;
+   rec->partial = RANDOM_PARTIAL;
+
+   total_length = sizeof(struct xlog_record);
+
+   if (rec->record_origin != INVALID_REP_ORIGIN_ID)
+   {
+      total_length += sizeof(uint8_t);
+      total_length += sizeof(rep_origin_id);
+   }
+
+   if (rec->toplevel_xid != INVALID_TRANSACTION_ID)
+   {
+      total_length += sizeof(uint8_t);
+      total_length += sizeof(transaction_id);
+   }
+
+   if (rec->main_data_len > 0)
+   {
+      total_length += sizeof(uint8_t);
+      if (rec->main_data_len <= UINT8_MAX)
+      {
+         total_length += sizeof(uint8_t);
+      }
+      else
+      {
+         total_length += sizeof(uint32_t);
+      }
+      total_length += rec->main_data_len;
+   }
+
+   rec->header.xl_tot_len = total_length;
+   rec->header.xl_xid = xid;
+   rec->header.xl_prev = 0;
+   rec->header.xl_info = info;
+   rec->header.xl_rmid = rmid;
+   rec->header.xl_crc = 0;
+   rec->size = rec->header.xl_tot_len;
+
+   for (int i = 0; i < XLR_MAX_BLOCK_ID + 1; i++)
+   {
+      rec->blocks[i].in_use = false;
+      rec->blocks[i].bimg_len = 0;
+      rec->blocks[i].data_len = 0;
+      rec->blocks[i].bkp_image = NULL;
+      rec->blocks[i].data = NULL;
+   }
+
+   if (main_data_len > 0 && main_data_src != NULL)
+   {
+      rec->main_data = (char*)malloc(main_data_len);
+      if (rec->main_data == NULL)
+      {
+         goto error;
+      }
+      memcpy(rec->main_data, main_data_src, main_data_len);
+   }
+
+   return rec;
+
+error:
+   if (rec != NULL)
+   {
+      free(rec->main_data);
+      free(rec);
+   }
+
+   return NULL;
+}
+
+static struct walfile*
+create_walfile_shell(void)
+{
+   struct walfile* wf = NULL;
+
+   wf = (struct walfile*)malloc(sizeof(struct walfile));
+   if (wf == NULL)
+   {
+      goto error;
+   }
+
+   memset(wf, 0, sizeof(struct walfile));
+
+   wf->long_phd = (struct xlog_long_page_header_data*)malloc(sizeof(struct xlog_long_page_header_data));
+   if (wf->long_phd == NULL)
+   {
+      goto error;
+   }
+
+   memset(wf->long_phd, 0, sizeof(struct xlog_long_page_header_data));
+   wf->long_phd->std.xlp_pageaddr = RANDOM_PAGEADDR;
+   wf->long_phd->std.xlp_magic = RANDOM_MAGIC_19; /* PG19 magic */
+   wf->long_phd->std.xlp_info = RANDOM_INFO_19;   /* PG19 flags */
+   wf->long_phd->std.xlp_tli = RANDOM_TLI;
+   wf->long_phd->xlp_seg_size = RANDOM_SEG_SIZE;
+   wf->long_phd->xlp_xlog_blcksz = RANDOM_XLOG_BLCKSZ;
+   wf->long_phd->std.xlp_rem_len = RANDOM_REMLEN;
+
+   if (pgmoneta_deque_create(false, &wf->page_headers))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_deque_create(false, &wf->records))
+   {
+      goto error;
+   }
+
+   return wf;
+
+error:
+   if (wf != NULL)
+   {
+      pgmoneta_deque_destroy(wf->records);
+      pgmoneta_deque_destroy(wf->page_headers);
+      free(wf->long_phd);
+      free(wf);
+   }
+
+   return NULL;
+}
+
+struct walfile*
+pgmoneta_test_generate_check_point_shutdown_v19(void)
+{
+   struct walfile* wf = NULL;
+   struct decoded_xlog_record* rec = NULL;
+
+   /* PostgreSQL 19 uses the same checkpoint structure as v17 */
+   struct check_point_v17 cp;
+   memset(&cp, 0, sizeof(cp));
+
+   cp.redo = RANDOM_REDO;
+   cp.this_timeline_id = RANDOM_THIS_TLI;
+   cp.prev_timeline_id = RANDOM_PREV_TLI;
+   cp.full_page_writes = RANDOM_FULL_PAGE_WRITES;
+   cp.wal_level = RANDOM_WAL_LEVEL;
+   cp.next_xid.value = RANDOM_NEXT_XID;
+   cp.next_oid = RANDOM_NEXT_OID;
+   cp.next_multi = RANDOM_NEXT_MULTI;
+   cp.next_multi_offset = RANDOM_NEXT_MULTI_OFFSET;
+   cp.oldest_xid = RANDOM_OLDEST_XID;
+   cp.oldest_xid_db = RANDOM_OLDEST_XID_DB;
+   cp.oldest_multi = RANDOM_OLDEST_MULTI;
+   cp.oldest_multi_db = RANDOM_OLDEST_MULTI_DB;
+   cp.time = RANDOM_TIME;
+   cp.oldest_commit_ts_xid = RANDOM_OLDEST_COMMIT_TS_XID;
+   cp.newest_commit_ts_xid = RANDOM_NEWEST_COMMIT_TS_XID;
+   cp.oldest_active_xid = RANDOM_OLDEST_ACTIVE_XID;
+
+   wf = create_walfile_shell();
+   if (wf == NULL)
+   {
+      goto error;
+   }
+
+   rec = create_record(RM_XLOG_ID, XLOG_CHECKPOINT_SHUTDOWN, 0,
+                       &cp, sizeof(cp));
+   if (rec == NULL)
+   {
+      goto error;
+   }
+
+   if (pgmoneta_deque_add(wf->records, NULL, (uintptr_t)rec, ValueRef))
+   {
+      goto error;
+   }
+
+   return wf;
+
+error:
+   if (rec != NULL)
+   {
+      free(rec->main_data);
+      free(rec);
+   }
+
+   pgmoneta_destroy_walfile(wf);
+
+   return NULL;
+}
+
+struct walfile*
+pgmoneta_test_generate_mixed_heap_wal_v19(void)
+{
+   struct walfile* wf = NULL;
+   struct decoded_xlog_record* rec_cp = NULL;
+   struct decoded_xlog_record* rec_ins = NULL;
+   struct decoded_xlog_record* rec_del = NULL;
+
+   /* PostgreSQL 19 uses the same checkpoint structure as v17 */
+   struct check_point_v17 cp;
+   memset(&cp, 0, sizeof(cp));
+   cp.redo = RANDOM_REDO;
+   cp.this_timeline_id = RANDOM_THIS_TLI;
+   cp.prev_timeline_id = RANDOM_PREV_TLI;
+   cp.full_page_writes = RANDOM_FULL_PAGE_WRITES;
+   cp.wal_level = RANDOM_WAL_LEVEL;
+   cp.next_xid.value = RANDOM_NEXT_XID;
+   cp.next_oid = RANDOM_NEXT_OID;
+   cp.next_multi = RANDOM_NEXT_MULTI;
+   cp.next_multi_offset = RANDOM_NEXT_MULTI_OFFSET;
+   cp.oldest_xid = RANDOM_OLDEST_XID;
+   cp.oldest_xid_db = RANDOM_OLDEST_XID_DB;
+   cp.oldest_multi = RANDOM_OLDEST_MULTI;
+   cp.oldest_multi_db = RANDOM_OLDEST_MULTI_DB;
+   cp.time = RANDOM_TIME;
+   cp.oldest_commit_ts_xid = RANDOM_OLDEST_COMMIT_TS_XID;
+   cp.newest_commit_ts_xid = RANDOM_NEWEST_COMMIT_TS_XID;
+   cp.oldest_active_xid = RANDOM_OLDEST_ACTIVE_XID;
+
+   struct xl_heap_insert ins;
+   memset(&ins, 0, sizeof(ins));
+   ins.offnum = 1;
+   ins.flags = 0;
+
+   struct xl_heap_delete del;
+   memset(&del, 0, sizeof(del));
+   del.xmax = 200;
+   del.offnum = 2;
+   del.infobits_set = 0;
+   del.flags = 0;
+
+   wf = create_walfile_shell();
+   if (wf == NULL)
+   {
+      return NULL;
+   }
+
+   rec_cp = create_record(RM_XLOG_ID, XLOG_CHECKPOINT_SHUTDOWN, 0,
+                          &cp, sizeof(cp));
+   if (rec_cp == NULL)
+   {
+      goto error;
+   }
+
+   if (pgmoneta_deque_add(wf->records, NULL, (uintptr_t)rec_cp, ValueRef))
+   {
+      goto error;
+   }
+   rec_cp = NULL;
+
+   rec_ins = create_record(RM_HEAP_ID, XLOG_HEAP_INSERT, 100,
+                           &ins, sizeof(ins));
+   if (rec_ins == NULL)
+   {
+      goto error;
+   }
+
+   if (pgmoneta_deque_add(wf->records, NULL, (uintptr_t)rec_ins, ValueRef))
+   {
+      goto error;
+   }
+   rec_ins = NULL;
+
+   rec_del = create_record(RM_HEAP_ID, XLOG_HEAP_DELETE, 200,
+                           &del, sizeof(del));
+   if (rec_del == NULL)
+   {
+      goto error;
+   }
+
+   if (pgmoneta_deque_add(wf->records, NULL, (uintptr_t)rec_del, ValueRef))
+   {
+      goto error;
+   }
+   rec_del = NULL;
+
+   return wf;
+
+error:
+   if (rec_del != NULL)
+   {
+      free(rec_del->main_data);
+      free(rec_del);
+   }
+   if (rec_ins != NULL)
+   {
+      free(rec_ins->main_data);
+      free(rec_ins);
+   }
+   if (rec_cp != NULL)
+   {
+      free(rec_cp->main_data);
+      free(rec_cp);
+   }
+   pgmoneta_destroy_walfile(wf);
+   return NULL;
+}

--- a/test/testcases/test_wal_summary.c
+++ b/test/testcases/test_wal_summary.c
@@ -37,6 +37,7 @@
 #include <network.h>
 #include <security.h>
 #include <server.h>
+#include <shmem.h>
 #include <tsclient.h>
 #include <tscommon.h>
 #include <tswalutils.h>
@@ -57,6 +58,28 @@
 /* Forward declarations for helper functions */
 static int pgmoneta_test_server_info_check(int srv);
 static void cleanup_connections(SSL** srv_ssl, int* srv_socket, SSL** custom_user_ssl, int* custom_user_socket);
+
+static bool shmem_allocated = false;
+
+MCTF_MODULE_SETUP(wal_summary)
+{
+   if (shmem == NULL)
+   {
+      pgmoneta_create_shared_memory(sizeof(struct main_configuration), HUGEPAGE_OFF, &shmem);
+      memset(shmem, 0, sizeof(struct main_configuration));
+      shmem_allocated = true;
+   }
+}
+
+MCTF_MODULE_TEARDOWN(wal_summary)
+{
+   if (shmem_allocated && shmem != NULL)
+   {
+      pgmoneta_destroy_shared_memory(shmem, sizeof(struct main_configuration));
+      shmem = NULL;
+      shmem_allocated = false;
+   }
+}
 
 MCTF_TEST(test_pgmoneta_wal_summary)
 {

--- a/test/testcases/test_wal_utils.c
+++ b/test/testcases/test_wal_utils.c
@@ -29,6 +29,7 @@
 
 // pgmoneta
 
+#include <shmem.h>
 #include <pgmoneta.h>
 #include <configuration.h>
 #include <deque.h>
@@ -61,6 +62,28 @@ static int compare_deque(struct deque* dq1, struct deque* dq2, int (*compare)(vo
 static int compare_xlog_page_header(void* a, void* b);
 static int compare_xlog_record(void* a, void* b);
 static void destroy_walfile(struct walfile* wf);
+
+static bool shmem_allocated = false;
+
+MCTF_MODULE_SETUP(wal_utils)
+{
+   if (shmem == NULL)
+   {
+      pgmoneta_create_shared_memory(sizeof(struct main_configuration), HUGEPAGE_OFF, &shmem);
+      memset(shmem, 0, sizeof(struct main_configuration));
+      shmem_allocated = true;
+   }
+}
+
+MCTF_MODULE_TEARDOWN(wal_utils)
+{
+   if (shmem_allocated && shmem != NULL)
+   {
+      pgmoneta_destroy_shared_memory(shmem, sizeof(struct main_configuration));
+      shmem = NULL;
+      shmem_allocated = false;
+   }
+}
 
 MCTF_TEST(test_check_point_shutdown_v17)
 {

--- a/test/testcases/test_walfilter.c
+++ b/test/testcases/test_walfilter.c
@@ -27,6 +27,7 @@
  *
  */
 
+#include <shmem.h>
 #include <pgmoneta.h>
 #include <mctf.h>
 #include <tscommon.h>
@@ -123,6 +124,28 @@ write_yaml_config(const char* yaml_path, const char* source_dir, const char* tar
 
    fclose(f);
    return 0;
+}
+
+static bool shmem_allocated = false;
+
+MCTF_MODULE_SETUP(walfilter)
+{
+   if (shmem == NULL)
+   {
+      pgmoneta_create_shared_memory(sizeof(struct main_configuration), HUGEPAGE_OFF, &shmem);
+      memset(shmem, 0, sizeof(struct main_configuration));
+      shmem_allocated = true;
+   }
+}
+
+MCTF_MODULE_TEARDOWN(walfilter)
+{
+   if (shmem_allocated && shmem != NULL)
+   {
+      pgmoneta_destroy_shared_memory(shmem, sizeof(struct main_configuration));
+      shmem = NULL;
+      shmem_allocated = false;
+   }
 }
 
 MCTF_TEST(test_walfilter_cli_usage)

--- a/test/testcases/test_walinfo.c
+++ b/test/testcases/test_walinfo.c
@@ -27,6 +27,7 @@
  *
  */
 
+#include <shmem.h>
 #include <pgmoneta.h>
 #include <aes.h>
 #include <configuration.h>
@@ -268,6 +269,28 @@ prepare_wal_test_path(char* path, size_t size)
       MCTF_ASSERT_INT_EQ(create_mock_wal_file((path), &(wf)), 0, cleanup, "Failed to create mock WAL file");          \
    }                                                                                                                  \
    while (0)
+
+static bool shmem_allocated = false;
+
+MCTF_MODULE_SETUP(walinfo)
+{
+   if (shmem == NULL)
+   {
+      pgmoneta_create_shared_memory(sizeof(struct main_configuration), HUGEPAGE_OFF, &shmem);
+      memset(shmem, 0, sizeof(struct main_configuration));
+      shmem_allocated = true;
+   }
+}
+
+MCTF_MODULE_TEARDOWN(walinfo)
+{
+   if (shmem_allocated && shmem != NULL)
+   {
+      pgmoneta_destroy_shared_memory(shmem, sizeof(struct main_configuration));
+      shmem = NULL;
+      shmem_allocated = false;
+   }
+}
 
 MCTF_TEST(test_walinfo_describe)
 {


### PR DESCRIPTION
- Support postgres-19 WAL magic number
- prevents stale WAL files in `/tmp` from causing incorrect WAL parsing and postgres version detection

Fixes [#1136]

Before
<img width="1483" height="144" alt="image" src="https://github.com/user-attachments/assets/2dfaddc2-2d46-49f9-8ed6-0e3cdd413298" />

---

After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/aead8e73-61eb-46c2-b368-98922ca36ffc" />
