### PR TITLE
[#1145] feat: collect worker failures and report them together on error

### DIFF
--- a/src/include/management.h
+++ b/src/include/management.h
@@ -198,6 +198,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_USED_SPACE            "UsedSpace"
 #define MANAGEMENT_ARGUMENT_VALID                 "Valid"
 #define MANAGEMENT_ARGUMENT_WAL                   "WAL"
+#define MANAGEMENT_ARGUMENT_WORKER_ERRORS         "WorkerErrors"
 #define MANAGEMENT_ARGUMENT_WORKERS               "Workers"
 #define MANAGEMENT_ARGUMENT_WORKFLOW              "Workflow"
 #define MANAGEMENT_ARGUMENT_WORKSPACE_FREE_SPACE  "WorkspaceFreeSpace"
@@ -873,6 +874,26 @@ pgmoneta_management_response_ok(SSL* ssl, int socket, struct timespec start_time
 int
 pgmoneta_management_response_error(SSL* ssl, int socket, char* server, int32_t error, char* workflow,
                                    uint8_t compression, uint8_t encryption, struct json* payload);
+
+/**
+ * Send an error response, attaching any worker failure messages stored in nodes
+ * under NODE_WORKER_ERRORS to the Outcome.WorkerErrors JSON array.
+ * When nodes is NULL this behaves identically to pgmoneta_management_response_error.
+ * @param ssl The SSL connection
+ * @param socket The socket
+ * @param server The server name
+ * @param error The error code
+ * @param workflow The workflow name
+ * @param compression The compress method for wire protocol
+ * @param encryption The encrypt method for wire protocol
+ * @param payload The full payload
+ * @param nodes The workflow ART node tree (may be NULL)
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_management_response_error_with_nodes(SSL* ssl, int socket, char* server, int32_t error, char* workflow,
+                                              uint8_t compression, uint8_t encryption, struct json* payload,
+                                              struct art* nodes);
 
 /**
  * Create a response

--- a/src/include/restore.h
+++ b/src/include/restore.h
@@ -96,7 +96,7 @@ pgmoneta_restore_backup(struct art* nodes);
  */
 int
 pgmoneta_combine_backups(int server, char* label, char* base, char* input_dir, char* output_dir, struct deque* prior_labels,
-                         struct backup* bck, struct json* manifest, bool incremental, bool combine_as_is);
+                         struct backup* bck, struct json* manifest, bool incremental, bool combine_as_is, struct art* nodes);
 
 /**
  * Rollup backups into a new backup

--- a/src/include/workers.h
+++ b/src/include/workers.h
@@ -80,7 +80,7 @@ struct workers
    volatile int number_of_working; /**< The number of workers */
    pthread_mutex_t worker_lock;    /**< The worker lock */
    pthread_cond_t worker_all_idle; /**< Are workers idle */
-   bool outcome;                   /**< Outcome of the workers */
+   struct deque* outcome;          /**< Aggregated failures */
    struct deque* queue;            /**< The task queue using deque */
    struct semaphore* has_tasks;    /**< Semaphore for tasks dispatching*/
 };
@@ -140,6 +140,45 @@ pgmoneta_workers_wait(struct workers* workers);
  */
 void
 pgmoneta_workers_destroy(struct workers* workers);
+
+/**
+ * True if no recorded worker failures (workers NULL means OK).
+ * @param workers The workers
+ * @return true if OK to continue dispatching
+ */
+bool
+pgmoneta_workers_outcome_ok(struct workers* workers);
+
+/**
+ * Record a failure message on the workers outcome deque (thread-safe).
+ * @param workers The workers
+ * @param message Message to append (copied)
+ */
+void
+pgmoneta_workers_record_failure(struct workers* workers, char* message);
+
+/**
+ * Log all failure messages collected in the outcome deque.
+ * Call this immediately after pgmoneta_workers_wait when
+ * pgmoneta_workers_outcome_ok returns false, so every failure
+ * from the batch is presented together rather than scattered
+ * across thread log output.
+ * @param workers The workers
+ */
+void
+pgmoneta_workers_log_failures(struct workers* workers);
+
+/**
+ * Log all failure messages and transfer them into the NODE_WORKER_ERRORS
+ * deque stored in nodes, so callers can surface them in the client response.
+ * If nodes is NULL this behaves identically to pgmoneta_workers_log_failures.
+ * Multiple calls accumulate into the same deque (failures from successive
+ * worker batches within one workflow are all collected together).
+ * @param workers The workers
+ * @param nodes   The workflow ART node tree
+ */
+void
+pgmoneta_workers_transfer_failures(struct workers* workers, struct art* nodes);
 
 /**
  * Get the number of workers for a server

--- a/src/include/workflow.h
+++ b/src/include/workflow.h
@@ -128,6 +128,7 @@ extern "C" {
 #define NODE_TARGET_BASE                 "target_base"         /* The target base directory */
 #define NODE_TARGET_FILE                 "target_file"         /* The target file */
 #define NODE_TARGET_ROOT                 "target_root"         /* The target root directory */
+#define NODE_WORKER_ERRORS               "worker_errors"       /* Deque of worker failure messages */
 
 /* Supplied by the user */
 #define USER_DIRECTORY  "directory"  /* The target root directory */

