### PR TITLE
[#1147] Integrate worker pool into remaining serial workflows

### DIFF
--- a/src/include/manifest.h
+++ b/src/include/manifest.h
@@ -102,10 +102,12 @@ pgmoneta_write_postgresql_manifest(struct json* manifest, char* path);
  * @param backup_data The data directory
  * @param backup The backup related to the manifest
  * @param manifest [out] The json manifest generated
+ * @param server The server identifier (for worker count lookup)
+ * @param nodes The workflow nodes (for worker error transfer)
  * @return 0 on success, otherwise 1
  */
 int
-pgmoneta_generate_manifest(int version, uint64_t system_id, char* backup_data, struct backup* bck, struct json** manifest);
+pgmoneta_generate_manifest(int version, uint64_t system_id, char* backup_data, struct backup* bck, struct json** manifest, int server, struct art* nodes);
 
 /**
  * Get the manifest record of a file
@@ -121,10 +123,12 @@ pgmoneta_get_file_manifest(char* path, char* manifest_path, struct json** file);
  * Generate the files manifest (in json format)
  * @param path The path to walk for manifest creation
  * @param files The json to append results
+ * @param server The server identifier (for worker count lookup)
+ * @param nodes The workflow nodes (for worker error transfer)
  * @return 0 if success, otherwise 1
  */
 int
-pgmoneta_generate_files_manifest(char* path, struct json* files);
+pgmoneta_generate_files_manifest(char* path, struct json* files, int server, struct art* nodes);
 
 /**
  * Get file paths from a manifest

--- a/src/libpgmoneta/manifest.c
+++ b/src/libpgmoneta/manifest.c
@@ -34,7 +34,9 @@
 #include <json.h>
 #include <logging.h>
 #include <manifest.h>
+#include <progress.h>
 #include <security.h>
+#include <workers.h>
 
 /* system */
 #include <dirent.h>
@@ -60,6 +62,12 @@ build_deque(struct deque* deque, struct csv_reader* reader, char** f);
 
 static void
 build_tree(struct art* tree, struct csv_reader* reader, char** f);
+
+static void
+do_file_manifest(struct worker_common* wc);
+
+static int
+dispatch_manifest_tasks(int server, char* source_dir, struct workers* workers, struct deque* all_deque);
 
 int
 pgmoneta_manifest_checksum_verify(char* root, struct art* file_checksums, struct art* file_sizes)
@@ -431,7 +439,7 @@ error:
 }
 
 int