--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -232,7 +232,7 @@ pgmoneta_encrypt_data(int server, char* d, struct workers* workers, struct deque
                {
                   if (workers != NULL)
                   {
-                     if (workers->outcome)
+                     if (pgmoneta_workers_outcome_ok(workers))
                      {
                         pgmoneta_workers_add(workers, do_encrypt_file, (struct worker_common*)wi);
                      }
@@ -301,7 +301,10 @@ do_encrypt_file(struct worker_common* wc)
       pgmoneta_log_warn("do_encrypt_file: %s -> %s", wi->from, wi->to);
       if (wi->common.workers != NULL)
       {
-         wi->common.workers->outcome = false;
+         char* msg = NULL;
+         msg = pgmoneta_format_and_append(msg, "AES encrypt failed: %s", wi->from);
+         pgmoneta_workers_record_failure(wi->common.workers, msg);
+         free(msg);
       }
    }
 
@@ -572,7 +575,7 @@ decrypt_data(char* d, struct workers* workers, struct deque* excludes)
             {
                if (workers != NULL)
                {
-                  if (workers->outcome)
+                  if (pgmoneta_workers_outcome_ok(workers))
                   {
                      pgmoneta_workers_add(workers, do_decrypt_file, (struct worker_common*)wi);
                   }
@@ -666,7 +669,10 @@ do_decrypt_file(struct worker_common* wc)
       pgmoneta_log_warn("do_decrypt_file: %s -> %s", wi->from, wi->to);
       if (wi->common.workers != NULL)
       {
-         wi->common.workers->outcome = false;
+         char* msg = NULL;
+         msg = pgmoneta_format_and_append(msg, "AES decrypt failed: %s", wi->from);
+         pgmoneta_workers_record_failure(wi->common.workers, msg);
+         free(msg);
       }
    }
 
@@ -2376,7 +2382,7 @@ dispatch_aes_operation(int server, char* from, char* to, int enc, struct workers
 
    if (workers != NULL)
    {
-      if (workers->outcome)
+      if (pgmoneta_workers_outcome_ok(workers))
       {
          if (pgmoneta_workers_add(workers, do_aes_operation, (struct worker_common*)task))
          {
@@ -2414,7 +2420,12 @@ do_aes_operation(struct worker_common* wc)
 
    if (result != 0 && task->common.workers != NULL)
    {
-      task->common.workers->outcome = false;
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "AES %s failed: %s",
+                                       task->enc ? "encrypt" : "decrypt",
+                                       task->from);
+      pgmoneta_workers_record_failure(task->common.workers, msg);
+      free(msg);
    }
 
    if (task->progress_enabled)

--- a/src/libpgmoneta/archive.c
+++ b/src/libpgmoneta/archive.c
@@ -241,10 +241,10 @@ pgmoneta_archive(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
 
 error:
 
-   pgmoneta_management_response_error(ssl, client_fd,
-                                      config->common.servers[server].name,
-                                      ec != -1 ? ec : MANAGEMENT_ERROR_ARCHIVE_ERROR, en != NULL ? en : NAME,
-                                      compression, encryption, payload);
+   pgmoneta_management_response_error_with_nodes(ssl, client_fd,
+                                                 config->common.servers[server].name,
+                                                 ec != -1 ? ec : MANAGEMENT_ERROR_ARCHIVE_ERROR, en != NULL ? en : NAME,
+                                                 compression, encryption, payload, nodes);
 
    pgmoneta_art_destroy(nodes);
 

--- a/src/libpgmoneta/backup.c
+++ b/src/libpgmoneta/backup.c
@@ -327,9 +327,9 @@ error:
    config->common.servers[server].active_backup = false;
    atomic_store(&config->common.servers[server].repository, false);
 
-   pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
-                                      ec != -1 ? ec : MANAGEMENT_ERROR_BACKUP_ERROR,
-                                      en != NULL ? en : WORKFLOW_NAME_BACKUP, compression, encryption, payload);
+   pgmoneta_management_response_error_with_nodes(NULL, client_fd, config->common.servers[server].name,
+                                                 ec != -1 ? ec : MANAGEMENT_ERROR_BACKUP_ERROR,
+                                                 en != NULL ? en : WORKFLOW_NAME_BACKUP, compression, encryption, payload, nodes);
 
    if (pgmoneta_exists(root))
    {
@@ -746,9 +746,9 @@ pgmoneta_delete_backup(int client_fd, int srv, uint8_t compression, uint8_t encr
 
 error:
 
-   pgmoneta_management_response_error(NULL, client_fd, config->common.servers[srv].name,
-                                      ec != -1 ? ec : MANAGEMENT_ERROR_DELETE_BACKUP_ERROR, en != NULL ? en : WORKFLOW_NAME_DELETE_BACKUP,
-                                      compression, encryption, payload);
+   pgmoneta_management_response_error_with_nodes(NULL, client_fd, config->common.servers[srv].name,
+                                                 ec != -1 ? ec : MANAGEMENT_ERROR_DELETE_BACKUP_ERROR, en != NULL ? en : WORKFLOW_NAME_DELETE_BACKUP,
+                                                 compression, encryption, payload, nodes);
 
    pgmoneta_art_destroy(nodes);
 

--- a/src/libpgmoneta/compression.c
+++ b/src/libpgmoneta/compression.c
@@ -331,7 +331,12 @@ do_compression_operation(struct worker_common* wc)
 
    if (result != 0 && task->common.workers != NULL)
    {
-      task->common.workers->outcome = false;
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "%s failed: %s",
+                                       task->decompress ? "Decompress" : "Compress",
+                                       task->from);
+      pgmoneta_workers_record_failure(task->common.workers, msg);
+      free(msg);
    }
 
    if (task->progress_enabled)
@@ -354,7 +359,7 @@ dispatch_compression_operation(int server, char* from, char* to, int type, bool 
 
    if (workers != NULL)
    {
-      if (workers->outcome)
+      if (pgmoneta_workers_outcome_ok(workers))
       {
          if (pgmoneta_workers_add(workers, do_compression_operation, (struct worker_common*)task))
          {

--- a/src/libpgmoneta/link.c
+++ b/src/libpgmoneta/link.c
@@ -107,7 +107,7 @@ pgmoneta_link_manifest(char* base_from, char* base_to, char* from, struct art* c
 
                if (workers != NULL)
                {
-                  if (workers->outcome)
+                  if (pgmoneta_workers_outcome_ok(workers))
                   {
                      pgmoneta_workers_add(workers, do_link, (struct worker_common*)wi);
                   }
@@ -244,7 +244,7 @@ pgmoneta_relink(char* from, char* to, struct workers* workers)
 
                if (workers != NULL)
                {
-                  if (workers->outcome)
+                  if (pgmoneta_workers_outcome_ok(workers))
                   {
                      pgmoneta_workers_add(workers, do_relink, (struct worker_common*)wi);
                   }
@@ -421,7 +421,7 @@ pgmoneta_link_comparefiles(char* from, char* to, struct workers* workers)
 
             if (workers != NULL)
             {
-               if (workers->outcome)
+               if (pgmoneta_workers_outcome_ok(workers))
                {
                   pgmoneta_workers_add(workers, do_comparefiles, (struct worker_common*)wi);
                }

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -35,6 +35,7 @@
 #include <lz4_compression.h>
 #include <management.h>
 #include <utils.h>
+#include <workflow.h>
 #include <zstandard_compression.h>
 
 /* system */
@@ -1083,9 +1084,9 @@ error:
    return 1;
 }
 
-int
-pgmoneta_management_response_error(SSL* ssl, int socket, char* server, int32_t error, char* workflow,
-                                   uint8_t compression, uint8_t encryption, struct json* payload)
+static int
+management_response_error_impl(SSL* ssl, int socket, char* server, int32_t error, char* workflow,
+                               uint8_t compression, uint8_t encryption, struct json* payload, struct art* nodes)
 {
    int srv = -1;
    bool own_payload = false;
@@ -1109,6 +1110,29 @@ pgmoneta_management_response_error(SSL* ssl, int socket, char* server, int32_t e
    if (pgmoneta_management_create_outcome_failure(root, error, workflow, &outcome))
    {
       goto error;
+   }
+
+   if (nodes != NULL && outcome != NULL)
+   {
+      struct deque* worker_errors = (struct deque*)pgmoneta_art_search(nodes, NODE_WORKER_ERRORS);
+      if (worker_errors != NULL && !pgmoneta_deque_empty(worker_errors))
+      {
+         struct json* errors_array = NULL;
+         struct deque_iterator* ei = NULL;
+
+         if (!pgmoneta_json_create(&errors_array) &&
+             !pgmoneta_deque_iterator_create(worker_errors, &ei))
+         {
+            while (pgmoneta_deque_iterator_next(ei))
+            {
+               pgmoneta_json_append(errors_array,
+                                    (uintptr_t)(char*)pgmoneta_value_data(ei->value),
+                                    ValueString);
+            }
+            pgmoneta_deque_iterator_destroy(ei);
+            pgmoneta_json_put(outcome, MANAGEMENT_ARGUMENT_WORKER_ERRORS, (uintptr_t)errors_array, ValueJSON);
+         }
+      }
    }
 
    if (server != NULL && strlen(server) > 0)
@@ -1160,6 +1184,21 @@ error:
    }
 
    return 1;
+}
+
+int
+pgmoneta_management_response_error(SSL* ssl, int socket, char* server, int32_t error, char* workflow,
+                                   uint8_t compression, uint8_t encryption, struct json* payload)
+{
+   return management_response_error_impl(ssl, socket, server, error, workflow, compression, encryption, payload, NULL);
+}
+
+int
+pgmoneta_management_response_error_with_nodes(SSL* ssl, int socket, char* server, int32_t error, char* workflow,
+                                              uint8_t compression, uint8_t encryption, struct json* payload,
+                                              struct art* nodes)
+{
+   return management_response_error_impl(ssl, socket, server, error, workflow, compression, encryption, payload, nodes);
 }
 
 int

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -690,9 +690,9 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
 
 error:
 
-   pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name,
-                                      ec != -1 ? ec : MANAGEMENT_ERROR_ANNOTATE_ERROR, en != NULL ? en : NAME,
-                                      compression, encryption, payload);
+   pgmoneta_management_response_error_with_nodes(ssl, client_fd, config->common.servers[server].name,
+                                                 ec != -1 ? ec : MANAGEMENT_ERROR_ANNOTATE_ERROR, en != NULL ? en : NAME,
+                                                 compression, encryption, payload, nodes);
 
    pgmoneta_json_destroy(payload);
 
@@ -832,7 +832,7 @@ pgmoneta_restore_backup(struct art* nodes)
 }
 
 int
-pgmoneta_combine_backups(int server, char* label, char* base, char* input_dir, char* output_dir, struct deque* prior_labels, struct backup* bck, struct json* manifest, bool incremental, bool combine_as_is)
+pgmoneta_combine_backups(int server, char* label, char* base, char* input_dir, char* output_dir, struct deque* prior_labels, struct backup* bck, struct json* manifest, bool incremental, bool combine_as_is, struct art* nodes)
 {
    uint32_t tsoid = 0;
    char relative_tablespace_path[MAX_PATH];
@@ -915,8 +915,9 @@ pgmoneta_combine_backups(int server, char* label, char* base, char* input_dir, c
 
    pgmoneta_workers_wait(workers);
 
-   if (workers != NULL && !workers->outcome)
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
    {
+      pgmoneta_workers_transfer_failures(workers, nodes);
       goto error;
    }
 
@@ -971,8 +972,9 @@ pgmoneta_combine_backups(int server, char* label, char* base, char* input_dir, c
 
    pgmoneta_workers_wait(workers);
 
-   if (workers != NULL && !workers->outcome)
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
    {
+      pgmoneta_workers_transfer_failures(workers, nodes);
       goto error;
    }
 
@@ -1571,7 +1573,7 @@ combine_backups_recursive(uint32_t tsoid,
          if (workers != NULL)
          {
             struct build_backup_file_input* wi = NULL;
-            if (workers->outcome)
+            if (pgmoneta_workers_outcome_ok(workers))
             {
                create_reconstruct_backup_file_input(server,
                                                     label,
@@ -1614,7 +1616,7 @@ combine_backups_recursive(uint32_t tsoid,
          if (workers != NULL)
          {
             struct build_backup_file_input* wi = NULL;
-            if (workers->outcome)
+            if (pgmoneta_workers_outcome_ok(workers))
             {
                create_copy_backup_file_input(server, label, ofulldir, relative_prefix, entry->d_name, exclude, workers, &wi);
                pgmoneta_workers_add(workers, do_copy_backup_file, (struct worker_common*)wi);
@@ -2420,6 +2422,7 @@ restore_backup_full(struct art* nodes)
       if (pgmoneta_mkdir(target_root))
       {
          pgmoneta_log_error("Unable to create target root directory %s", target_root);
+         ret = RESTORE_ERROR;
          goto error;
       }
    }
@@ -2429,6 +2432,7 @@ restore_backup_full(struct art* nodes)
       if (pgmoneta_mkdir(target_base))
       {
          pgmoneta_log_error("Unable to create target base directory %s", target_base);
+         ret = RESTORE_ERROR;
          goto error;
       }
    }
@@ -2876,6 +2880,8 @@ static void
 do_reconstruct_backup_file(struct worker_common* wc)
 {
    struct build_backup_file_input* input = (struct build_backup_file_input*)wc;
+   char* msg = NULL;
+
    if (reconstruct_backup_file(input->server,
                                input->label,
                                input->output_dir,
@@ -2888,13 +2894,15 @@ do_reconstruct_backup_file(struct worker_common* wc)
    {
       goto error;
    }
-   input->common.workers->outcome = true;
    free(input);
    return;
 
 error:
    pgmoneta_log_error("Unable to construct file %s/%s", input->label, input->relative_dir, input->file_name);
-   input->common.workers->outcome = false;
+   msg = pgmoneta_format_and_append(msg, "Reconstruct failed: %s/%s",
+                                    input->relative_dir, input->file_name);
+   pgmoneta_workers_record_failure(input->common.workers, msg);
+   free(msg);
    free(input);
    return;
 }
@@ -2903,6 +2911,8 @@ static void
 do_copy_backup_file(struct worker_common* wc)
 {
    struct build_backup_file_input* input = (struct build_backup_file_input*)wc;
+   char* msg = NULL;
+
    if (copy_backup_file(input->server,
                         input->label,
                         input->output_dir,
@@ -2917,7 +2927,10 @@ do_copy_backup_file(struct worker_common* wc)
 
 error:
    pgmoneta_log_error("Unable to construct file %s/%s", input->label, input->relative_dir, input->file_name);
-   input->common.workers->outcome = false;
+   msg = pgmoneta_format_and_append(msg, "Copy failed: %s/%s",
+                                    input->relative_dir, input->file_name);
+   pgmoneta_workers_record_failure(input->common.workers, msg);
+   free(msg);
    free(input);
    return;
 }

--- a/src/libpgmoneta/s3.c
+++ b/src/libpgmoneta/s3.c
@@ -205,9 +205,9 @@ error:
    {
       pgmoneta_progress_teardown(server);
    }
-   pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
-                                      ec != -1 ? ec : MANAGEMENT_ERROR_LIST_S3_ERROR, en != NULL ? en : NAME,
-                                      compression, encryption, payload);
+   pgmoneta_management_response_error_with_nodes(NULL, client_fd, config->common.servers[server].name,
+                                                 ec != -1 ? ec : MANAGEMENT_ERROR_LIST_S3_ERROR, en != NULL ? en : NAME,
+                                                 compression, encryption, payload, nodes);
 
    pgmoneta_json_destroy(payload);
    pgmoneta_art_destroy(nodes);
@@ -327,9 +327,9 @@ error:
    {
       pgmoneta_progress_teardown(server);
    }
-   pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
-                                      ec != -1 ? ec : MANAGEMENT_ERROR_DELETE_S3_ERROR, en != NULL ? en : NAME,
-                                      compression, encryption, payload);
+   pgmoneta_management_response_error_with_nodes(NULL, client_fd, config->common.servers[server].name,
+                                                 ec != -1 ? ec : MANAGEMENT_ERROR_DELETE_S3_ERROR, en != NULL ? en : NAME,
+                                                 compression, encryption, payload, nodes);
 
    pgmoneta_json_destroy(payload);
    pgmoneta_art_destroy(nodes);
@@ -489,9 +489,9 @@ pgmoneta_restore_s3_objects(int client_fd, int server, char* prefix, uint8_t com
 
 error:
 
-   pgmoneta_management_response_error(NULL, client_fd, config->common.servers[server].name,
-                                      ec != -1 ? ec : MANAGEMENT_ERROR_RESTORE_S3_ERROR, en != NULL ? en : NAME,
-                                      compression, encryption, payload);
+   pgmoneta_management_response_error_with_nodes(NULL, client_fd, config->common.servers[server].name,
+                                                 ec != -1 ? ec : MANAGEMENT_ERROR_RESTORE_S3_ERROR, en != NULL ? en : NAME,
+                                                 compression, encryption, payload, nodes);
 
    pgmoneta_json_destroy(payload);
    pgmoneta_art_destroy(nodes);

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -959,7 +959,7 @@ s3_download_files(char* s3_root, char* local_root, int server, int compression, 
          goto error;
       }
 
-      if (workers != NULL && workers->outcome)
+      if (workers != NULL && pgmoneta_workers_outcome_ok(workers))
       {
          if (pgmoneta_workers_add(workers, do_download_file, (struct worker_common*)task))
          {
@@ -991,8 +991,9 @@ s3_download_files(char* s3_root, char* local_root, int server, int compression, 
    }
 
    pgmoneta_workers_wait(workers);
-   if (workers != NULL && !workers->outcome)
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
    {
+      pgmoneta_workers_log_failures(workers);
       goto error;
    }
    pgmoneta_workers_destroy(workers);
@@ -1135,7 +1136,10 @@ do_download_file(struct worker_common* wc)
 
    if (s3_download_one_file(task) && task->common.workers != NULL)
    {
-      task->common.workers->outcome = false;
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "S3 download failed: %s", task->remote_path);
+      pgmoneta_workers_record_failure(task->common.workers, msg);
+      free(msg);
    }
 
    free(task);
@@ -1166,7 +1170,10 @@ do_upload_file(struct worker_common* wc)
 
    if (s3_upload_one_file(task) && task->common.workers != NULL)
    {
-      task->common.workers->outcome = false;
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "S3 upload failed: %s", task->remote_path);
+      pgmoneta_workers_record_failure(task->common.workers, msg);
+      free(msg);
    }
 
    free(task);
@@ -1236,7 +1243,7 @@ s3_upload_files(char* local_root, char* s3_root, int server, int compression, in
          goto error;
       }
 
-      if (workers != NULL && workers->outcome)
+      if (workers != NULL && pgmoneta_workers_outcome_ok(workers))
       {
          if (pgmoneta_workers_add(workers, do_upload_file, (struct worker_common*)task))
          {
@@ -1266,8 +1273,9 @@ s3_upload_files(char* local_root, char* s3_root, int server, int compression, in
    }
 
    pgmoneta_workers_wait(workers);
-   if (workers != NULL && !workers->outcome)
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
    {
+      pgmoneta_workers_log_failures(workers);
       goto error;
    }
    pgmoneta_workers_destroy(workers);

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -2385,7 +2385,7 @@ pgmoneta_delete_file(char* file, struct workers* workers)
 
    if (workers != NULL)
    {
-      if (workers->outcome)
+      if (pgmoneta_workers_outcome_ok(workers))
       {
          pgmoneta_workers_add(workers, do_delete_file, (struct worker_common*)fi);
       }
@@ -2566,7 +2566,7 @@ pgmoneta_copy_file(char* from, char* to, struct workers* workers)
 
    if (workers != NULL)
    {
-      if (workers->outcome)
+      if (pgmoneta_workers_outcome_ok(workers))
       {
          pgmoneta_workers_add(workers, do_copy_file, (struct worker_common*)fi);
       }
@@ -2814,11 +2814,6 @@ do_copy_file(struct worker_common* wc)
    pgmoneta_log_trace("FILETRACKER | Copy | %s | %s |", fi->from, fi->to);
 #endif
 
-   if (fi->common.workers != NULL)
-   {
-      fi->common.workers->outcome = true;
-   }
-
    free(dn);
    free(from);
    free(to);
@@ -2853,7 +2848,10 @@ error:
 
    if (fi->common.workers != NULL)
    {
-      fi->common.workers->outcome = false;
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "File copy failed: %s", fi->from);
+      pgmoneta_workers_record_failure(fi->common.workers, msg);
+      free(msg);
    }
 
    free(dn);

--- a/src/libpgmoneta/verify.c
+++ b/src/libpgmoneta/verify.c
@@ -225,14 +225,14 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
 
    if (pgmoneta_management_create_response(payload, server, &response))
    {
-      pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_ALLOCATION, NAME, compression, encryption, payload);
+      pgmoneta_management_response_error_with_nodes(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_ALLOCATION, NAME, compression, encryption, payload, nodes);
 
       goto error;
    }
 
    if (pgmoneta_json_create(&filesj))
    {
-      pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_ALLOCATION, NAME, compression, encryption, payload);
+      pgmoneta_management_response_error_with_nodes(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_ALLOCATION, NAME, compression, encryption, payload, nodes);
 
       goto error;
    }
@@ -257,7 +257,7 @@ pgmoneta_verify(SSL* ssl, int client_fd, int server, uint8_t compression, uint8_
 
    if (pgmoneta_management_response_ok(ssl, client_fd, start_t, end_t, compression, encryption, payload))
    {
-      pgmoneta_management_response_error(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_VERIFY_NETWORK, NAME, compression, encryption, payload);
+      pgmoneta_management_response_error_with_nodes(ssl, client_fd, config->common.servers[server].name, MANAGEMENT_ERROR_VERIFY_NETWORK, NAME, compression, encryption, payload, nodes);
       pgmoneta_log_error("Verify: Error sending response for %s/%s", config->common.servers[server].name, identifier);
 
       goto error;

--- a/src/libpgmoneta/wf_bzip2.c
+++ b/src/libpgmoneta/wf_bzip2.c
@@ -159,8 +159,9 @@ bzip2_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       if (workers != NULL)
       {
          pgmoneta_workers_wait(workers);
-         if (!workers->outcome)
+         if (!pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
       }
@@ -299,8 +300,9 @@ bzip2_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    if (workers != NULL)
    {
       pgmoneta_workers_wait(workers);
-      if (!workers->outcome)
+      if (!pgmoneta_workers_outcome_ok(workers))
       {
+         pgmoneta_workers_transfer_failures(workers, nodes);
          goto error;
       }
    }

--- a/src/libpgmoneta/wf_delete.c
+++ b/src/libpgmoneta/wf_delete.c
@@ -48,7 +48,7 @@
 static char* delete_name(void);
 static int delete_backup_execute(char*, struct art*);
 
-static int delete_backup(int server, int index, struct backup* backup, int number_of_backups, struct backup** backups);
+static int delete_backup(int server, int index, struct backup* backup, int number_of_backups, struct backup** backups, struct art* nodes);
 
 struct workflow*
 pgmoneta_create_delete_backup(void)
@@ -165,7 +165,7 @@ delete_backup_execute(char* name __attribute__((unused)), struct art* nodes)
       }
    }
 
-   if (delete_backup(server, backup_index, backups[backup_index], number_of_backups, backups))
+   if (delete_backup(server, backup_index, backups[backup_index], number_of_backups, backups, nodes))
    {
       pgmoneta_art_insert(nodes, NODE_ERROR_CODE, (uintptr_t)MANAGEMENT_ERROR_DELETE_BACKUP_FULL, ValueInt32);
       pgmoneta_log_error("Delete: Full backup error for %s/%s", config->common.servers[server].name, label);
@@ -248,7 +248,7 @@ error:
 }
 
 static int
-delete_backup(int server, int index, struct backup* backup __attribute__((unused)), int number_of_backups, struct backup** backups)
+delete_backup(int server, int index, struct backup* backup __attribute__((unused)), int number_of_backups, struct backup** backups, struct art* nodes)
 {
    int prev_index = -1;
    int next_index = -1;
@@ -313,8 +313,9 @@ delete_backup(int server, int index, struct backup* backup __attribute__((unused
          pgmoneta_relink(from, to, workers);
 
          pgmoneta_workers_wait(workers);
-         if (workers != NULL && !workers->outcome)
+         if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
          pgmoneta_workers_destroy(workers);
@@ -367,8 +368,9 @@ delete_backup(int server, int index, struct backup* backup __attribute__((unused
          pgmoneta_relink(from, to, workers);
 
          pgmoneta_workers_wait(workers);
-         if (workers != NULL && !workers->outcome)
+         if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
          pgmoneta_workers_destroy(workers);

--- a/src/libpgmoneta/wf_encryption.c
+++ b/src/libpgmoneta/wf_encryption.c
@@ -164,8 +164,9 @@ encryption_execute(char* name __attribute__((unused)), struct art* nodes)
       if (workers != NULL)
       {
          pgmoneta_workers_wait(workers);
-         if (!workers->outcome)
+         if (!pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
       }
@@ -310,8 +311,9 @@ decryption_execute(char* name __attribute__((unused)), struct art* nodes)
    if (workers != NULL)
    {
       pgmoneta_workers_wait(workers);
-      if (!workers->outcome)
+      if (!pgmoneta_workers_outcome_ok(workers))
       {
+         pgmoneta_workers_transfer_failures(workers, nodes);
          ret = 1;
          goto error;
       }

--- a/src/libpgmoneta/wf_gzip.c
+++ b/src/libpgmoneta/wf_gzip.c
@@ -162,8 +162,9 @@ gzip_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       if (workers != NULL)
       {
          pgmoneta_workers_wait(workers);
-         if (!workers->outcome)
+         if (!pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
       }
@@ -292,8 +293,9 @@ gzip_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    if (workers != NULL)
    {
       pgmoneta_workers_wait(workers);
-      if (!workers->outcome)
+      if (!pgmoneta_workers_outcome_ok(workers))
       {
+         pgmoneta_workers_transfer_failures(workers, nodes);
          goto error;
       }
    }

--- a/src/libpgmoneta/wf_hot_standby.c
+++ b/src/libpgmoneta/wf_hot_standby.c
@@ -315,8 +315,9 @@ hot_standby_execute(char* name __attribute__((unused)), struct art* nodes)
          pgmoneta_log_debug("hot_standby source:      %s", source);
          pgmoneta_log_debug("hot_standby destination: %s", destination);
          pgmoneta_workers_wait(workers);
-         if (workers != NULL && !workers->outcome)
+         if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             error = true;
             goto cleanup;
          }
@@ -331,8 +332,9 @@ hot_standby_execute(char* name __attribute__((unused)), struct art* nodes)
             if (workers != NULL)
             {
                pgmoneta_workers_wait(workers);
-               if (!workers->outcome)
+               if (!pgmoneta_workers_outcome_ok(workers))
                {
+                  pgmoneta_workers_transfer_failures(workers, nodes);
                   error = true;
                   goto cleanup;
                }
@@ -349,8 +351,9 @@ hot_standby_execute(char* name __attribute__((unused)), struct art* nodes)
             if (workers != NULL)
             {
                pgmoneta_workers_wait(workers);
-               if (!workers->outcome)
+               if (!pgmoneta_workers_outcome_ok(workers))
                {
+                  pgmoneta_workers_transfer_failures(workers, nodes);
                   error = true;
                   goto cleanup;
                }
@@ -374,8 +377,9 @@ hot_standby_execute(char* name __attribute__((unused)), struct art* nodes)
             pgmoneta_log_debug("No hot_standby_overrides %s", config->common.servers[server].hot_standby[i]);
          }
          pgmoneta_workers_wait(workers);
-         if (workers != NULL && !workers->outcome)
+         if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             error = true;
             goto cleanup;
          }

--- a/src/libpgmoneta/wf_link.c
+++ b/src/libpgmoneta/wf_link.c
@@ -175,8 +175,9 @@ link_execute(char* name __attribute__((unused)), struct art* nodes)
          pgmoneta_link_manifest(from, to, from, changed_files, added_files, workers);
 
          pgmoneta_workers_wait(workers);
-         if (workers != NULL && !workers->outcome)
+         if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
          pgmoneta_workers_destroy(workers);

--- a/src/libpgmoneta/wf_lz4.c
+++ b/src/libpgmoneta/wf_lz4.c
@@ -161,8 +161,9 @@ lz4_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       if (workers != NULL)
       {
          pgmoneta_workers_wait(workers);
-         if (!workers->outcome)
+         if (!pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
       }
@@ -292,8 +293,9 @@ lz4_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    if (workers != NULL)
    {
       pgmoneta_workers_wait(workers);
-      if (!workers->outcome)
+      if (!pgmoneta_workers_outcome_ok(workers))
       {
+         pgmoneta_workers_transfer_failures(workers, nodes);
          goto error;
       }
    }

--- a/src/libpgmoneta/wf_restore.c
+++ b/src/libpgmoneta/wf_restore.c
@@ -225,8 +225,9 @@ restore_execute(char* name __attribute__((unused)), struct art* nodes)
    }
 
    pgmoneta_workers_wait(workers);
-   if (workers != NULL && !workers->outcome)
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
    {
+      pgmoneta_workers_transfer_failures(workers, nodes);
       goto error;
    }
    pgmoneta_workers_destroy(workers);
@@ -339,7 +340,7 @@ combine_incremental_execute(char* name __attribute__((unused)), struct art* node
       }
    }
 
-   if (pgmoneta_combine_backups(server, label, base, input_dir, output_dir, prior_labels, bck, manifest, incremental, combine_as_is))
+   if (pgmoneta_combine_backups(server, label, base, input_dir, output_dir, prior_labels, bck, manifest, incremental, combine_as_is, nodes))
    {
       goto error;
    }
@@ -773,8 +774,9 @@ copy_wal_execute(char* name __attribute__((unused)), struct art* nodes)
    pgmoneta_copy_wal_files(waldir, waltarget, &backup->wal[0], workers);
 
    pgmoneta_workers_wait(workers);
-   if (workers != NULL && !workers->outcome)
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
    {
+      pgmoneta_workers_transfer_failures(workers, nodes);
       goto error;
    }
    pgmoneta_workers_destroy(workers);

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -192,7 +192,7 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
 
       if (number_of_workers > 0)
       {
-         if (workers->outcome)
+         if (pgmoneta_workers_outcome_ok(workers))
          {
             pgmoneta_workers_add(workers, do_verify, (struct worker_common*)payload);
          }
@@ -207,8 +207,9 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
    }
 
    pgmoneta_workers_wait(workers);
-   if (workers != NULL && !workers->outcome)
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
    {
+      pgmoneta_workers_transfer_failures(workers, nodes);
       goto error;
    }
    pgmoneta_workers_destroy(workers);

--- a/src/libpgmoneta/wf_zstd.c
+++ b/src/libpgmoneta/wf_zstd.c
@@ -163,8 +163,9 @@ zstd_execute_compress(char* name __attribute__((unused)), struct art* nodes)
       if (workers != NULL)
       {
          pgmoneta_workers_wait(workers);
-         if (!workers->outcome)
+         if (!pgmoneta_workers_outcome_ok(workers))
          {
+            pgmoneta_workers_transfer_failures(workers, nodes);
             goto error;
          }
       }
@@ -293,8 +294,9 @@ zstd_execute_uncompress(char* name __attribute__((unused)), struct art* nodes)
    if (workers != NULL)
    {
       pgmoneta_workers_wait(workers);
-      if (!workers->outcome)
+      if (!pgmoneta_workers_outcome_ok(workers))
       {
+         pgmoneta_workers_transfer_failures(workers, nodes);
          goto error;
       }
    }

--- a/src/libpgmoneta/workers.c
+++ b/src/libpgmoneta/workers.c
@@ -32,6 +32,7 @@
 #include <deque.h>
 #include <logging.h>
 #include <workers.h>
+#include <workflow.h>
 #include <value.h>
 #include <aes.h>
 
@@ -78,7 +79,13 @@ pgmoneta_workers_initialize(int num, struct workers** workers)
 
    w->number_of_alive = 0;
    w->number_of_working = 0;
-   w->outcome = true;
+   w->outcome = NULL;
+
+   if (pgmoneta_deque_create(true, &w->outcome))
+   {
+      pgmoneta_log_error("Could not allocate memory for workers outcome deque");
+      goto error;
+   }
 
    if (pgmoneta_deque_create(true, &w->queue))
    {
@@ -127,12 +134,109 @@ error:
 
    if (w != NULL)
    {
+      if (w->outcome != NULL)
+      {
+         pgmoneta_deque_destroy(w->outcome);
+      }
       pgmoneta_deque_destroy(w->queue);
       free(w->has_tasks);
       free(w);
    }
 
    return 1;
+}
+
+bool
+pgmoneta_workers_outcome_ok(struct workers* workers)
+{
+   if (workers == NULL || workers->outcome == NULL)
+   {
+      return true;
+   }
+   return pgmoneta_deque_empty(workers->outcome);
+}
+
+void
+pgmoneta_workers_record_failure(struct workers* workers, char* message)
+{
+   char* copy = NULL;
+
+   if (workers == NULL || workers->outcome == NULL || message == NULL)
+   {
+      return;
+   }
+
+   copy = pgmoneta_append(NULL, message);
+   if (copy != NULL)
+   {
+      pgmoneta_deque_add(workers->outcome, NULL, (uintptr_t)copy, ValueString);
+   }
+}
+
+void
+pgmoneta_workers_log_failures(struct workers* workers)
+{
+   struct deque_iterator* iter = NULL;
+
+   if (workers == NULL || workers->outcome == NULL)
+   {
+      return;
+   }
+
+   if (pgmoneta_deque_iterator_create(workers->outcome, &iter))
+   {
+      return;
+   }
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      pgmoneta_log_error("Worker failure: %s", (char*)pgmoneta_value_data(iter->value));
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+}
+
+void
+pgmoneta_workers_transfer_failures(struct workers* workers, struct art* nodes)
+{
+   struct deque* existing = NULL;
+   struct deque_iterator* iter = NULL;
+
+   pgmoneta_workers_log_failures(workers);
+
+   if (workers == NULL || workers->outcome == NULL || nodes == NULL)
+   {
+      return;
+   }
+
+   existing = (struct deque*)pgmoneta_art_search(nodes, NODE_WORKER_ERRORS);
+
+   if (existing != NULL)
+   {
+      if (!pgmoneta_deque_iterator_create(workers->outcome, &iter))
+      {
+         while (pgmoneta_deque_iterator_next(iter))
+         {
+            char* msg = (char*)pgmoneta_value_data(iter->value);
+            char* copy = pgmoneta_append(NULL, msg);
+
+            if (copy != NULL)
+            {
+               pgmoneta_deque_add(existing, NULL, (uintptr_t)copy, ValueString);
+            }
+         }
+         pgmoneta_deque_iterator_destroy(iter);
+      }
+      pgmoneta_deque_destroy(workers->outcome);
+      workers->outcome = NULL;
+      return;
+   }
+
+   if (pgmoneta_art_insert(nodes, NODE_WORKER_ERRORS, (uintptr_t)workers->outcome, ValueDeque))
+   {
+      return;
+   }
+   workers->outcome = NULL;
 }
 
 int
@@ -213,6 +317,7 @@ pgmoneta_workers_destroy(struct workers* workers)
       }
 
       pgmoneta_deque_destroy(workers->queue);
+      pgmoneta_deque_destroy(workers->outcome);
       free(workers->has_tasks);
 
       for (int n = 0; n < worker_total; n++)


### PR DESCRIPTION

Replace the worker pool’s single success/failure flag with a deque of error messages. On command failure, those messages are reported together in the management response.

- closes #1145 

**Before**:
```
Outcome:
  Error: 600
  Status: false
  Workflow: restore
```

**after**:
```
Outcome:
  Error: 600
  Errors:
    - File copy failed: /path/to/backup/.../data/pg_ident.conf.zstd
  Status: false
  Workflow: restore
```