-pgmoneta_generate_manifest(int version, uint64_t system_id, char* backup_data, struct backup* bck, struct json** m)
+pgmoneta_generate_manifest(int version, uint64_t system_id, char* backup_data, struct backup* bck, struct json** m, int server, struct art* nodes)
 {
    struct json* manifest = NULL;
    struct json* wal_ranges = NULL;
@@ -452,7 +460,7 @@ pgmoneta_generate_manifest(int version, uint64_t system_id, char* backup_data, s
 
    /* put files */
    pgmoneta_json_create(&files);
-   if (pgmoneta_generate_files_manifest(backup_data, files))
+   if (pgmoneta_generate_files_manifest(backup_data, files, server, nodes))
    {
       pgmoneta_json_destroy(files);
       pgmoneta_log_error("Unable to generate manifest records for: %s", backup_data);
@@ -491,7 +499,7 @@ pgmoneta_get_file_manifest(char* path, char* manifest_path, struct json** file)
    struct json* f = NULL;
    size_t size = 0;
    time_t t;
-   struct tm* tinfo;
+   struct tm tm_buf;
    char now[MISC_LENGTH];
    char* checksum = NULL;
 
@@ -501,9 +509,9 @@ pgmoneta_get_file_manifest(char* path, char* manifest_path, struct json** file)
    size = pgmoneta_get_file_size(path);
 
    time(&t);
-   tinfo = gmtime(&t);
+   gmtime_r(&t, &tm_buf);
    memset(now, 0, sizeof(now));
-   strftime(now, sizeof(now), "%Y-%m-%d %H:%M:%S GMT", tinfo);
+   strftime(now, sizeof(now), "%Y-%m-%d %H:%M:%S GMT", &tm_buf);
 
    if (pgmoneta_create_sha512_file(path, &checksum))
    {
@@ -526,20 +534,50 @@ error:
    return 1;
 }
 
-int
-pgmoneta_generate_files_manifest(char* source_dir, struct json* files)
+static void
+do_file_manifest(struct worker_common* wc)
+{
+   struct worker_input* wi = (struct worker_input*)wc;
+   struct json* file = NULL;
+
+   if (pgmoneta_get_file_manifest(wi->from, wi->to, &file))
+   {
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "Manifest failed: %s", wi->from);
+      pgmoneta_workers_record_failure(wi->common.workers, msg);
+      free(msg);
+      goto done;
+   }
+
+   pgmoneta_deque_add(wi->all, wi->from, (uintptr_t)file, ValueJSON);
+   file = NULL;
+
+   if (pgmoneta_is_progress_enabled(wi->level))
+   {
+      pgmoneta_progress_increment(wi->level, 1);
+   }
+
+done:
+   pgmoneta_json_destroy(file);
+   wi->all = NULL;
+   free(wi);
+}
+
+static int
+dispatch_manifest_tasks(int server, char* source_dir, struct workers* workers, struct deque* all_deque)
 {
    char real_path[MAX_PATH];
    struct stat s;
    struct dirent* dent;
-   struct json* file = NULL;
+   DIR* dir = NULL;
 
-   DIR* dir = opendir(source_dir);
+   dir = opendir(source_dir);
    if (!dir)
    {
       pgmoneta_log_error("Could not open directory: %s", source_dir);
-      return 1;
+      goto error;
    }
+
    while ((dent = readdir(dir)) != NULL)
    {
       char* entry_name = dent->d_name;
@@ -555,29 +593,126 @@ pgmoneta_generate_files_manifest(char* source_dir, struct json* files)
       lstat(real_path, &s);
       if (S_ISDIR(s.st_mode))
       {
-         if (pgmoneta_generate_files_manifest(real_path, files)) // recurse
+         if (dispatch_manifest_tasks(server, real_path, workers, all_deque))
          {
-            pgmoneta_log_error("Unable to generate manifest records for: %s", entry_name);
             goto error;
          }
       }
       else
       {
-         if (pgmoneta_get_file_manifest(real_path, entry_name, &file))
+         struct worker_input* payload = NULL;
+
+         if (pgmoneta_create_worker_input(NULL, real_path, entry_name, server, workers, &payload))
          {
-            pgmoneta_log_error("Unable to generate manifest records for: %s", entry_name);
             goto error;
          }
 
-         pgmoneta_json_append(files, (uintptr_t)file, ValueJSON);
-         file = NULL;
+         payload->all = all_deque;
+
+         if (workers != NULL)
+         {
+            if (pgmoneta_workers_outcome_ok(workers))
+            {
+               if (pgmoneta_workers_add(workers, do_file_manifest, (struct worker_common*)payload))
+               {
+                  free(payload);
+                  goto error;
+               }
+            }
+            else
+            {
+               free(payload);
+            }
+         }
+         else
+         {
+            do_file_manifest((struct worker_common*)payload);
+         }
       }
    }
 
    closedir(dir);
    return 0;
+
 error:
-   closedir(dir);
+
+   if (dir != NULL)
+   {
+      closedir(dir);
+   }
+
+   return 1;
+}
+
+int
+pgmoneta_generate_files_manifest(char* source_dir, struct json* files, int server, struct art* nodes)
+{
+   int number_of_workers = 0;
+   struct workers* workers = NULL;
+   struct deque* all_deque = NULL;
+   struct deque_iterator* iter = NULL;
+
+   number_of_workers = pgmoneta_get_number_of_workers(server);
+   if (number_of_workers > 0)
+   {
+      pgmoneta_workers_initialize(number_of_workers, &workers);
+   }
+
+   if (pgmoneta_deque_create(true, &all_deque))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_is_progress_enabled(server))
+   {
+      int file_count = pgmoneta_count_files(source_dir);
+      pgmoneta_progress_set_total(server, file_count);
+   }
+
+   if (dispatch_manifest_tasks(server, source_dir, workers, all_deque))
+   {
+      goto error;
+   }
+
+   pgmoneta_workers_wait(workers);
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
+   {
+      pgmoneta_workers_transfer_failures(workers, nodes);
+      goto error;
+   }
+   pgmoneta_workers_destroy(workers);
+   workers = NULL;
+
+   if (pgmoneta_deque_iterator_create(all_deque, &iter))
+   {
+      goto error;
+   }
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      struct json* file = (struct json*)pgmoneta_value_data(iter->value);
+      pgmoneta_json_append(files, (uintptr_t)file, ValueJSON);
+      iter->value->data = 0;
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   iter = NULL;
+
+   pgmoneta_deque_destroy(all_deque);
+   all_deque = NULL;
+
+   return 0;
+
+error:
+
+   if (workers != NULL)
+   {
+      pgmoneta_workers_destroy(workers);
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(all_deque);
+
    return 1;
 }
 

--- a/src/libpgmoneta/wf_manifest.c
+++ b/src/libpgmoneta/wf_manifest.c
@@ -141,7 +141,7 @@ manifest_execute(char* name __attribute__((unused)), struct art* nodes)
    /* create manifest file manually for incremental backups for PostgreSQL version 14-16 */
    if (incremental && config->common.servers[server].version < 17)
    {
-      if (pgmoneta_generate_manifest(1, 0, backup_data, backup, &m))
+      if (pgmoneta_generate_manifest(1, 0, backup_data, backup, &m, server, nodes))
       {
          pgmoneta_log_error("Could not generate the manifest");
          goto error;

--- a/src/libpgmoneta/wf_permissions.c
+++ b/src/libpgmoneta/wf_permissions.c
@@ -30,17 +30,22 @@
 #include <pgmoneta.h>
 #include <extraction.h>
 #include <logging.h>
+#include <progress.h>
 #include <utils.h>
 #include <workflow.h>
 
 /* system */
 #include <assert.h>
+#include <dirent.h>
 #include <stdlib.h>
 
 static char* permissions_name(void);
 static int permissions_execute_backup(char*, struct art*);
 static int permissions_execute_restore(char*, struct art*);
 static int permissions_execute_archive(char*, struct art*);
+
+static void do_set_permissions(struct worker_common* wc);
+static int dispatch_permissions_tasks(int server, char* path, struct workers* workers);
 
 struct workflow*
 pgmoneta_create_permissions(int type)
@@ -88,6 +93,8 @@ permissions_execute_backup(char* name __attribute__((unused)), struct art* nodes
    int server = -1;
    char* label = NULL;
    char* path = NULL;
+   int number_of_workers = 0;
+   struct workers* workers = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -106,11 +113,46 @@ permissions_execute_backup(char* name __attribute__((unused)), struct art* nodes
 
    path = pgmoneta_get_server_backup_identifier_data(server, label);
 
-   pgmoneta_permission_recursive(path);
+   number_of_workers = pgmoneta_get_number_of_workers(server);
+   if (number_of_workers > 0)
+   {
+      pgmoneta_workers_initialize(number_of_workers, &workers);
+   }
+
+   if (pgmoneta_is_progress_enabled(server))
+   {
+      int file_count = pgmoneta_count_files(path);
+      pgmoneta_progress_set_total(server, file_count);
+   }
+
+   if (dispatch_permissions_tasks(server, path, workers))
+   {
+      goto error;
+   }
+
+   pgmoneta_workers_wait(workers);
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
+   {
+      pgmoneta_workers_transfer_failures(workers, nodes);
+      goto error;
+   }
+   pgmoneta_workers_destroy(workers);
+   workers = NULL;
 
    free(path);
 
    return 0;
+
+error:
+
+   if (workers != NULL)
+   {
+      pgmoneta_workers_destroy(workers);
+   }
+
+   free(path);
+
+   return 1;
 }
 
 static int
@@ -119,6 +161,8 @@ permissions_execute_restore(char* name __attribute__((unused)), struct art* node
    int server = -1;
    char* label = NULL;
    char* path = NULL;
+   int number_of_workers = 0;
+   struct workers* workers = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -145,11 +189,46 @@ permissions_execute_restore(char* name __attribute__((unused)), struct art* node
 
    pgmoneta_log_debug("Permissions (restore): %s/%s at %s", config->common.servers[server].name, label, path);
 
-   pgmoneta_permission_recursive(path);
+   number_of_workers = pgmoneta_get_number_of_workers(server);
+   if (number_of_workers > 0)
+   {
+      pgmoneta_workers_initialize(number_of_workers, &workers);
+   }
+
+   if (pgmoneta_is_progress_enabled(server))
+   {
+      int file_count = pgmoneta_count_files(path);
+      pgmoneta_progress_set_total(server, file_count);
+   }
+
+   if (dispatch_permissions_tasks(server, path, workers))
+   {
+      goto error;
+   }
+
+   pgmoneta_workers_wait(workers);
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
+   {
+      pgmoneta_workers_transfer_failures(workers, nodes);
+      goto error;
+   }
+   pgmoneta_workers_destroy(workers);
+   workers = NULL;
 
    free(path);
 
    return 0;
+
+error:
+
+   if (workers != NULL)
+   {
+      pgmoneta_workers_destroy(workers);
+   }
+
+   free(path);
+
+   return 1;
 }
 
 static int
@@ -214,4 +293,97 @@ permissions_execute_archive(char* name __attribute__((unused)), struct art* node
    free(path);
 
    return 0;
+}
+
+static void
+do_set_permissions(struct worker_common* wc)
+{
+   struct worker_input* wi = (struct worker_input*)wc;
+   pgmoneta_permission(wi->from, 6, 0, 0);
+
+   if (pgmoneta_is_progress_enabled(wi->level))
+   {
+      pgmoneta_progress_increment(wi->level, 1);
+   }
+
+   free(wi);
+}
+
+static int
+dispatch_permissions_tasks(int server, char* path, struct workers* workers)
+{
+   DIR* dir = NULL;
+   struct dirent* entry;
+   char full_path[MAX_PATH];
+
+   dir = opendir(path);
+   if (dir == NULL)
+   {
+      goto error;
+   }
+
+   while ((entry = readdir(dir)) != NULL)
+   {
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
+      {
+         continue;
+      }
+
+      pgmoneta_snprintf(full_path, sizeof(full_path), "%s/%s", path, entry->d_name);
+
+      bool is_dir = (entry->d_type == DT_DIR) ||
+                    ((entry->d_type == DT_LNK || entry->d_type == DT_UNKNOWN) &&
+                     pgmoneta_is_directory(full_path));
+
+      if (is_dir)
+      {
+         pgmoneta_permission(full_path, 7, 0, 0);
+
+         if (dispatch_permissions_tasks(server, full_path, workers))
+         {
+            goto error;
+         }
+      }
+      else
+      {
+         struct worker_input* payload = NULL;
+
+         if (pgmoneta_create_worker_input(NULL, full_path, NULL, server, workers, &payload))
+         {
+            goto error;
+         }
+
+         if (workers != NULL)
+         {
+            if (pgmoneta_workers_outcome_ok(workers))
+            {
+               if (pgmoneta_workers_add(workers, do_set_permissions, (struct worker_common*)payload))
+               {
+                  free(payload);
+                  goto error;
+               }
+            }
+            else
+            {
+               free(payload);
+            }
+         }
+         else
+         {
+            do_set_permissions((struct worker_common*)payload);
+         }
+      }
+   }
+
+   closedir(dir);
+   return 0;
+
+error:
+
+   if (dir != NULL)
+   {
+      closedir(dir);
+   }
+
+   return 1;
 }

--- a/src/libpgmoneta/wf_sha256.c
+++ b/src/libpgmoneta/wf_sha256.c
@@ -29,6 +29,7 @@
 /* pgmoneta */
 #include <pgmoneta.h>
 #include <logging.h>
+#include <progress.h>
 #include <security.h>
 #include <utils.h>
 #include <workflow.h>
@@ -40,9 +41,9 @@
 static char* sha256_name(void);
 static int sha256_execute(char*, struct art*);
 
-static int write_backup_sha256(char* root, char* relative_path);
-
-static FILE* sha256_file = NULL;
+static void do_sha256(struct worker_common* wc);
+static int dispatch_sha256_tasks(int server, char* root, char* relative_path,
+                                 struct workers* workers, struct deque* all_deque);
 
 struct workflow*
 pgmoneta_create_sha256(void)
@@ -74,6 +75,11 @@ sha256_execute(char* name __attribute__((unused)), struct art* nodes)
    char* root = NULL;
    char* d = NULL;
    char* sha256_path = NULL;
+   int number_of_workers = 0;
+   struct workers* workers = NULL;
+   struct deque* all_deque = NULL;
+   struct deque_iterator* iter = NULL;
+   FILE* sha256_file = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -99,18 +105,71 @@ sha256_execute(char* name __attribute__((unused)), struct art* nodes)
    sha256_path = pgmoneta_append(sha256_path, root);
    sha256_path = pgmoneta_append(sha256_path, "backup.sha256");
 
+   d = pgmoneta_get_server_backup_identifier_data(server, label);
+
+   if (pgmoneta_deque_create(true, &all_deque))
+   {
+      goto error;
+   }
+
+   number_of_workers = pgmoneta_get_number_of_workers(server);
+   if (number_of_workers > 0)
+   {
+      pgmoneta_workers_initialize(number_of_workers, &workers);
+   }
+
+   if (pgmoneta_is_progress_enabled(server))
+   {
+      int file_count = pgmoneta_count_files(d);
+      pgmoneta_progress_set_total(server, file_count);
+   }
+
+   if (dispatch_sha256_tasks(server, d, "", workers, all_deque))
+   {
+      goto error;
+   }
+
+   pgmoneta_workers_wait(workers);
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
+   {
+      pgmoneta_workers_transfer_failures(workers, nodes);
+      goto error;
+   }
+   pgmoneta_workers_destroy(workers);
+   workers = NULL;
+
    sha256_file = fopen(sha256_path, "w");
    if (sha256_file == NULL)
    {
       goto error;
    }
 
-   d = pgmoneta_get_server_backup_identifier_data(server, label);
-
-   if (write_backup_sha256(d, ""))
+   if (pgmoneta_deque_iterator_create(all_deque, &iter))
    {
       goto error;
    }
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      struct json* result = (struct json*)pgmoneta_value_data(iter->value);
+      char* path = (char*)pgmoneta_json_get(result, "Path");
+      char* hash = (char*)pgmoneta_json_get(result, "Hash");
+      char* line = NULL;
+
+      line = pgmoneta_append(line, path);
+      line = pgmoneta_append(line, ":");
+      line = pgmoneta_append(line, hash);
+      line = pgmoneta_append(line, "\n");
+      fputs(line, sha256_file);
+      fflush(sha256_file);
+      free(line);
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   iter = NULL;
+
+   pgmoneta_deque_destroy(all_deque);
+   all_deque = NULL;
 
    pgmoneta_permission(sha256_path, 6, 0, 0);
 
@@ -125,11 +184,19 @@ sha256_execute(char* name __attribute__((unused)), struct art* nodes)
 
 error:
 
+   if (workers != NULL)
+   {
+      pgmoneta_workers_destroy(workers);
+   }
+
    if (sha256_file != NULL)
    {
       fflush(sha256_file);
       fclose(sha256_file);
    }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(all_deque);
 
    free(sha256_path);
    free(root);
@@ -138,15 +205,55 @@ error:
    return 1;
 }
 
+static void
+do_sha256(struct worker_common* wc)
+{
+   struct worker_input* wi = (struct worker_input*)wc;
+   char* sha256 = NULL;
+   struct json* result = NULL;
+
+   if (pgmoneta_create_sha256_file(wi->from, &sha256))
+   {
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "SHA256 failed: %s", wi->from);
+      pgmoneta_workers_record_failure(wi->common.workers, msg);
+      free(msg);
+      goto done;
+   }
+
+   if (pgmoneta_json_create(&result))
+   {
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "SHA256 allocation failed: %s", wi->from);
+      pgmoneta_workers_record_failure(wi->common.workers, msg);
+      free(msg);
+      goto done;
+   }
+
+   pgmoneta_json_put(result, "Path", (uintptr_t)wi->to, ValueString);
+   pgmoneta_json_put(result, "Hash", (uintptr_t)sha256, ValueString);
+
+   pgmoneta_deque_add(wi->all, wi->from, (uintptr_t)result, ValueJSON);
+   result = NULL;
+
+   if (pgmoneta_is_progress_enabled(wi->level))
+   {
+      pgmoneta_progress_increment(wi->level, 1);
+   }
+
+done:
+   pgmoneta_json_destroy(result);
+   free(sha256);
+   wi->all = NULL;
+   free(wi);
+}
+
 static int
-write_backup_sha256(char* root, char* relative_path)
+dispatch_sha256_tasks(int server, char* root, char* relative_path,
+                      struct workers* workers, struct deque* all_deque)
 {
    char* dir_path = NULL;
-   char* relative_file_path;
-   char* absolute_file_path;
-   char* buffer;
-   char* sha256;
-   DIR* dir;
+   DIR* dir = NULL;
    struct dirent* entry;
 
    dir_path = pgmoneta_append(dir_path, root);
@@ -159,48 +266,65 @@ write_backup_sha256(char* root, char* relative_path)
 
    while ((entry = readdir(dir)) != NULL)
    {
-      char relative_dir[1024];
+      char entry_path[MAX_PATH];
+      bool is_dir;
 
-      if (entry->d_type == DT_DIR)
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
       {
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-         {
-            continue;
-         }
+         continue;
+      }
 
+      pgmoneta_snprintf(entry_path, sizeof(entry_path), "%s/%s", dir_path, entry->d_name);
+
+      is_dir = (entry->d_type == DT_DIR) ||
+               ((entry->d_type == DT_LNK || entry->d_type == DT_UNKNOWN) &&
+                pgmoneta_is_directory(entry_path));
+
+      if (is_dir)
+      {
+         char relative_dir[MAX_PATH];
          pgmoneta_snprintf(relative_dir, sizeof(relative_dir), "%s/%s", relative_path, entry->d_name);
 
-         write_backup_sha256(root, relative_dir);
+         if (dispatch_sha256_tasks(server, root, relative_dir, workers, all_deque))
+         {
+            goto error;
+         }
       }
       else
       {
-         relative_file_path = NULL;
-         absolute_file_path = NULL;
-         sha256 = NULL;
-         buffer = NULL;
+         char relative_file[MAX_PATH];
+         char absolute_file[MAX_PATH];
+         struct worker_input* payload = NULL;
 
-         relative_file_path = pgmoneta_append(relative_file_path, relative_path);
-         relative_file_path = pgmoneta_append(relative_file_path, "/");
-         relative_file_path = pgmoneta_append(relative_file_path, entry->d_name);
+         pgmoneta_snprintf(relative_file, sizeof(relative_file), "%s/%s", relative_path, entry->d_name);
+         pgmoneta_snprintf(absolute_file, sizeof(absolute_file), "%s%s", root, relative_file);
 
-         absolute_file_path = pgmoneta_append(absolute_file_path, root);
-         absolute_file_path = pgmoneta_append(absolute_file_path, "/");
-         absolute_file_path = pgmoneta_append(absolute_file_path, relative_file_path);
+         if (pgmoneta_create_worker_input(NULL, absolute_file, relative_file, server, workers, &payload))
+         {
+            goto error;
+         }
 
-         pgmoneta_create_sha256_file(absolute_file_path, &sha256);
+         payload->all = all_deque;
 
-         buffer = pgmoneta_append(buffer, relative_file_path);
-         buffer = pgmoneta_append(buffer, ":");
-         buffer = pgmoneta_append(buffer, sha256);
-         buffer = pgmoneta_append(buffer, "\n");
-
-         fputs(buffer, sha256_file);
-         fflush(sha256_file);
-
-         free(buffer);
-         free(sha256);
-         free(relative_file_path);
-         free(absolute_file_path);
+         if (workers != NULL)
+         {
+            if (pgmoneta_workers_outcome_ok(workers))
+            {
+               if (pgmoneta_workers_add(workers, do_sha256, (struct worker_common*)payload))
+               {
+                  free(payload);
+                  goto error;
+               }
+            }
+            else
+            {
+               free(payload);
+            }
+         }
+         else
+         {
+            do_sha256((struct worker_common*)payload);
+         }
       }
    }
 

--- a/src/libpgmoneta/wf_sha512.c
+++ b/src/libpgmoneta/wf_sha512.c
@@ -45,10 +45,9 @@
 static char* sha512_name(void);
 static int sha512_execute(char*, struct art*);
 
-static int write_backup_sha512(int server, char* root, char* relative_path,
-                               bool progress_enabled);
-
-static FILE* sha512_file = NULL;
+static void do_sha512(struct worker_common* wc);
+static int dispatch_sha512_tasks(int server, char* root, char* relative_path,
+                                 struct workers* workers, struct deque* all_deque);
 
 struct workflow*
 pgmoneta_create_sha512(void)
@@ -80,10 +79,14 @@ sha512_execute(char* name __attribute__((unused)), struct art* nodes)
    struct timespec start_t;
    struct timespec end_t;
    char* root = NULL;
-   char* d = NULL;
    char* sha512_path = NULL;
    char* server_backup = NULL;
    struct backup* backup = NULL;
+   int number_of_workers = 0;
+   struct workers* workers = NULL;
+   struct deque* all_deque = NULL;
+   struct deque_iterator* iter = NULL;
+   FILE* sha512_file = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -122,26 +125,69 @@ sha512_execute(char* name __attribute__((unused)), struct art* nodes)
    }
    sha512_path = pgmoneta_append(sha512_path, "backup.sha512");
 
+   if (pgmoneta_deque_create(true, &all_deque))
+   {
+      goto error;
+   }
+
+   number_of_workers = pgmoneta_get_number_of_workers(server);
+   if (number_of_workers > 0)
+   {
+      pgmoneta_workers_initialize(number_of_workers, &workers);
+   }
+
+   if (pgmoneta_is_progress_enabled(server))
+   {
+      int file_count = pgmoneta_count_files(root);
+      pgmoneta_progress_set_total(server, file_count);
+   }
+
+   if (dispatch_sha512_tasks(server, root, "", workers, all_deque))
+   {
+      goto error;
+   }
+
+   pgmoneta_workers_wait(workers);
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
+   {
+      pgmoneta_workers_transfer_failures(workers, nodes);
+      goto error;
+   }
+   pgmoneta_workers_destroy(workers);
+   workers = NULL;
+
    sha512_file = fopen(sha512_path, "w");
    if (sha512_file == NULL)
    {
       goto error;
    }
 
-   d = pgmoneta_get_server_backup_identifier_data(server, label);
-
-   bool progress_enabled = pgmoneta_is_progress_enabled(server);
-
-   if (progress_enabled)
-   {
-      int file_count = pgmoneta_count_files(root);
-      pgmoneta_progress_set_total(server, file_count);
-   }
-
-   if (write_backup_sha512(server, root, "", progress_enabled))
+   if (pgmoneta_deque_iterator_create(all_deque, &iter))
    {
       goto error;
    }
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      struct json* result = (struct json*)pgmoneta_value_data(iter->value);
+      char* path = (char*)pgmoneta_json_get(result, "Path");
+      char* hash = (char*)pgmoneta_json_get(result, "Hash");
+      char* line = NULL;
+
+      line = pgmoneta_append(line, hash);
+      line = pgmoneta_append(line, " *.");
+      line = pgmoneta_append(line, path);
+      line = pgmoneta_append(line, "\n");
+      fputs(line, sha512_file);
+      fflush(sha512_file);
+      free(line);
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   iter = NULL;
+
+   pgmoneta_deque_destroy(all_deque);
+   all_deque = NULL;
 
    pgmoneta_permission(sha512_path, 6, 0, 0);
 
@@ -168,11 +214,15 @@ sha512_execute(char* name __attribute__((unused)), struct art* nodes)
 
    free(sha512_path);
    free(root);
-   free(d);
 
    return 0;
 
 error:
+
+   if (workers != NULL)
+   {
+      pgmoneta_workers_destroy(workers);
+   }
 
    if (sha512_file != NULL)
    {
@@ -180,23 +230,64 @@ error:
       fclose(sha512_file);
    }
 
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(all_deque);
+
    free(sha512_path);
    free(root);
-   free(d);
 
    return 1;
 }
 
+static void
+do_sha512(struct worker_common* wc)
+{
+   struct worker_input* wi = (struct worker_input*)wc;
+   char* sha512 = NULL;
+   struct json* result = NULL;
+
+   if (pgmoneta_create_sha512_file(wi->from, &sha512))
+   {
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "SHA512 failed: %s", wi->from);
+      pgmoneta_workers_record_failure(wi->common.workers, msg);
+      free(msg);
+      goto done;
+   }
+
+   if (pgmoneta_json_create(&result))
+   {
+      char* msg = NULL;
+      msg = pgmoneta_format_and_append(msg, "SHA512 allocation failed: %s", wi->from);
+      pgmoneta_workers_record_failure(wi->common.workers, msg);
+      free(msg);
+      goto done;
+   }
+
+   pgmoneta_json_put(result, "Path", (uintptr_t)wi->to, ValueString);
+   pgmoneta_json_put(result, "Hash", (uintptr_t)sha512, ValueString);
+
+   pgmoneta_deque_add(wi->all, wi->from, (uintptr_t)result, ValueJSON);
+   result = NULL;
+
+   if (pgmoneta_is_progress_enabled(wi->level))
+   {
+      pgmoneta_progress_increment(wi->level, 1);
+   }
+
+done:
+   pgmoneta_json_destroy(result);
+   free(sha512);
+   wi->all = NULL;
+   free(wi);
+}
+
 static int
-write_backup_sha512(int server, char* root, char* relative_path,
-                    bool progress_enabled)
+dispatch_sha512_tasks(int server, char* root, char* relative_path,
+                      struct workers* workers, struct deque* all_deque)
 {
    char* dir_path = NULL;
-   char* relative_file_path;
-   char* absolute_file_path;
-   char* buffer;
-   char* sha512;
-   DIR* dir;
+   DIR* dir = NULL;
    struct dirent* entry;
 
    dir_path = pgmoneta_append(dir_path, root);
@@ -209,53 +300,65 @@ write_backup_sha512(int server, char* root, char* relative_path,
 
    while ((entry = readdir(dir)) != NULL)
    {
-      char relative_dir[1024];
+      char entry_path[MAX_PATH];
+      bool is_dir;
 
-      if (entry->d_type == DT_DIR)
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
       {
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-         {
-            continue;
-         }
+         continue;
+      }
 
+      pgmoneta_snprintf(entry_path, sizeof(entry_path), "%s/%s", dir_path, entry->d_name);
+
+      is_dir = (entry->d_type == DT_DIR) ||
+               ((entry->d_type == DT_LNK || entry->d_type == DT_UNKNOWN) &&
+                pgmoneta_is_directory(entry_path));
+
+      if (is_dir)
+      {
+         char relative_dir[MAX_PATH];
          pgmoneta_snprintf(relative_dir, sizeof(relative_dir), "%s/%s", relative_path, entry->d_name);
 
-         write_backup_sha512(server, root, relative_dir, progress_enabled);
-      }
-      else if (strcmp(entry->d_name, "backup.sha512"))
-      {
-         relative_file_path = NULL;
-         absolute_file_path = NULL;
-         sha512 = NULL;
-         buffer = NULL;
-
-         relative_file_path = pgmoneta_append(relative_file_path, relative_path);
-         relative_file_path = pgmoneta_append(relative_file_path, "/");
-         relative_file_path = pgmoneta_append(relative_file_path, entry->d_name);
-
-         absolute_file_path = pgmoneta_append(absolute_file_path, root);
-         absolute_file_path = pgmoneta_append(absolute_file_path, "/");
-         absolute_file_path = pgmoneta_append(absolute_file_path, relative_file_path);
-
-         pgmoneta_create_sha512_file(absolute_file_path, &sha512);
-
-         buffer = pgmoneta_append(buffer, sha512);
-         buffer = pgmoneta_append(buffer, " *.");
-         buffer = pgmoneta_append(buffer, relative_file_path);
-         buffer = pgmoneta_append(buffer, "\n");
-
-         fputs(buffer, sha512_file);
-         fflush(sha512_file);
-
-         if (progress_enabled)
+         if (dispatch_sha512_tasks(server, root, relative_dir, workers, all_deque))
          {
-            pgmoneta_progress_increment(server, 1);
+            goto error;
+         }
+      }
+      else if (!pgmoneta_compare_string(entry->d_name, "backup.sha512"))
+      {
+         char relative_file[MAX_PATH];
+         char absolute_file[MAX_PATH];
+         struct worker_input* payload = NULL;
+
+         pgmoneta_snprintf(relative_file, sizeof(relative_file), "%s/%s", relative_path, entry->d_name);
+         pgmoneta_snprintf(absolute_file, sizeof(absolute_file), "%s%s", root, relative_file);
+
+         if (pgmoneta_create_worker_input(NULL, absolute_file, relative_file, server, workers, &payload))
+         {
+            goto error;
          }
 
-         free(buffer);
-         free(sha512);
-         free(relative_file_path);
-         free(absolute_file_path);
+         payload->all = all_deque;
+
+         if (workers != NULL)
+         {
+            if (pgmoneta_workers_outcome_ok(workers))
+            {
+               if (pgmoneta_workers_add(workers, do_sha512, (struct worker_common*)payload))
+               {
+                  free(payload);
+                  goto error;
+               }
+            }
+            else
+            {
+               free(payload);
+            }
+         }
+         else
+         {
+            do_sha512((struct worker_common*)payload);
+         }
       }
    }
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -300,6 +300,7 @@ host = localhost
 port = $PORT
 user = $PG_REPL_USER_NAME
 wal_slot = repl
+workers = 4
 hot_standby = $HOT_STANDBY_DIRECTORY
 hot_standby_overrides = $HOT_STANDBY_DIRECTORY/overrides
 EOF


### PR DESCRIPTION
Parallelize leftover file-processing workflows so they use the configured worker pool when `workers > 0`

- fixes  #1147 

**what changed:** 

- _SHA512 / SHA256_ : Per-file hashing uses the worker pool when `workers > 0`; otherwise the existing serial path is unchanged
- _Permissions_:  Per-file permission updates are dispatched to workers when configured
- _Manifest generation:_ Per-file manifest records (_checksum_ + _metadata_) are built in parallel for the incremental manifest path
- Also added progress for these new worker paths 