### PR TITLE
#1151 fix: replace strcmp with pgmoneta_compare_string for string equ…

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -209,23 +209,23 @@ main(int argc, char** argv)
       {
          break;
       }
-      else if (!strcmp(optname, "U") || !strcmp(optname, "user"))
+      else if (pgmoneta_compare_string(optname, "U") || pgmoneta_compare_string(optname, "user"))
       {
          username = optarg;
       }
-      else if (!strcmp(optname, "P") || !strcmp(optname, "password"))
+      else if (pgmoneta_compare_string(optname, "P") || pgmoneta_compare_string(optname, "password"))
       {
          password = optarg;
       }
-      else if (!strcmp(optname, "f") || !strcmp(optname, "file"))
+      else if (pgmoneta_compare_string(optname, "f") || pgmoneta_compare_string(optname, "file"))
       {
          file_path = optarg;
       }
-      else if (!strcmp(optname, "g") || !strcmp(optname, "generate"))
+      else if (pgmoneta_compare_string(optname, "g") || pgmoneta_compare_string(optname, "generate"))
       {
          generate_pwd = true;
       }
-      else if (!strcmp(optname, "l") || !strcmp(optname, "length"))
+      else if (pgmoneta_compare_string(optname, "l") || pgmoneta_compare_string(optname, "length"))
       {
          char* endptr = NULL;
          long val;
@@ -238,11 +238,11 @@ main(int argc, char** argv)
          }
          pwd_length = (int)val;
       }
-      else if (!strcmp(optname, "V") || !strcmp(optname, "version"))
+      else if (pgmoneta_compare_string(optname, "V") || pgmoneta_compare_string(optname, "version"))
       {
          version();
       }
-      else if (!strcmp(optname, "F") || !strcmp(optname, "format"))
+      else if (pgmoneta_compare_string(optname, "F") || pgmoneta_compare_string(optname, "format"))
       {
          if (!strncmp(optarg, "json", MISC_LENGTH))
          {
@@ -258,7 +258,7 @@ main(int argc, char** argv)
             exit(1);
          }
       }
-      else if (!strcmp(optname, "?") || !strcmp(optname, "help"))
+      else if (pgmoneta_compare_string(optname, "?") || pgmoneta_compare_string(optname, "help"))
       {
          usage();
          exit(0);
@@ -709,7 +709,7 @@ username:
          warnx("invalid users file line while adding user");
          goto error;
       }
-      if (!strcmp(username, ptr))
+      if (pgmoneta_compare_string(username, ptr))
       {
          warnx("Existing user: %s", username);
          goto error;
@@ -1065,7 +1065,7 @@ username:
          warnx("invalid users file line while updating user");
          goto error;
       }
-      if (!strcmp(username, ptr))
+      if (pgmoneta_compare_string(username, ptr))
       {
          /* Password */
          if (password == NULL)
@@ -1399,7 +1399,7 @@ username:
          warnx("invalid users file line while removing user");
          goto error;
       }
-      if (!strcmp(username, ptr))
+      if (pgmoneta_compare_string(username, ptr))
       {
          found = true;
       }

--- a/src/cli.c
+++ b/src/cli.c
@@ -502,39 +502,39 @@ main(int argc, char** argv)
       {
          break;
       }
-      else if (!strcmp(optname, "c") || !strcmp(optname, "config"))
+      else if (pgmoneta_compare_string(optname, "c") || pgmoneta_compare_string(optname, "config"))
       {
          configuration_path = optarg;
       }
-      else if (!strcmp(optname, "h") || !strcmp(optname, "host"))
+      else if (pgmoneta_compare_string(optname, "h") || pgmoneta_compare_string(optname, "host"))
       {
          host = optarg;
       }
-      else if (!strcmp(optname, "p") || !strcmp(optname, "port"))
+      else if (pgmoneta_compare_string(optname, "p") || pgmoneta_compare_string(optname, "port"))
       {
          port = optarg;
       }
-      else if (!strcmp(optname, "U") || !strcmp(optname, "user"))
+      else if (pgmoneta_compare_string(optname, "U") || pgmoneta_compare_string(optname, "user"))
       {
          username = optarg;
       }
-      else if (!strcmp(optname, "P") || !strcmp(optname, "password"))
+      else if (pgmoneta_compare_string(optname, "P") || pgmoneta_compare_string(optname, "password"))
       {
          password = optarg;
       }
-      else if (!strcmp(optname, "L") || !strcmp(optname, "logfile"))
+      else if (pgmoneta_compare_string(optname, "L") || pgmoneta_compare_string(optname, "logfile"))
       {
          logfile = optarg;
       }
-      else if (!strcmp(optname, "v") || !strcmp(optname, "verbose"))
+      else if (pgmoneta_compare_string(optname, "v") || pgmoneta_compare_string(optname, "verbose"))
       {
          verbose = true;
       }
-      else if (!strcmp(optname, "V") || !strcmp(optname, "version"))
+      else if (pgmoneta_compare_string(optname, "V") || pgmoneta_compare_string(optname, "version"))
       {
          version();
       }
-      else if (!strcmp(optname, "F") || !strcmp(optname, "format"))
+      else if (pgmoneta_compare_string(optname, "F") || pgmoneta_compare_string(optname, "format"))
       {
          if (!strncmp(optarg, "json", MISC_LENGTH))
          {
@@ -554,7 +554,7 @@ main(int argc, char** argv)
             exit(1);
          }
       }
-      else if (!strcmp(optname, "C") || !strcmp(optname, "compress"))
+      else if (pgmoneta_compare_string(optname, "C") || pgmoneta_compare_string(optname, "compress"))
       {
          if (!strncmp(optarg, "gz", MISC_LENGTH))
          {
@@ -582,7 +582,7 @@ main(int argc, char** argv)
             exit(1);
          }
       }
-      else if (!strcmp(optname, "E") || !strcmp(optname, "encrypt"))
+      else if (pgmoneta_compare_string(optname, "E") || pgmoneta_compare_string(optname, "encrypt"))
       {
          if (!strncmp(optarg, "aes", MISC_LENGTH))
          {
@@ -610,7 +610,7 @@ main(int argc, char** argv)
             exit(1);
          }
       }
-      else if (!strcmp(optname, "s") || !strcmp(optname, "sort"))
+      else if (pgmoneta_compare_string(optname, "s") || pgmoneta_compare_string(optname, "sort"))
       {
          if (!strncmp(optarg, "asc", 3) || !strncmp(optarg, "desc", 4))
          {
@@ -622,15 +622,15 @@ main(int argc, char** argv)
             exit(1);
          }
       }
-      else if (!strcmp(optname, "cascade"))
+      else if (pgmoneta_compare_string(optname, "cascade"))
       {
          cascade = true;
       }
-      else if (!strcmp(optname, "force"))
+      else if (pgmoneta_compare_string(optname, "force"))
       {
          force = true;
       }
-      else if (!strcmp(optname, "?") || !strcmp(optname, "help"))
+      else if (pgmoneta_compare_string(optname, "?") || pgmoneta_compare_string(optname, "help"))
       {
          usage();
          exit(0);
@@ -1297,91 +1297,91 @@ help_progress(void)
 static void
 display_helper(char* command)
 {
-   if (!strcmp(command, COMMAND_BACKUP))
+   if (pgmoneta_compare_string(command, COMMAND_BACKUP))
    {
       help_backup();
    }
-   else if (!strcmp(command, COMMAND_LIST_BACKUP))
+   else if (pgmoneta_compare_string(command, COMMAND_LIST_BACKUP))
    {
       help_list_backup();
    }
-   else if (!strcmp(command, COMMAND_S3))
+   else if (pgmoneta_compare_string(command, COMMAND_S3))
    {
       help_s3();
    }
-   else if (!strcmp(command, COMMAND_RESTORE))
+   else if (pgmoneta_compare_string(command, COMMAND_RESTORE))
    {
       help_restore();
    }
-   else if (!strcmp(command, COMMAND_VERIFY))
+   else if (pgmoneta_compare_string(command, COMMAND_VERIFY))
    {
       help_verify();
    }
-   else if (!strcmp(command, COMMAND_ARCHIVE))
+   else if (pgmoneta_compare_string(command, COMMAND_ARCHIVE))
    {
       help_archive();
    }
-   else if (!strcmp(command, COMMAND_DELETE))
+   else if (pgmoneta_compare_string(command, COMMAND_DELETE))
    {
       help_delete();
    }
-   else if (!strcmp(command, COMMAND_RETAIN))
+   else if (pgmoneta_compare_string(command, COMMAND_RETAIN))
    {
       help_retain();
    }
-   else if (!strcmp(command, COMMAND_EXPUNGE))
+   else if (pgmoneta_compare_string(command, COMMAND_EXPUNGE))
    {
       help_expunge();
    }
-   else if (!strcmp(command, COMMAND_DECRYPT))
+   else if (pgmoneta_compare_string(command, COMMAND_DECRYPT))
    {
       help_decrypt();
    }
-   else if (!strcmp(command, COMMAND_ENCRYPT))
+   else if (pgmoneta_compare_string(command, COMMAND_ENCRYPT))
    {
       help_encrypt();
    }
-   else if (!strcmp(command, COMMAND_DECOMPRESS))
+   else if (pgmoneta_compare_string(command, COMMAND_DECOMPRESS))
    {
       help_decompress();
    }
-   else if (!strcmp(command, COMMAND_COMPRESS))
+   else if (pgmoneta_compare_string(command, COMMAND_COMPRESS))
    {
       help_compress();
    }
-   else if (!strcmp(command, COMMAND_PING))
+   else if (pgmoneta_compare_string(command, COMMAND_PING))
    {
       help_ping();
    }
-   else if (!strcmp(command, COMMAND_SHUTDOWN))
+   else if (pgmoneta_compare_string(command, COMMAND_SHUTDOWN))
    {
       help_shutdown();
    }
-   else if (!strcmp(command, COMMAND_STATUS))
+   else if (pgmoneta_compare_string(command, COMMAND_STATUS))
    {
       help_status_details();
    }
-   else if (!strcmp(command, COMMAND_CONF))
+   else if (pgmoneta_compare_string(command, COMMAND_CONF))
    {
       help_conf();
    }
-   else if (!strcmp(command, COMMAND_CLEAR))
+   else if (pgmoneta_compare_string(command, COMMAND_CLEAR))
    {
       help_clear();
    }
-   else if (!strcmp(command, COMMAND_INFO))
+   else if (pgmoneta_compare_string(command, COMMAND_INFO))
    {
       help_info();
    }
-   else if (!strcmp(command, COMMAND_ANNOTATE))
+   else if (pgmoneta_compare_string(command, COMMAND_ANNOTATE))
    {
       help_annotate();
    }
-   else if (!strcmp(command, COMMAND_MODE))
+   else if (pgmoneta_compare_string(command, COMMAND_MODE))
    {
       help_mode();
    }
-   else if (!strcmp(command, COMMAND_PROGRESS))
+   else if (pgmoneta_compare_string(command, COMMAND_PROGRESS))
    {
       help_progress();
    }
@@ -2266,7 +2266,7 @@ process_set_result(SSL* ssl, int socket, char* config_key, int32_t output_format
    }
 
    // Handle success cases with accurate messaging
-   if (conf_status && !strcmp(conf_status, CONFIGURATION_STATUS_SUCCESS))
+   if (conf_status && pgmoneta_compare_string(conf_status, CONFIGURATION_STATUS_SUCCESS))
    {
       printf("Configuration change applied successfully\n");
       printf("   Parameter: %s\n", config_key ? config_key : "unknown");
@@ -2274,7 +2274,7 @@ process_set_result(SSL* ssl, int socket, char* config_key, int32_t output_format
       printf("   New value: %s\n", new_value ? new_value : "unknown");
       printf("   Status: Active (applied to running instance)\n");
    }
-   else if (conf_status && !strcmp(conf_status, CONFIGURATION_STATUS_RESTART_REQUIRED))
+   else if (conf_status && pgmoneta_compare_string(conf_status, CONFIGURATION_STATUS_RESTART_REQUIRED))
    {
       printf("Configuration change requires manual restart\n");
       printf("   Parameter: %s\n", config_key ? config_key : "unknown");
@@ -2458,14 +2458,14 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
       if (strlen(context) > 0)
       {
          // Looking for a specific context (like "mydb" in "limit.mydb.username")
-         if (!strcmp(context, iter->key) && iter->value->type == ValueJSON)
+         if (pgmoneta_compare_string(context, iter->key) && iter->value->type == ValueJSON)
          {
             struct json* nested_obj = (struct json*)iter->value->data;
             struct json_iterator* nested_iter;
             pgmoneta_json_iterator_create(nested_obj, &nested_iter);
             while (pgmoneta_json_iterator_next(nested_iter))
             {
-               if (!strcmp(key, nested_iter->key))
+               if (pgmoneta_compare_string(key, nested_iter->key))
                {
                   config_value = pgmoneta_value_to_string(nested_iter->value, FORMAT_TEXT, NULL, 0);
                   if (output_format == MANAGEMENT_OUTPUT_FORMAT_JSON)
@@ -2479,7 +2479,7 @@ get_config_key_result(char* config_key, struct json* j, uintptr_t* r, int32_t ou
             break;
          }
       }
-      else if (!strcmp(key, iter->key))
+      else if (pgmoneta_compare_string(key, iter->key))
       {
          // Handle single or two-part keys
          if (iter->value->type == ValueJSON)

--- a/src/config.c
+++ b/src/config.c
@@ -604,7 +604,7 @@ config_get(const char* file_path, const char* section, const char* key)
             *(bracket_end + 1) = '\0';
          }
 
-         if (!strcmp(trimmed, section_header))
+         if (pgmoneta_compare_string(trimmed, section_header))
          {
             in_section = true;
          }
@@ -633,7 +633,7 @@ config_get(const char* file_path, const char* section, const char* key)
                *nl = '\0';
             }
 
-            if (!strcmp(found_key, key))
+            if (pgmoneta_compare_string(found_key, key))
             {
                printf("%s\n", found_value);
                fclose(file);
@@ -726,7 +726,7 @@ config_set(const char* file_path, const char* section, const char* key, const ch
             *(bracket_end + 1) = '\0';
          }
 
-         if (!strcmp(trimmed, section_header))
+         if (pgmoneta_compare_string(trimmed, section_header))
          {
             section_found = true;
             section_start = i;
@@ -754,7 +754,7 @@ config_set(const char* file_path, const char* section, const char* key, const ch
             {
                *eq = '\0';
                char* found_key = trim(kt);
-               if (!strcmp(found_key, key))
+               if (pgmoneta_compare_string(found_key, key))
                {
                   key_found = true;
                   key_line = i;
@@ -959,7 +959,7 @@ config_del(const char* file_path, const char* section, const char* key)
          if (bracket_end)
             *(bracket_end + 1) = '\0';
 
-         if (!strcmp(trimmed, section_header))
+         if (pgmoneta_compare_string(trimmed, section_header))
          {
             section_found = true;
             section_start = i;
@@ -984,7 +984,7 @@ config_del(const char* file_path, const char* section, const char* key)
             if (eq != NULL)
             {
                *eq = '\0';
-               if (!strcmp(trim(kt), key))
+               if (pgmoneta_compare_string(trim(kt), key))
                {
                   key_line = i;
                }
@@ -1115,7 +1115,7 @@ config_ls(const char* file_path, const char* section)
 
          if (section != NULL)
          {
-            if (!strcmp(trimmed, section_header))
+            if (pgmoneta_compare_string(trimmed, section_header))
             {
                in_section = true;
             }
@@ -1187,23 +1187,23 @@ main(int argc, char** argv)
       {
          break;
       }
-      else if (!strcmp(optname, "o") || !strcmp(optname, "output"))
+      else if (pgmoneta_compare_string(optname, "o") || pgmoneta_compare_string(optname, "output"))
       {
          output_path = optarg;
       }
-      else if (!strcmp(optname, "q") || !strcmp(optname, "quiet"))
+      else if (pgmoneta_compare_string(optname, "q") || pgmoneta_compare_string(optname, "quiet"))
       {
          quiet = true;
       }
-      else if (!strcmp(optname, "F") || !strcmp(optname, "force"))
+      else if (pgmoneta_compare_string(optname, "F") || pgmoneta_compare_string(optname, "force"))
       {
          force = true;
       }
-      else if (!strcmp(optname, "V") || !strcmp(optname, "version"))
+      else if (pgmoneta_compare_string(optname, "V") || pgmoneta_compare_string(optname, "version"))
       {
          version();
       }
-      else if (!strcmp(optname, "?") || !strcmp(optname, "help"))
+      else if (pgmoneta_compare_string(optname, "?") || pgmoneta_compare_string(optname, "help"))
       {
          usage();
          exit(0);

--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -188,7 +188,7 @@ pgmoneta_encrypt_data(int server, char* d, struct workers* workers, struct deque
       {
          char path[1024];
 
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0 || strcmp(entry->d_name, "pg_tblspc") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, "..") || pgmoneta_compare_string(entry->d_name, "pg_tblspc"))
          {
             continue;
          }
@@ -539,7 +539,7 @@ decrypt_data(char* d, struct workers* workers, struct deque* excludes)
       {
          char path[1024];
 
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }

--- a/src/libpgmoneta/backup.c
+++ b/src/libpgmoneta/backup.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -166,11 +166,11 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
          goto error;
       }
 
-      if (!strcmp(incremental, "oldest"))
+      if (pgmoneta_compare_string(incremental, "oldest"))
       {
          backup_index = 0;
       }
-      else if (!strcmp(incremental, "latest") || !strcmp(incremental, "newest"))
+      else if (pgmoneta_compare_string(incremental, "latest") || pgmoneta_compare_string(incremental, "newest"))
       {
          backup_index = number_of_backups - 1;
       }
@@ -178,7 +178,7 @@ pgmoneta_backup(int client_fd, int server, uint8_t compression, uint8_t encrypti
       {
          for (int i = 0; backup_index == -1 && i < number_of_backups; i++)
          {
-            if (!strcmp(backups[i]->label, incremental))
+            if (pgmoneta_compare_string(backups[i]->label, incremental))
             {
                backup_index = i;
             }
@@ -418,11 +418,11 @@ pgmoneta_list_backup(int client_fd, int server, uint8_t compression, uint8_t enc
       if (sort_order != NULL)
       {
          // Only accept valid sort orders: "asc" or "desc"
-         if (!strcmp(sort_order, "desc"))
+         if (pgmoneta_compare_string(sort_order, "desc"))
          {
             sort_desc = true;
          }
-         else if (!strcmp(sort_order, "asc"))
+         else if (pgmoneta_compare_string(sort_order, "asc"))
          {
             sort_desc = false;
          }

--- a/src/libpgmoneta/cmd.c
+++ b/src/libpgmoneta/cmd.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,6 +27,7 @@
  */
 
 #include <cmd.h>
+#include <utils.h>
 
 #include <err.h>
 
@@ -40,11 +41,11 @@ option_requires_arg(char* option_name, cli_option* options, int num_options, boo
 
       if (is_long_option)
       {
-         matches = (strcmp(option_name, option->long_name) == 0);
+         matches = (pgmoneta_compare_string(option_name, option->long_name));
       }
       else
       {
-         matches = (strcmp(option_name, option->short_name) == 0);
+         matches = (pgmoneta_compare_string(option_name, option->short_name));
       }
 
       if (matches)
@@ -192,12 +193,12 @@ cmd_parse(
             if (is_long_option)
             {
                /* Match long option (--option) */
-               matches = (strcmp(option_text, option->long_name) == 0);
+               matches = (pgmoneta_compare_string(option_text, option->long_name));
             }
             else
             {
                /* Match short option (-X) */
-               matches = (strcmp(option_text, option->short_name) == 0);
+               matches = (pgmoneta_compare_string(option_text, option->short_name));
             }
 
             if (matches)

--- a/src/libpgmoneta/compression.c
+++ b/src/libpgmoneta/compression.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -424,7 +424,7 @@ process_directory_operation(int server, char* directory, int type, struct worker
    {
       char* to = NULL;
 
-      if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
       {
          continue;
       }

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -334,9 +334,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
 
                /* printf("|%s|%s|\n", key, value); */
 
-               if (!strcmp(key, "host"))
+               if (pgmoneta_compare_string(key, "host"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -365,7 +365,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "port"))
+               else if (pgmoneta_compare_string(key, "port"))
                {
                   if (strlen(section) > 0)
                   {
@@ -379,7 +379,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "user"))
+               else if (pgmoneta_compare_string(key, "user"))
                {
                   if (strlen(section) > 0)
                   {
@@ -401,7 +401,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "extra"))
+               else if (pgmoneta_compare_string(key, "extra"))
                {
                   if (strlen(section) > 0)
                   {
@@ -425,7 +425,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "wal_slot"))
+               else if (pgmoneta_compare_string(key, "wal_slot"))
                {
                   if (strlen(section) > 0)
                   {
@@ -447,9 +447,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "create_slot"))
+               else if (pgmoneta_compare_string(key, "create_slot"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -486,7 +486,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "follow"))
+               else if (pgmoneta_compare_string(key, "follow"))
                {
                   if (strlen(section) > 0)
                   {
@@ -508,9 +508,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "base_dir"))
+               else if (pgmoneta_compare_string(key, "base_dir"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -524,7 +524,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "wal_shipping"))
+               else if (pgmoneta_compare_string(key, "wal_shipping"))
                {
                   if (strcmp(section, "pgmoneta") && strlen(section) > 0)
                   {
@@ -536,7 +536,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      memcpy(&srv.wal_shipping[0], value, max);
                   }
                }
-               else if (!strcmp(key, "hot_standby"))
+               else if (pgmoneta_compare_string(key, "hot_standby"))
                {
                   if (strlen(section) > 0)
                   {
@@ -575,7 +575,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      srv.number_of_hot_standbys = count;
                   }
                }
-               else if (!strcmp(key, "hot_standby_overrides"))
+               else if (pgmoneta_compare_string(key, "hot_standby_overrides"))
                {
                   if (strlen(section) > 0)
                   {
@@ -613,7 +613,7 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      free(paths);
                   }
                }
-               else if (!strcmp(key, "hot_standby_tablespaces"))
+               else if (pgmoneta_compare_string(key, "hot_standby_tablespaces"))
                {
                   if (strlen(section) > 0)
                   {
@@ -651,22 +651,22 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      free(paths);
                   }
                }
-               else if (!strcmp(key, "progress"))
+               else if (pgmoneta_compare_string(key, "progress"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
-                     if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+                     if (pgmoneta_compare_string(value, "on") || pgmoneta_compare_string(value, "true") || pgmoneta_compare_string(value, "1"))
                      {
                         config->progress = true;
                      }
                   }
                   else if (strlen(section) > 0)
                   {
-                     if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+                     if (pgmoneta_compare_string(value, "on") || pgmoneta_compare_string(value, "true") || pgmoneta_compare_string(value, "1"))
                      {
                         srv.progress_enabled = 1;
                      }
-                     else if (!strcmp(value, "off") || !strcmp(value, "false") || !strcmp(value, "0"))
+                     else if (pgmoneta_compare_string(value, "off") || pgmoneta_compare_string(value, "false") || pgmoneta_compare_string(value, "0"))
                      {
                         srv.progress_enabled = 0;
                      }
@@ -676,9 +676,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "metrics"))
+               else if (pgmoneta_compare_string(key, "metrics"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->metrics))
                      {
@@ -690,9 +690,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "console"))
+               else if (pgmoneta_compare_string(key, "console"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->console))
                      {
@@ -704,9 +704,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "metrics_cache_max_size"))
+               else if (pgmoneta_compare_string(key, "metrics_cache_max_size"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_bytes(value, &config->metrics_cache_max_size, 0))
                      {
@@ -718,9 +718,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "metrics_cache_max_age"))
+               else if (pgmoneta_compare_string(key, "metrics_cache_max_age"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_seconds(value, &config->metrics_cache_max_age, PGMONETA_TIME_DISABLED))
                      {
@@ -732,9 +732,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "management"))
+               else if (pgmoneta_compare_string(key, "management"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->management))
                      {
@@ -746,9 +746,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "tls"))
+               else if (pgmoneta_compare_string(key, "tls"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_bool(value, &config->tls))
                      {
@@ -760,9 +760,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "tls_ca_file"))
+               else if (pgmoneta_compare_string(key, "tls_ca_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -791,9 +791,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "tls_cert_file"))
+               else if (pgmoneta_compare_string(key, "tls_cert_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -822,9 +822,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "tls_key_file"))
+               else if (pgmoneta_compare_string(key, "tls_key_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -853,9 +853,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "metrics_cert_file"))
+               else if (pgmoneta_compare_string(key, "metrics_cert_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -869,9 +869,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "metrics_key_file"))
+               else if (pgmoneta_compare_string(key, "metrics_key_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -885,9 +885,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "metrics_ca_file"))
+               else if (pgmoneta_compare_string(key, "metrics_ca_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -901,9 +901,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "blocking_timeout"))
+               else if (pgmoneta_compare_string(key, "blocking_timeout"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_seconds(value, &config->blocking_timeout, PGMONETA_TIME_SEC(DEFAULT_BLOCKING_TIMEOUT)))
                      {
@@ -915,9 +915,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "pidfile"))
+               else if (pgmoneta_compare_string(key, "pidfile"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -931,9 +931,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "update_process_title"))
+               else if (pgmoneta_compare_string(key, "update_process_title"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->update_process_title = as_update_process_title(value, UPDATE_PROCESS_TITLE_VERBOSE);
                   }
@@ -942,9 +942,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = false;
                   }
                }
-               else if (!strcmp(key, "workers"))
+               else if (pgmoneta_compare_string(key, "workers"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->workers))
                      {
@@ -963,9 +963,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_type"))
+               else if (pgmoneta_compare_string(key, "log_type"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->common.log_type = as_logging_type(value);
                   }
@@ -974,9 +974,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_level"))
+               else if (pgmoneta_compare_string(key, "log_level"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->common.log_level = as_logging_level(value);
                   }
@@ -985,9 +985,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_path"))
+               else if (pgmoneta_compare_string(key, "log_path"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1001,9 +1001,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_rotation_size"))
+               else if (pgmoneta_compare_string(key, "log_rotation_size"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_logging_rotation_size(value, &config->common.log_rotation_size))
                      {
@@ -1015,9 +1015,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_rotation_age"))
+               else if (pgmoneta_compare_string(key, "log_rotation_age"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_seconds(value, &config->common.log_rotation_age, PGMONETA_TIME_DISABLED))
                      {
@@ -1029,9 +1029,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_line_prefix"))
+               else if (pgmoneta_compare_string(key, "log_line_prefix"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1045,9 +1045,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_mode"))
+               else if (pgmoneta_compare_string(key, "log_mode"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->common.log_mode = as_logging_mode(value);
                   }
@@ -1056,9 +1056,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "unix_socket_dir"))
+               else if (pgmoneta_compare_string(key, "unix_socket_dir"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1072,9 +1072,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "libev"))
+               else if (pgmoneta_compare_string(key, "libev"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1088,9 +1088,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "keep_alive"))
+               else if (pgmoneta_compare_string(key, "keep_alive"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_bool(value, &config->common.keep_alive))
                      {
@@ -1102,9 +1102,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "nodelay"))
+               else if (pgmoneta_compare_string(key, "nodelay"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_bool(value, &config->common.nodelay))
                      {
@@ -1116,9 +1116,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "non_blocking"))
+               else if (pgmoneta_compare_string(key, "non_blocking"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_bool(value, &config->common.non_blocking))
                      {
@@ -1130,9 +1130,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "backlog"))
+               else if (pgmoneta_compare_string(key, "backlog"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->backlog))
                      {
@@ -1144,9 +1144,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "hugepage"))
+               else if (pgmoneta_compare_string(key, "hugepage"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->hugepage = as_hugepage(value);
                   }
@@ -1155,9 +1155,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "direct_io"))
+               else if (pgmoneta_compare_string(key, "direct_io"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->direct_io = as_direct_io(value);
                   }
@@ -1166,9 +1166,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "compression"))
+               else if (pgmoneta_compare_string(key, "compression"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->compression_type = as_compression(value);
                   }
@@ -1177,9 +1177,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "compression_level"))
+               else if (pgmoneta_compare_string(key, "compression_level"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->compression_level))
                      {
@@ -1191,9 +1191,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "storage_engine"))
+               else if (pgmoneta_compare_string(key, "storage_engine"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->storage_engine = as_storage_engine(value);
                   }
@@ -1202,9 +1202,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "ssh_hostname"))
+               else if (pgmoneta_compare_string(key, "ssh_hostname"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1218,9 +1218,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "ssh_username"))
+               else if (pgmoneta_compare_string(key, "ssh_username"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1234,9 +1234,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "ssh_base_dir"))
+               else if (pgmoneta_compare_string(key, "ssh_base_dir"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -1250,9 +1250,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "ssh_ciphers"))
+               else if (pgmoneta_compare_string(key, "ssh_ciphers"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      char* ciphers = as_ciphers(value);
 
@@ -1270,9 +1270,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "ssh_public_key_file"))
+               else if (pgmoneta_compare_string(key, "ssh_public_key_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -1286,9 +1286,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "ssh_private_key_file"))
+               else if (pgmoneta_compare_string(key, "ssh_private_key_file"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -1302,9 +1302,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_use_tls"))
+               else if (pgmoneta_compare_string(key, "s3_use_tls"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_bool(value, &config->s3.use_tls))
                      {
@@ -1323,9 +1323,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_storage_class"))
+               else if (pgmoneta_compare_string(key, "s3_storage_class"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1348,9 +1348,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_port"))
+               else if (pgmoneta_compare_string(key, "s3_port"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->s3.port))
                      {
@@ -1369,9 +1369,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_endpoint"))
+               else if (pgmoneta_compare_string(key, "s3_endpoint"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1394,9 +1394,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_region"))
+               else if (pgmoneta_compare_string(key, "s3_region"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1419,9 +1419,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_access_key_id"))
+               else if (pgmoneta_compare_string(key, "s3_access_key_id"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1444,9 +1444,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_secret_access_key"))
+               else if (pgmoneta_compare_string(key, "s3_secret_access_key"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1469,9 +1469,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_bucket"))
+               else if (pgmoneta_compare_string(key, "s3_bucket"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1494,9 +1494,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "s3_base_dir"))
+               else if (pgmoneta_compare_string(key, "s3_base_dir"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -1519,9 +1519,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "azure_storage_account"))
+               else if (pgmoneta_compare_string(key, "azure_storage_account"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1535,9 +1535,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "azure_container"))
+               else if (pgmoneta_compare_string(key, "azure_container"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1551,9 +1551,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "azure_shared_key"))
+               else if (pgmoneta_compare_string(key, "azure_shared_key"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -1567,9 +1567,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "azure_base_dir"))
+               else if (pgmoneta_compare_string(key, "azure_base_dir"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -1583,9 +1583,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "workspace"))
+               else if (pgmoneta_compare_string(key, "workspace"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      max = strlen(value);
                      if (max > MAX_PATH - 1)
@@ -1615,9 +1615,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                   }
                }
 
-               else if (!strcmp(key, "retention"))
+               else if (pgmoneta_compare_string(key, "retention"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      config->retention_days = -1;
                      config->retention_weeks = -1;
@@ -1650,9 +1650,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "retention_interval"))
+               else if (pgmoneta_compare_string(key, "retention_interval"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->retention_interval))
                      {
@@ -1664,9 +1664,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "encryption"))
+               else if (pgmoneta_compare_string(key, "encryption"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_encryption_mode(value, &config->common.encryption) != 0)
                      {
@@ -1678,9 +1678,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "max_rate"))
+               else if (pgmoneta_compare_string(key, "max_rate"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_int(value, &config->max_rate))
                      {
@@ -1705,9 +1705,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "verification"))
+               else if (pgmoneta_compare_string(key, "verification"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_seconds(value, &config->verification, PGMONETA_TIME_DISABLED))
                      {
@@ -1720,9 +1720,9 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                   }
                }
 #ifdef DEBUG
-               else if (!strcmp(key, "link"))
+               else if (pgmoneta_compare_string(key, "link"))
                {
-                  if (!strcmp(section, "pgmoneta"))
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
                   {
                      if (as_bool(value, &config->link))
                      {
@@ -2002,13 +2002,13 @@ pgmoneta_validate_main_configuration(void* shm)
 
    for (int i = 0; i < config->common.number_of_servers; i++)
    {
-      if (!strcmp(config->common.servers[i].name, "pgmoneta"))
+      if (pgmoneta_compare_string(config->common.servers[i].name, "pgmoneta"))
       {
          pgmoneta_log_fatal("pgmoneta is a reserved word for a host");
          return 1;
       }
 
-      if (!strcmp(config->common.servers[i].name, "all"))
+      if (pgmoneta_compare_string(config->common.servers[i].name, "all"))
       {
          pgmoneta_log_fatal("all is a reserved word for a host");
          return 1;
@@ -2043,7 +2043,7 @@ pgmoneta_validate_main_configuration(void* shm)
          found = false;
          for (int j = 0; !found && j < config->common.number_of_servers; j++)
          {
-            if (!strcmp(config->common.servers[i].follow, config->common.servers[j].name))
+            if (pgmoneta_compare_string(config->common.servers[i].follow, config->common.servers[j].name))
             {
                found = true;
             }
@@ -2158,7 +2158,7 @@ pgmoneta_read_cli_configuration(void* shmem, char* filename)
 
          if (key && value)
          {
-            if (!strcmp(key, CONFIGURATION_ARGUMENT_HOST))
+            if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_HOST))
             {
                max = strlen(value);
                if (max > MISC_LENGTH - 1)
@@ -2167,19 +2167,19 @@ pgmoneta_read_cli_configuration(void* shmem, char* filename)
                }
                memcpy(config->host, value, max);
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_PORT))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_PORT))
             {
                as_int(value, &config->port);
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_LOG_TYPE))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_LOG_TYPE))
             {
                config->common.log_type = as_logging_type(value);
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_LOG_LEVEL))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_LOG_LEVEL))
             {
                config->common.log_level = as_logging_level(value);
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_LOG_PATH))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_LOG_PATH))
             {
                max = strlen(value);
                if (max > MISC_LENGTH - 1)
@@ -2188,11 +2188,11 @@ pgmoneta_read_cli_configuration(void* shmem, char* filename)
                }
                memcpy(config->common.log_path, value, max);
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_LOG_MODE))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_LOG_MODE))
             {
                config->common.log_mode = as_logging_mode(value);
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_UNIX_SOCKET_DIR))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_UNIX_SOCKET_DIR))
             {
                max = strlen(value);
                if (max > MISC_LENGTH - 1)
@@ -2201,7 +2201,7 @@ pgmoneta_read_cli_configuration(void* shmem, char* filename)
                }
                memcpy(config->common.unix_socket_dir, value, max);
             }
-            else if (!strcmp(key, MANAGEMENT_ARGUMENT_OUTPUT))
+            else if (pgmoneta_compare_string(key, MANAGEMENT_ARGUMENT_OUTPUT))
             {
                int out = as_output_format(value);
                if (out != -1)
@@ -2209,14 +2209,14 @@ pgmoneta_read_cli_configuration(void* shmem, char* filename)
                   config->output_format = out;
                }
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_COMPRESSION))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_COMPRESSION))
             {
                if (as_management_compression(value, &config->compression))
                {
                   warnx("Unknown management compression: %s", value);
                }
             }
-            else if (!strcmp(key, CONFIGURATION_ARGUMENT_ENCRYPTION))
+            else if (pgmoneta_compare_string(key, CONFIGURATION_ARGUMENT_ENCRYPTION))
             {
                if (as_management_encryption(value, &config->encryption))
                {
@@ -2398,7 +2398,7 @@ pgmoneta_read_walinfo_configuration(void* shmem, char* filename)
 
                /* printf("|%s|%s|\n", key, value); */
 
-               if (!strcmp(key, "host"))
+               if (pgmoneta_compare_string(key, "host"))
                {
                   if (strlen(section) > 0)
                   {
@@ -2420,7 +2420,7 @@ pgmoneta_read_walinfo_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "port"))
+               else if (pgmoneta_compare_string(key, "port"))
                {
                   if (strlen(section) > 0)
                   {
@@ -2434,7 +2434,7 @@ pgmoneta_read_walinfo_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "user"))
+               else if (pgmoneta_compare_string(key, "user"))
                {
                   if (strlen(section) > 0)
                   {
@@ -2456,9 +2456,9 @@ pgmoneta_read_walinfo_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_type"))
+               else if (pgmoneta_compare_string(key, "log_type"))
                {
-                  if (!strcmp(section, "pgmoneta-walinfo"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walinfo"))
                   {
                      config->common.log_type = as_logging_type(value);
                   }
@@ -2467,9 +2467,9 @@ pgmoneta_read_walinfo_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_level"))
+               else if (pgmoneta_compare_string(key, "log_level"))
                {
-                  if (!strcmp(section, "pgmoneta-walinfo"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walinfo"))
                   {
                      config->common.log_level = as_logging_level(value);
                   }
@@ -2478,9 +2478,9 @@ pgmoneta_read_walinfo_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_path"))
+               else if (pgmoneta_compare_string(key, "log_path"))
                {
-                  if (!strcmp(section, "pgmoneta-walinfo"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walinfo"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -2494,9 +2494,9 @@ pgmoneta_read_walinfo_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "encryption"))
+               else if (pgmoneta_compare_string(key, "encryption"))
                {
-                  if (!strcmp(section, "pgmoneta-walinfo"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walinfo"))
                   {
                      if (as_encryption_mode(value, &config->common.encryption) != 0)
                      {
@@ -2674,7 +2674,7 @@ pgmoneta_read_walfilter_configuration(void* shmem, char* filename)
 
                /* printf("|%s|%s|\n", key, value); */
 
-               if (!strcmp(key, "host"))
+               if (pgmoneta_compare_string(key, "host"))
                {
                   if (strlen(section) > 0)
                   {
@@ -2696,7 +2696,7 @@ pgmoneta_read_walfilter_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "port"))
+               else if (pgmoneta_compare_string(key, "port"))
                {
                   if (strlen(section) > 0)
                   {
@@ -2710,7 +2710,7 @@ pgmoneta_read_walfilter_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "user"))
+               else if (pgmoneta_compare_string(key, "user"))
                {
                   if (strlen(section) > 0)
                   {
@@ -2732,9 +2732,9 @@ pgmoneta_read_walfilter_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_type"))
+               else if (pgmoneta_compare_string(key, "log_type"))
                {
-                  if (!strcmp(section, "pgmoneta-walfilter"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walfilter"))
                   {
                      config->common.log_type = as_logging_type(value);
                   }
@@ -2743,9 +2743,9 @@ pgmoneta_read_walfilter_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_level"))
+               else if (pgmoneta_compare_string(key, "log_level"))
                {
-                  if (!strcmp(section, "pgmoneta-walfilter"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walfilter"))
                   {
                      config->common.log_level = as_logging_level(value);
                   }
@@ -2754,9 +2754,9 @@ pgmoneta_read_walfilter_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "log_path"))
+               else if (pgmoneta_compare_string(key, "log_path"))
                {
-                  if (!strcmp(section, "pgmoneta-walfilter"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walfilter"))
                   {
                      max = strlen(value);
                      if (max > MISC_LENGTH - 1)
@@ -2770,9 +2770,9 @@ pgmoneta_read_walfilter_configuration(void* shmem, char* filename)
                      unknown = true;
                   }
                }
-               else if (!strcmp(key, "encryption"))
+               else if (pgmoneta_compare_string(key, "encryption"))
                {
-                  if (!strcmp(section, "pgmoneta-walfilter"))
+                  if (pgmoneta_compare_string(section, "pgmoneta-walfilter"))
                   {
                      if (as_encryption_mode(value, &config->common.encryption) != 0)
                      {
@@ -3051,7 +3051,7 @@ pgmoneta_validate_users_configuration(void* shm)
 
       for (int j = 0; !found && j < config->common.number_of_users; j++)
       {
-         if (!strcmp(config->common.servers[i].username, config->common.users[j].username))
+         if (pgmoneta_compare_string(config->common.servers[i].username, config->common.users[j].username))
          {
             found = true;
          }
@@ -4316,7 +4316,7 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
    // Server-specific configuration
    if (srv != NULL)
    {
-      if (!strcmp(key, "host"))
+      if (pgmoneta_compare_string(key, "host"))
       {
          max = strlen(value);
          if (max > MISC_LENGTH - 1)
@@ -4326,14 +4326,14 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
          memcpy(srv->host, value, max);
          srv->host[max] = '\0';
       }
-      else if (!strcmp(key, "port"))
+      else if (pgmoneta_compare_string(key, "port"))
       {
          if (as_int(value, &srv->port))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "user"))
+      else if (pgmoneta_compare_string(key, "user"))
       {
          max = strlen(value);
          if (max > MAX_USERNAME_LENGTH - 1)
@@ -4343,7 +4343,7 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
          memcpy(srv->username, value, max);
          srv->username[max] = '\0';
       }
-      else if (!strcmp(key, "wal_slot"))
+      else if (pgmoneta_compare_string(key, "wal_slot"))
       {
          max = strlen(value);
          if (max > MISC_LENGTH - 1)
@@ -4353,14 +4353,14 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
          memcpy(srv->wal_slot, value, max);
          srv->wal_slot[max] = '\0';
       }
-      else if (!strcmp(key, "create_slot"))
+      else if (pgmoneta_compare_string(key, "create_slot"))
       {
          if (as_create_slot(value, &srv->create_slot))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "follow"))
+      else if (pgmoneta_compare_string(key, "follow"))
       {
          max = strlen(value);
          if (max > MISC_LENGTH - 1)
@@ -4370,21 +4370,21 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
          memcpy(srv->follow, value, max);
          srv->follow[max] = '\0';
       }
-      else if (!strcmp(key, "workers"))
+      else if (pgmoneta_compare_string(key, "workers"))
       {
          if (as_int(value, &srv->workers))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "max_rate"))
+      else if (pgmoneta_compare_string(key, "max_rate"))
       {
          if (as_int(value, &srv->max_rate))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "retention"))
+      else if (pgmoneta_compare_string(key, "retention"))
       {
          srv->retention_days = -1;
          srv->retention_weeks = -1;
@@ -4395,13 +4395,13 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
             unknown = true;
          }
       }
-      else if (!strcmp(key, "progress"))
+      else if (pgmoneta_compare_string(key, "progress"))
       {
-         if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+         if (pgmoneta_compare_string(value, "on") || pgmoneta_compare_string(value, "true") || pgmoneta_compare_string(value, "1"))
          {
             srv->progress_enabled = 1;
          }
-         else if (!strcmp(value, "off") || !strcmp(value, "false") || !strcmp(value, "0"))
+         else if (pgmoneta_compare_string(value, "off") || pgmoneta_compare_string(value, "false") || pgmoneta_compare_string(value, "0"))
          {
             srv->progress_enabled = 0;
          }
@@ -4414,7 +4414,7 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
    else
    {
       // Main configuration
-      if (!strcmp(key, "host"))
+      if (pgmoneta_compare_string(key, "host"))
       {
          max = strlen(value);
          if (max > MISC_LENGTH - 1)
@@ -4424,43 +4424,43 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
          memcpy(config->host, value, max);
          config->host[max] = '\0';
       }
-      else if (!strcmp(key, "metrics"))
+      else if (pgmoneta_compare_string(key, "metrics"))
       {
          if (as_int(value, &config->metrics))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "console"))
+      else if (pgmoneta_compare_string(key, "console"))
       {
          if (as_int(value, &config->console))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "management"))
+      else if (pgmoneta_compare_string(key, "management"))
       {
          if (as_int(value, &config->management))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "workers"))
+      else if (pgmoneta_compare_string(key, "workers"))
       {
          if (as_int(value, &config->workers))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "log_level"))
+      else if (pgmoneta_compare_string(key, "log_level"))
       {
          config->common.log_level = as_logging_level(value);
       }
-      else if (!strcmp(key, "log_type"))
+      else if (pgmoneta_compare_string(key, "log_type"))
       {
          config->common.log_type = as_logging_type(value);
       }
-      else if (!strcmp(key, "log_path"))
+      else if (pgmoneta_compare_string(key, "log_path"))
       {
          max = strlen(value);
          if (max > MISC_LENGTH - 1)
@@ -4470,18 +4470,18 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
          memcpy(config->common.log_path, value, max);
          config->common.log_path[max] = '\0';
       }
-      else if (!strcmp(key, "compression"))
+      else if (pgmoneta_compare_string(key, "compression"))
       {
          config->compression_type = as_compression(value);
       }
-      else if (!strcmp(key, "compression_level"))
+      else if (pgmoneta_compare_string(key, "compression_level"))
       {
          if (as_int(value, &config->compression_level))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "retention"))
+      else if (pgmoneta_compare_string(key, "retention"))
       {
          config->retention_days = -1;
          config->retention_weeks = -1;
@@ -4492,48 +4492,48 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
             unknown = true;
          }
       }
-      else if (!strcmp(key, "max_rate"))
+      else if (pgmoneta_compare_string(key, "max_rate"))
       {
          if (as_int(value, &config->max_rate))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "verification"))
+      else if (pgmoneta_compare_string(key, "verification"))
       {
          if (as_seconds(value, &config->verification, PGMONETA_TIME_DISABLED))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "blocking_timeout"))
+      else if (pgmoneta_compare_string(key, "blocking_timeout"))
       {
          if (as_seconds(value, &config->blocking_timeout, PGMONETA_TIME_SEC(DEFAULT_BLOCKING_TIMEOUT)))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "metrics_cache_max_age"))
+      else if (pgmoneta_compare_string(key, "metrics_cache_max_age"))
       {
          if (as_seconds(value, &config->metrics_cache_max_age, PGMONETA_TIME_DISABLED))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "log_rotation_age"))
+      else if (pgmoneta_compare_string(key, "log_rotation_age"))
       {
          if (as_seconds(value, &config->common.log_rotation_age, PGMONETA_TIME_DISABLED))
          {
             unknown = true;
          }
       }
-      else if (!strcmp(key, "progress"))
+      else if (pgmoneta_compare_string(key, "progress"))
       {
-         if (!strcmp(value, "on") || !strcmp(value, "true") || !strcmp(value, "1"))
+         if (pgmoneta_compare_string(value, "on") || pgmoneta_compare_string(value, "true") || pgmoneta_compare_string(value, "1"))
          {
             config->progress = true;
          }
-         else if (!strcmp(value, "off") || !strcmp(value, "false") || !strcmp(value, "0"))
+         else if (pgmoneta_compare_string(value, "off") || pgmoneta_compare_string(value, "false") || pgmoneta_compare_string(value, "0"))
          {
             config->progress = false;
          }
@@ -4576,65 +4576,65 @@ write_config_value(char* buffer, char* config_key, size_t buffer_size)
    switch (key_info.section_type)
    {
       case 0: // Main configuration
-         if (!strcmp(key_info.key, "host"))
+         if (pgmoneta_compare_string(key_info.key, "host"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%s", config->host);
          }
-         else if (!strcmp(key_info.key, "metrics"))
+         else if (pgmoneta_compare_string(key_info.key, "metrics"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->metrics);
          }
-         else if (!strcmp(key_info.key, "console"))
+         else if (pgmoneta_compare_string(key_info.key, "console"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->console);
          }
-         else if (!strcmp(key_info.key, "management"))
+         else if (pgmoneta_compare_string(key_info.key, "management"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->management);
          }
-         else if (!strcmp(key_info.key, "workers"))
+         else if (pgmoneta_compare_string(key_info.key, "workers"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->workers);
          }
-         else if (!strcmp(key_info.key, "log_level"))
+         else if (pgmoneta_compare_string(key_info.key, "log_level"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->common.log_level);
          }
-         else if (!strcmp(key_info.key, "log_type"))
+         else if (pgmoneta_compare_string(key_info.key, "log_type"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->common.log_type);
          }
-         else if (!strcmp(key_info.key, "log_path"))
+         else if (pgmoneta_compare_string(key_info.key, "log_path"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%s", config->common.log_path);
          }
-         else if (!strcmp(key_info.key, "compression"))
+         else if (pgmoneta_compare_string(key_info.key, "compression"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->compression_type);
          }
-         else if (!strcmp(key_info.key, "compression_level"))
+         else if (pgmoneta_compare_string(key_info.key, "compression_level"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->compression_level);
          }
-         else if (!strcmp(key_info.key, "storage_engine"))
+         else if (pgmoneta_compare_string(key_info.key, "storage_engine"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->storage_engine);
          }
-         else if (!strcmp(key_info.key, "max_rate"))
+         else if (pgmoneta_compare_string(key_info.key, "max_rate"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%d", config->max_rate);
          }
-         else if (!strcmp(key_info.key, "verification"))
+         else if (pgmoneta_compare_string(key_info.key, "verification"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%" PRId64, pgmoneta_time_convert(config->verification, FORMAT_TIME_S));
          }
-         else if (!strcmp(key_info.key, "retention"))
+         else if (pgmoneta_compare_string(key_info.key, "retention"))
          {
             char* ret = get_retention_string(config->retention_days, config->retention_weeks, config->retention_months, config->retention_years);
             pgmoneta_snprintf(buffer, buffer_size, "%s", ret ? ret : "");
             free(ret);
          }
-         else if (!strcmp(key_info.key, "progress"))
+         else if (pgmoneta_compare_string(key_info.key, "progress"))
          {
             pgmoneta_snprintf(buffer, buffer_size, "%s", config->progress ? "on" : "off");
          }
@@ -4655,81 +4655,81 @@ write_config_value(char* buffer, char* config_key, size_t buffer_size)
                struct server* srv = &config->common.servers[i];
                server_found = true;
 
-               if (!strcmp(key_info.key, "host"))
+               if (pgmoneta_compare_string(key_info.key, "host"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->host);
                }
-               else if (!strcmp(key_info.key, "port"))
+               else if (pgmoneta_compare_string(key_info.key, "port"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%d", srv->port);
                }
-               else if (!strcmp(key_info.key, "user"))
+               else if (pgmoneta_compare_string(key_info.key, "user"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->username);
                }
-               else if (!strcmp(key_info.key, "wal_slot"))
+               else if (pgmoneta_compare_string(key_info.key, "wal_slot"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->wal_slot);
                }
-               else if (!strcmp(key_info.key, "create_slot"))
+               else if (pgmoneta_compare_string(key_info.key, "create_slot"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%d", srv->create_slot);
                }
-               else if (!strcmp(key_info.key, "follow"))
+               else if (pgmoneta_compare_string(key_info.key, "follow"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->follow);
                }
-               else if (!strcmp(key_info.key, "workers"))
+               else if (pgmoneta_compare_string(key_info.key, "workers"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%d", srv->workers);
                }
-               else if (!strcmp(key_info.key, "max_rate"))
+               else if (pgmoneta_compare_string(key_info.key, "max_rate"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%d", srv->max_rate);
                }
-               else if (!strcmp(key_info.key, "retention"))
+               else if (pgmoneta_compare_string(key_info.key, "retention"))
                {
                   char* ret = get_retention_string(srv->retention_days, srv->retention_weeks, srv->retention_months, srv->retention_years);
                   pgmoneta_snprintf(buffer, buffer_size, "%s", ret ? ret : "");
                   free(ret);
                }
-               else if (!strcmp(key_info.key, "s3_use_tls"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_use_tls"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.use_tls ? "true" : "false");
                }
-               else if (!strcmp(key_info.key, "s3_storage_class"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_storage_class"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.storage_class);
                }
-               else if (!strcmp(key_info.key, "s3_endpoint"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_endpoint"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.endpoint);
                }
-               else if (!strcmp(key_info.key, "s3_port"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_port"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%d", srv->s3.port);
                }
-               else if (!strcmp(key_info.key, "s3_region"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_region"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.region);
                }
-               else if (!strcmp(key_info.key, "s3_access_key_id"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_access_key_id"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.access_key_id);
                }
-               else if (!strcmp(key_info.key, "s3_secret_access_key"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_secret_access_key"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.secret_access_key);
                }
-               else if (!strcmp(key_info.key, "s3_bucket"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_bucket"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.bucket);
                }
-               else if (!strcmp(key_info.key, "s3_base_dir"))
+               else if (pgmoneta_compare_string(key_info.key, "s3_base_dir"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->s3.base_dir);
                }
-               else if (!strcmp(key_info.key, "progress"))
+               else if (pgmoneta_compare_string(key_info.key, "progress"))
                {
                   pgmoneta_snprintf(buffer, buffer_size, "%s", srv->progress_enabled == 1 ? "on" : (srv->progress_enabled == 0 ? "off" : "inherit"));
                }
@@ -5302,7 +5302,7 @@ as_retention(char* str, int* days, int* weeks, int* months, int* years)
       }
       if (as_int(token, days))
       {
-         if (!strcmp(token, "X") || !strcmp(token, "x") || !strcmp(token, "-"))
+         if (pgmoneta_compare_string(token, "X") || pgmoneta_compare_string(token, "x") || pgmoneta_compare_string(token, "-"))
          {
             *days = -1;
          }
@@ -5346,7 +5346,7 @@ as_retention(char* str, int* days, int* weeks, int* months, int* years)
       }
       if (as_int(token, weeks))
       {
-         if (!strcmp(token, "X") || !strcmp(token, "x") || !strcmp(token, "-"))
+         if (pgmoneta_compare_string(token, "X") || pgmoneta_compare_string(token, "x") || pgmoneta_compare_string(token, "-"))
          {
             *weeks = -1;
          }
@@ -5390,7 +5390,7 @@ as_retention(char* str, int* days, int* weeks, int* months, int* years)
       }
       if (as_int(token, months))
       {
-         if (!strcmp(token, "X") || !strcmp(token, "x") || !strcmp(token, "-"))
+         if (pgmoneta_compare_string(token, "X") || pgmoneta_compare_string(token, "x") || pgmoneta_compare_string(token, "-"))
          {
             *months = -1;
          }
@@ -5434,7 +5434,7 @@ as_retention(char* str, int* days, int* weeks, int* months, int* years)
       }
       if (as_int(token, years))
       {
-         if (!strcmp(token, "X") || !strcmp(token, "x") || !strcmp(token, "-"))
+         if (pgmoneta_compare_string(token, "X") || pgmoneta_compare_string(token, "x") || pgmoneta_compare_string(token, "-"))
          {
             *years = -1;
          }
@@ -5517,31 +5517,31 @@ as_ciphers(char* str)
    ptr = strtok(converted, ",");
    while (ptr != NULL)
    {
-      if (strcmp("aes-256-ctr", ptr) == 0)
+      if (pgmoneta_compare_string("aes-256-ctr", ptr))
       {
          result = pgmoneta_append(result, "aes256-ctr");
       }
-      else if (strcmp("aes-192-ctr", ptr) == 0)
+      else if (pgmoneta_compare_string("aes-192-ctr", ptr))
       {
          result = pgmoneta_append(result, "aes192-ctr");
       }
-      else if (strcmp("aes-128-ctr", ptr) == 0)
+      else if (pgmoneta_compare_string("aes-128-ctr", ptr))
       {
          result = pgmoneta_append(result, "aes128-ctr");
       }
-      else if (strcmp("aes-256-cbc", ptr) == 0 || strcmp("aes-256", ptr) == 0)
+      else if (pgmoneta_compare_string("aes-256-cbc", ptr) || pgmoneta_compare_string("aes-256", ptr))
       {
          result = pgmoneta_append(result, "aes256-cbc");
       }
-      else if (strcmp("aes-192-cbc", ptr) == 0 || strcmp("aes-192", ptr) == 0)
+      else if (pgmoneta_compare_string("aes-192-cbc", ptr) || pgmoneta_compare_string("aes-192", ptr))
       {
          result = pgmoneta_append(result, "aes192-cbc");
       }
-      else if (strcmp("aes-128-cbc", ptr) == 0 || strcmp("aes-128", ptr) == 0)
+      else if (pgmoneta_compare_string("aes-128-cbc", ptr) || pgmoneta_compare_string("aes-128", ptr))
       {
          result = pgmoneta_append(result, "aes128-cbc");
       }
-      else if (strcmp("aes", ptr) == 0)
+      else if (pgmoneta_compare_string("aes", ptr))
       {
          result = pgmoneta_append(result, "aes256-cbc");
       }
@@ -6376,7 +6376,7 @@ is_empty_string(char* s)
       return true;
    }
 
-   if (!strcmp(s, ""))
+   if (pgmoneta_compare_string(s, ""))
    {
       return true;
    }

--- a/src/libpgmoneta/console.c
+++ b/src/libpgmoneta/console.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -199,11 +199,11 @@ resolve_page(struct message* msg)
 
    pgmoneta_write_byte(msg->data + index, '\0');
 
-   if (strcmp(from, "/") == 0 || strcmp(from, "/index.html") == 0)
+   if (pgmoneta_compare_string(from, "/") || pgmoneta_compare_string(from, "/index.html"))
    {
       return PAGE_HOME;
    }
-   else if (strcmp(from, "/api") == 0 || strcmp(from, "/api/") == 0)
+   else if (pgmoneta_compare_string(from, "/api") || pgmoneta_compare_string(from, "/api/"))
    {
       return PAGE_API;
    }
@@ -436,7 +436,7 @@ console_refresh_metrics(int endpoint, struct console_page* console)
          }
 
          effective_endpoint = 0;
-         resolved_host = (strlen(config->host) == 0 || strcmp(config->host, "*") == 0 || strcmp(config->host, "0.0.0.0") == 0) ? "127.0.0.1" : config->host;
+         resolved_host = (strlen(config->host) == 0 || pgmoneta_compare_string(config->host, "*") || pgmoneta_compare_string(config->host, "0.0.0.0")) ? "127.0.0.1" : config->host;
 
          if (strcmp(resolved_host, config->host) != 0)
          {
@@ -1296,7 +1296,7 @@ find_or_create_category(struct console_page* console, char* category_name)
    /* Try to find existing */
    for (int i = 0; i < console->category_count; i++)
    {
-      if (strcmp(console->categories[i].name, category_name) == 0)
+      if (pgmoneta_compare_string(console->categories[i].name, category_name))
       {
          return &console->categories[i];
       }
@@ -1448,7 +1448,7 @@ extract_labels_from_prometheus_attrs(struct prometheus_attributes* attrs, struct
          continue;
       }
 
-      if (strcmp(attr->key, "server") == 0 || strcmp(attr->key, "name") == 0)
+      if (pgmoneta_compare_string(attr->key, "server") || pgmoneta_compare_string(attr->key, "name"))
       {
          free(metric->server);
          metric->server = strdup(attr->value);
@@ -1498,7 +1498,7 @@ add_or_increment_prefix(struct prefix_count** counts, int* size, int* capacity, 
    /* Find existing prefix */
    for (int j = 0; j < *size; j++)
    {
-      if (strcmp((*counts)[j].prefix, prefix) == 0)
+      if (pgmoneta_compare_string((*counts)[j].prefix, prefix))
       {
          found = j;
          break;
@@ -1920,14 +1920,14 @@ collect_simple_label_columns(struct console_category* category, char*** label_ke
             continue;
          }
 
-         if (strcmp(key, "endpoint") == 0)
+         if (pgmoneta_compare_string(key, "endpoint"))
          {
             continue;
          }
 
          for (int i = 0; i < count; i++)
          {
-            if (strcmp(keys[i], key) == 0)
+            if (pgmoneta_compare_string(keys[i], key))
             {
                exists = true;
                break;
@@ -1987,7 +1987,7 @@ find_metric_label_value(struct console_metric* metric, const char* key)
          continue;
       }
 
-      if (strcmp(metric->labels[i].key, key) == 0)
+      if (pgmoneta_compare_string(metric->labels[i].key, key))
       {
          return metric->labels[i].value;
       }

--- a/src/libpgmoneta/extension.c
+++ b/src/libpgmoneta/extension.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -175,7 +175,7 @@ detect_extensions(SSL* ssl, int socket, int server)
                  current->data[0], MISC_LENGTH - 1);
          config->common.servers[server].extensions[extension_idx].name[MISC_LENGTH - 1] = '\0';
 
-         if (!strcmp(current->data[0], "pgmoneta_ext"))
+         if (pgmoneta_compare_string(current->data[0], "pgmoneta_ext"))
          {
             pgmoneta_ext_found = true;
             if (current->data[1] != NULL)
@@ -288,7 +288,7 @@ pgmoneta_detect_server_extensions(int server)
    /* Find and authenticate user for this server */
    for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
    {
-      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      if (pgmoneta_compare_string(config->common.servers[server].username, config->common.users[i].username))
       {
          usr = i;
       }
@@ -499,7 +499,7 @@ pgmoneta_extension_is_installed(int server, const char* extension_name)
 
    for (int i = 0; i < config->common.servers[server].number_of_extensions; i++)
    {
-      if (strcmp(config->common.servers[server].extensions[i].name, extension_name) == 0 &&
+      if (pgmoneta_compare_string(config->common.servers[server].extensions[i].name, extension_name) &&
           config->common.servers[server].extensions[i].enabled)
       {
          return 1;
@@ -523,7 +523,7 @@ pgmoneta_get_extension_info(int server, const char* extension_name)
 
    for (int i = 0; i < config->common.servers[server].number_of_extensions; i++)
    {
-      if (strcmp(config->common.servers[server].extensions[i].name, extension_name) == 0)
+      if (pgmoneta_compare_string(config->common.servers[server].extensions[i].name, extension_name))
       {
          return &config->common.servers[server].extensions[i];
       }

--- a/src/libpgmoneta/fips.c
+++ b/src/libpgmoneta/fips.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -106,7 +106,7 @@ pgmoneta_fips_server(SSL* ssl, int socket, int server, bool* status)
          goto done;
       }
 
-      *status = strcmp(current->data[0], "t") == 0;
+      *status = pgmoneta_compare_string(current->data[0], "t");
    }
    else if (config->common.servers[server].version >= 14)
    {
@@ -130,7 +130,7 @@ pgmoneta_fips_server(SSL* ssl, int socket, int server, bool* status)
          goto done;
       }
 
-      *status = strcmp(current->data[0], "t") == 0;
+      *status = pgmoneta_compare_string(current->data[0], "t");
    }
 
 done:

--- a/src/libpgmoneta/info.c
+++ b/src/libpgmoneta/info.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -93,7 +93,7 @@ pgmoneta_update_info_annotate(int server, struct backup* backup, char* action, c
 
    old_comments = pgmoneta_append(old_comments, backup->comments);
 
-   if (!strcmp("add", action))
+   if (pgmoneta_compare_string("add", action))
    {
       if (old_comments == NULL || strlen(old_comments) == 0)
       {
@@ -154,7 +154,7 @@ pgmoneta_update_info_annotate(int server, struct backup* backup, char* action, c
          free(tokens);
       }
    }
-   else if (!strcmp("update", action))
+   else if (pgmoneta_compare_string("update", action))
    {
       if (old_comments == NULL || strlen(old_comments) == 0)
       {
@@ -212,7 +212,7 @@ pgmoneta_update_info_annotate(int server, struct backup* backup, char* action, c
          }
       }
    }
-   else if (!strcmp("remove", action))
+   else if (pgmoneta_compare_string("remove", action))
    {
       if (old_comments == NULL || strlen(old_comments) == 0)
       {
@@ -273,7 +273,7 @@ pgmoneta_update_info_annotate(int server, struct backup* backup, char* action, c
 
    if (new_comments != NULL)
    {
-      if (!strcmp(new_comments, ",") || pgmoneta_starts_with(new_comments, ","))
+      if (pgmoneta_compare_string(new_comments, ",") || pgmoneta_starts_with(new_comments, ","))
       {
          new_comments = pgmoneta_remove_first(new_comments);
 
@@ -447,7 +447,7 @@ pgmoneta_load_info(char* directory, char* identifier, struct backup** backup)
    assert(strlen(identifier) > 0);
 #endif
 
-   if (!strcmp(identifier, "oldest") || !strcmp(identifier, "newest") || !strcmp(identifier, "latest"))
+   if (pgmoneta_compare_string(identifier, "oldest") || pgmoneta_compare_string(identifier, "newest") || pgmoneta_compare_string(identifier, "latest"))
    {
       int number_of_backups = 0;
       struct backup** backups = NULL;
@@ -462,11 +462,11 @@ pgmoneta_load_info(char* directory, char* identifier, struct backup** backup)
          goto error;
       }
 
-      if (!strcmp(identifier, "oldest"))
+      if (pgmoneta_compare_string(identifier, "oldest"))
       {
          label = pgmoneta_append(label, backups[0]->label);
       }
-      else if (!strcmp(identifier, "latest") || !strcmp(identifier, "newest"))
+      else if (pgmoneta_compare_string(identifier, "latest") || pgmoneta_compare_string(identifier, "newest"))
       {
          label = pgmoneta_append(label, backups[number_of_backups - 1]->label);
       }
@@ -539,13 +539,13 @@ pgmoneta_load_info(char* directory, char* identifier, struct backup** backup)
 
          memcpy(&value[0], ptr, strlen(ptr) - 1);
 
-         if (!strcmp(INFO_PGMONETA_VERSION, &key[0]))
+         if (pgmoneta_compare_string(INFO_PGMONETA_VERSION, &key[0]))
          {
             memcpy(&bck->version[0], &value[0], strlen(&value[0]));
          }
-         else if (!strcmp(INFO_STATUS, &key[0]))
+         else if (pgmoneta_compare_string(INFO_STATUS, &key[0]))
          {
-            if (!strcmp("1", &value[0]))
+            if (pgmoneta_compare_string("1", &value[0]))
             {
                bck->valid = VALID_TRUE;
             }
@@ -554,91 +554,91 @@ pgmoneta_load_info(char* directory, char* identifier, struct backup** backup)
                bck->valid = VALID_FALSE;
             }
          }
-         else if (!strcmp(INFO_LABEL, &key[0]))
+         else if (pgmoneta_compare_string(INFO_LABEL, &key[0]))
          {
             memcpy(&bck->label[0], &value[0], strlen(&value[0]));
          }
-         else if (!strcmp(INFO_WAL, &key[0]))
+         else if (pgmoneta_compare_string(INFO_WAL, &key[0]))
          {
             memcpy(&bck->wal[0], &value[0], strlen(&value[0]));
          }
-         else if (!strcmp(INFO_BACKUP, &key[0]))
+         else if (pgmoneta_compare_string(INFO_BACKUP, &key[0]))
          {
             bck->backup_size = strtoul(&value[0], &ptr, 10);
          }
-         else if (!strcmp(INFO_RESTORE, &key[0]))
+         else if (pgmoneta_compare_string(INFO_RESTORE, &key[0]))
          {
             bck->restore_size = strtoul(&value[0], &ptr, 10);
          }
-         else if (!strcmp(INFO_BIGGEST_FILE, &key[0]))
+         else if (pgmoneta_compare_string(INFO_BIGGEST_FILE, &key[0]))
          {
             bck->biggest_file_size = strtoul(&value[0], &ptr, 10);
          }
-         else if (!strcmp(INFO_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_ELAPSED, &key[0]))
          {
             bck->total_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_BASEBACKUP_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_BASEBACKUP_ELAPSED, &key[0]))
          {
             bck->basebackup_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_HASH_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_HASH_ELAPSED, &key[0]))
          {
             bck->hash_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_MANIFEST_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_MANIFEST_ELAPSED, &key[0]))
          {
             bck->manifest_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_COMPRESSION_ZSTD_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_COMPRESSION_ZSTD_ELAPSED, &key[0]))
          {
             bck->compression_zstd_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_COMPRESSION_BZIP2_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_COMPRESSION_BZIP2_ELAPSED, &key[0]))
          {
             bck->compression_bzip2_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_COMPRESSION_GZIP_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_COMPRESSION_GZIP_ELAPSED, &key[0]))
          {
             bck->compression_gzip_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_COMPRESSION_LZ4_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_COMPRESSION_LZ4_ELAPSED, &key[0]))
          {
             bck->compression_lz4_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_ENCRYPTION_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_ENCRYPTION_ELAPSED, &key[0]))
          {
             bck->encryption_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_LINKING_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_LINKING_ELAPSED, &key[0]))
          {
             bck->linking_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_REMOTE_SSH_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_REMOTE_SSH_ELAPSED, &key[0]))
          {
             bck->remote_ssh_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_REMOTE_AZURE_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_REMOTE_AZURE_ELAPSED, &key[0]))
          {
             bck->remote_azure_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_REMOTE_S3_ELAPSED, &key[0]))
+         else if (pgmoneta_compare_string(INFO_REMOTE_S3_ELAPSED, &key[0]))
          {
             bck->remote_s3_elapsed_time = atof(&value[0]);
          }
-         else if (!strcmp(INFO_MAJOR_VERSION, &key[0]))
+         else if (pgmoneta_compare_string(INFO_MAJOR_VERSION, &key[0]))
          {
             bck->major_version = atoi(&value[0]);
          }
-         else if (!strcmp(INFO_MINOR_VERSION, &key[0]))
+         else if (pgmoneta_compare_string(INFO_MINOR_VERSION, &key[0]))
          {
             bck->minor_version = atoi(&value[0]);
          }
-         else if (!strcmp(INFO_KEEP, &key[0]))
+         else if (pgmoneta_compare_string(INFO_KEEP, &key[0]))
          {
             bck->keep = atoi(&value[0]) == 1 ? true : false;
          }
-         else if (!strcmp(INFO_TABLESPACES, &key[0]))
+         else if (pgmoneta_compare_string(INFO_TABLESPACES, &key[0]))
          {
             bck->number_of_tablespaces = strtoul(&value[0], &ptr, 10);
          }
@@ -911,7 +911,7 @@ pgmoneta_get_backup_child(int server, struct backup* backup, struct backup** chi
 
    for (int j = 0; c_identifier == NULL && j < number_of_backups; j++)
    {
-      if (!strcmp(backup->label, backups[j]->parent_label))
+      if (pgmoneta_compare_string(backup->label, backups[j]->parent_label))
       {
          c_identifier = pgmoneta_append(c_identifier, backups[j]->label);
       }
@@ -998,11 +998,11 @@ pgmoneta_info_request(SSL* ssl, int client_fd, int server,
       goto error;
    }
 
-   if (!strcmp("oldest", identifier))
+   if (pgmoneta_compare_string("oldest", identifier))
    {
       bck = backups[0];
    }
-   else if (!strcmp("newest", identifier) || !strcmp("latest", identifier))
+   else if (pgmoneta_compare_string("newest", identifier) || pgmoneta_compare_string("latest", identifier))
    {
       bck = backups[number_of_backups - 1];
    }
@@ -1010,7 +1010,7 @@ pgmoneta_info_request(SSL* ssl, int client_fd, int server,
    {
       for (int i = 0; bck == NULL && i < number_of_backups; i++)
       {
-         if (!strcmp(backups[i]->label, identifier))
+         if (pgmoneta_compare_string(backups[i]->label, identifier))
          {
             bck = backups[i];
          }
@@ -1191,11 +1191,11 @@ pgmoneta_annotate_request(SSL* ssl, int client_fd, int server, uint8_t compressi
    key = (char*)pgmoneta_json_get(req, MANAGEMENT_ARGUMENT_KEY);
    comment = (char*)pgmoneta_json_get(req, MANAGEMENT_ARGUMENT_COMMENT);
 
-   if (!strcmp("oldest", backup))
+   if (pgmoneta_compare_string("oldest", backup))
    {
       bck = backups[0];
    }
-   else if (!strcmp("newest", backup) || !strcmp("latest", backup))
+   else if (pgmoneta_compare_string("newest", backup) || pgmoneta_compare_string("latest", backup))
    {
       bck = backups[number_of_backups - 1];
    }
@@ -1203,7 +1203,7 @@ pgmoneta_annotate_request(SSL* ssl, int client_fd, int server, uint8_t compressi
    {
       for (int i = 0; bck == NULL && i < number_of_backups; i++)
       {
-         if (!strcmp(backups[i]->label, backup))
+         if (pgmoneta_compare_string(backups[i]->label, backup))
          {
             bck = backups[i];
          }
@@ -1604,7 +1604,7 @@ split_file_path(char* path, char** relative_path, char** bare_file_name)
 
    path_copy = pgmoneta_append(path_copy, path);
 
-   if (path_copy == NULL || !strcmp(path_copy, ".") || !strcmp(path_copy, ".."))
+   if (path_copy == NULL || pgmoneta_compare_string(path_copy, ".") || pgmoneta_compare_string(path_copy, ".."))
    {
       goto error;
    }
@@ -1615,13 +1615,13 @@ split_file_path(char* path, char** relative_path, char** bare_file_name)
    relative_path_len = strlen(rel_path);
 
    /* path is only the filename (doesn't contain any '/') */
-   if (!strcmp(rel_path, "."))
+   if (pgmoneta_compare_string(rel_path, "."))
    {
       file_name = pgmoneta_append(file_name, path);
    }
 
    /* path is the root directory */
-   if (!strcmp(rel_path, "/"))
+   if (pgmoneta_compare_string(rel_path, "/"))
    {
       file_name = pgmoneta_append(file_name, path + relative_path_len);
    }

--- a/src/libpgmoneta/json.c
+++ b/src/libpgmoneta/json.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -180,7 +180,7 @@ pgmoneta_json_locate(struct json_reader* reader, char** key_path, int key_path_l
                goto error;
             }
             // if the cur_key matches current key in path
-            if (!strcmp(cur_key, key))
+            if (pgmoneta_compare_string(cur_key, key))
             {
                if (i == key_path_length - 1)
                {

--- a/src/libpgmoneta/keep.c
+++ b/src/libpgmoneta/keep.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -106,7 +106,7 @@ keep(char* prefix, SSL* ssl, int client_fd, int srv, bool k, uint8_t compression
    backup_id = (char*)pgmoneta_json_get(req, MANAGEMENT_ARGUMENT_BACKUP);
    cascade = (bool)pgmoneta_json_get(req, MANAGEMENT_ARGUMENT_CASCADE);
 
-   if (!strcmp(backup_id, "oldest"))
+   if (pgmoneta_compare_string(backup_id, "oldest"))
    {
       for (int i = 0; backup_index == -1 && i < number_of_backups; i++)
       {
@@ -116,7 +116,7 @@ keep(char* prefix, SSL* ssl, int client_fd, int srv, bool k, uint8_t compression
          }
       }
    }
-   else if (!strcmp(backup_id, "latest") || !strcmp(backup_id, "newest"))
+   else if (pgmoneta_compare_string(backup_id, "latest") || pgmoneta_compare_string(backup_id, "newest"))
    {
       for (int i = number_of_backups - 1; backup_index == -1 && i >= 0; i--)
       {
@@ -130,7 +130,7 @@ keep(char* prefix, SSL* ssl, int client_fd, int srv, bool k, uint8_t compression
    {
       for (int i = 0; backup_index == -1 && i < number_of_backups; i++)
       {
-         if (backups[i] != NULL && !strcmp(backups[i]->label, backup_id))
+         if (backups[i] != NULL && pgmoneta_compare_string(backups[i]->label, backup_id))
          {
             backup_index = i;
          }

--- a/src/libpgmoneta/link.c
+++ b/src/libpgmoneta/link.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -65,7 +65,7 @@ pgmoneta_link_manifest(char* base_from, char* base_to, char* from, struct art* c
 
    while ((entry = readdir(from_dir)))
    {
-      if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
       {
          continue;
       }
@@ -197,7 +197,7 @@ pgmoneta_relink(char* from, char* to, struct workers* workers)
 
    while ((entry = readdir(from_dir)))
    {
-      if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
       {
          continue;
       }
@@ -385,7 +385,7 @@ pgmoneta_link_comparefiles(char* from, char* to, struct workers* workers)
 
    while ((entry = readdir(from_dir)))
    {
-      if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..") || !strcmp(entry->d_name, "data"))
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, "..") || pgmoneta_compare_string(entry->d_name, "data"))
       {
          continue;
       }

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -1139,7 +1139,7 @@ management_response_error_impl(SSL* ssl, int socket, char* server, int32_t error
    {
       for (int i = 0; i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(server, config->common.servers[i].name))
+         if (pgmoneta_compare_string(server, config->common.servers[i].name))
          {
             srv = i;
          }

--- a/src/libpgmoneta/manifest.c
+++ b/src/libpgmoneta/manifest.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -199,7 +199,7 @@ pgmoneta_compare_manifests(char* old_manifest, char* new_manifest, struct art** 
             checksum = (char*)pgmoneta_art_search(tree, iter->tag);
             if (checksum != NULL)
             {
-               if (!strcmp((char*)pgmoneta_value_data(iter->value), checksum))
+               if (pgmoneta_compare_string((char*)pgmoneta_value_data(iter->value), checksum))
                {
                   // not changed but not deleted, remove the entry
                   pgmoneta_deque_iterator_remove(iter);

--- a/src/libpgmoneta/network.c
+++ b/src/libpgmoneta/network.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -67,7 +67,7 @@ pgmoneta_bind(char* hostname, int port, int** fds, int* length)
    int* star_fds = NULL;
    int star_length = 0;
 
-   if (!strcmp("*", hostname))
+   if (pgmoneta_compare_string("*", hostname))
    {
       if (getifaddrs(&ifaddr) == -1)
       {

--- a/src/libpgmoneta/progress.c
+++ b/src/libpgmoneta/progress.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -33,6 +33,7 @@
 #include <info.h>
 #include <logging.h>
 #include <progress.h>
+#include <utils.h>
 #include <workflow.h>
 
 /* system */
@@ -523,43 +524,43 @@ pgmoneta_progress_teardown(int server)
 int
 pgmoneta_progress_phase_from_workflow_name(char* name)
 {
-   if (!strcmp(name, PHASE_NAME_BASEBACKUP) || !strcmp(name, PHASE_NAME_INCREMENTAL_BACKUP))
+   if (pgmoneta_compare_string(name, PHASE_NAME_BASEBACKUP) || pgmoneta_compare_string(name, PHASE_NAME_INCREMENTAL_BACKUP))
    {
       return PHASE_BASEBACKUP;
    }
-   if (!strcmp(name, PHASE_NAME_MANIFEST))
+   if (pgmoneta_compare_string(name, PHASE_NAME_MANIFEST))
    {
       return PHASE_MANIFEST;
    }
-   if (!strcmp(name, PHASE_NAME_SHA512))
+   if (pgmoneta_compare_string(name, PHASE_NAME_SHA512))
    {
       return PHASE_SHA512;
    }
-   if (!strcmp(name, PHASE_NAME_LINK))
+   if (pgmoneta_compare_string(name, PHASE_NAME_LINK))
    {
       return PHASE_LINKING;
    }
-   if (!strcmp(name, PHASE_NAME_ZSTD) || !strcmp(name, PHASE_NAME_GZIP) || !strcmp(name, PHASE_NAME_LZ4) || !strcmp(name, PHASE_NAME_BZIP2))
+   if (pgmoneta_compare_string(name, PHASE_NAME_ZSTD) || pgmoneta_compare_string(name, PHASE_NAME_GZIP) || pgmoneta_compare_string(name, PHASE_NAME_LZ4) || pgmoneta_compare_string(name, PHASE_NAME_BZIP2))
    {
       return PHASE_COMPRESSION;
    }
-   if (!strcmp(name, PHASE_NAME_ENCRYPTION))
+   if (pgmoneta_compare_string(name, PHASE_NAME_ENCRYPTION))
    {
       return PHASE_ENCRYPTION;
    }
-   if (!strcmp(name, PHASE_NAME_DELETE))
+   if (pgmoneta_compare_string(name, PHASE_NAME_DELETE))
    {
       return PHASE_DELETE;
    }
-   if (!strcmp(name, PHASE_NAME_INFO))
+   if (pgmoneta_compare_string(name, PHASE_NAME_INFO))
    {
       return PHASE_INFO;
    }
-   if (!strcmp(name, PHASE_NAME_RESTORE))
+   if (pgmoneta_compare_string(name, PHASE_NAME_RESTORE))
    {
       return PHASE_RESTORE;
    }
-   if (!strcmp(name, PHASE_NAME_VERIFY))
+   if (pgmoneta_compare_string(name, PHASE_NAME_VERIFY))
    {
       return PHASE_VERIFY;
    }

--- a/src/libpgmoneta/prometheus.c
+++ b/src/libpgmoneta/prometheus.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -310,11 +310,11 @@ resolve_page(struct message* msg)
 
    pgmoneta_write_byte(msg->data + index, '\0');
 
-   if (strcmp(from, "/") == 0 || strcmp(from, "/index.html") == 0)
+   if (pgmoneta_compare_string(from, "/") || pgmoneta_compare_string(from, "/index.html"))
    {
       return PAGE_HOME;
    }
-   else if (strcmp(from, "/metrics") == 0)
+   else if (pgmoneta_compare_string(from, "/metrics"))
    {
       return PAGE_METRICS;
    }
@@ -2662,7 +2662,7 @@ general_information(prometheus_metrics_container_t* container)
       for (int j = 0; j < config->common.servers[i].number_of_extensions; j++)
       {
          struct extension_info* ext = &config->common.servers[i].extensions[j];
-         if (strcmp(ext->name, "pgmoneta_ext") == 0)
+         if (pgmoneta_compare_string(ext->name, "pgmoneta_ext"))
          {
             found_pgmoneta_ext = true;
             data = pgmoneta_append(data, "pgmoneta_extension_pgmoneta_ext{");
@@ -4809,7 +4809,7 @@ size_information(prometheus_metrics_container_t* container, int* number_of_backu
       data = pgmoneta_append(data, "\", ");
 
       data = pgmoneta_append(data, "lsn=\"");
-      if (!strcmp(config->common.servers[i].current_wal_lsn, ""))
+      if (pgmoneta_compare_string(config->common.servers[i].current_wal_lsn, ""))
       {
          data = pgmoneta_append(data, "0/0");
       }

--- a/src/libpgmoneta/prometheus_client.c
+++ b/src/libpgmoneta/prometheus_client.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -436,7 +436,7 @@ attributes_contains(struct deque* attributes, struct prometheus_attribute* attri
       {
          struct prometheus_attribute* a = (struct prometheus_attribute*)attributes_iterator->value->data;
 
-         if (!strcmp(a->key, attribute->key) && !strcmp(a->value, attribute->value))
+         if (pgmoneta_compare_string(a->key, attribute->key) && pgmoneta_compare_string(a->value, attribute->value))
          {
             found = true;
          }
@@ -1107,7 +1107,7 @@ parse_body_to_bridge(time_t timestamp, char* body, struct prometheus_bridge* bri
 
    while (line != NULL)
    {
-      if (line[0] == '\0' || !strcmp(line, "\r"))
+      if (line[0] == '\0' || pgmoneta_compare_string(line, "\r"))
       {
          line = strtok_r(NULL, "\n", &saveptr);
          continue;

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -498,7 +498,7 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
             memcpy(&value[0], equal + 1, val_len);
          }
 
-         if (!strcmp(&key[0], "lsn"))
+         if (pgmoneta_compare_string(&key[0], "lsn"))
          {
             if (target_identifier != NULL)
             {
@@ -509,7 +509,7 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
             target_identifier = pgmoneta_append(target_identifier, &value[0]);
             target_count++;
          }
-         else if (!strcmp(&key[0], "time"))
+         else if (pgmoneta_compare_string(&key[0], "time"))
          {
             if (target_identifier != NULL)
             {
@@ -520,19 +520,19 @@ pgmoneta_restore(SSL* ssl, int client_fd, int server, uint8_t compression, uint8
             target_identifier = pgmoneta_append(target_identifier, &value[0]);
             target_count++;
          }
-         else if (!strcmp(&key[0], "current") || !strcmp(&key[0], "immediate"))
+         else if (pgmoneta_compare_string(&key[0], "current") || pgmoneta_compare_string(&key[0], "immediate"))
          {
             target_count++;
          }
-         else if (!strcmp(&key[0], "name"))
+         else if (pgmoneta_compare_string(&key[0], "name"))
          {
             target_count++;
          }
-         else if (!strcmp(&key[0], "xid"))
+         else if (pgmoneta_compare_string(&key[0], "xid"))
          {
             target_count++;
          }
-         else if (!strcmp(&key[0], "timeline"))
+         else if (pgmoneta_compare_string(&key[0], "timeline"))
          {
             /* timeline is a modifier, not a primary target.
              * Save the value for potential backup selection below. */
@@ -776,24 +776,24 @@ pgmoneta_restore_backup(struct art* nodes)
             memcpy(&value[0], equal + 1, strlen(equal) - 1);
          }
 
-         if (!strcmp(&key[0], "current") ||
-             !strcmp(&key[0], "immediate") ||
-             !strcmp(&key[0], "name") ||
-             !strcmp(&key[0], "xid") ||
-             !strcmp(&key[0], "lsn") ||
-             !strcmp(&key[0], "time"))
+         if (pgmoneta_compare_string(&key[0], "current") ||
+             pgmoneta_compare_string(&key[0], "immediate") ||
+             pgmoneta_compare_string(&key[0], "name") ||
+             pgmoneta_compare_string(&key[0], "xid") ||
+             pgmoneta_compare_string(&key[0], "lsn") ||
+             pgmoneta_compare_string(&key[0], "time"))
          {
             copy_wal = true;
          }
-         else if (!strcmp(&key[0], "primary"))
+         else if (pgmoneta_compare_string(&key[0], "primary"))
          {
             primary = true;
          }
-         else if (!strcmp(&key[0], "replica"))
+         else if (pgmoneta_compare_string(&key[0], "replica"))
          {
             primary = false;
          }
-         else if (!strcmp(&key[0], "inclusive") || !strcmp(&key[0], "timeline") || !strcmp(&key[0], "action"))
+         else if (pgmoneta_compare_string(&key[0], "inclusive") || pgmoneta_compare_string(&key[0], "timeline") || pgmoneta_compare_string(&key[0], "action"))
          {
             /* Ok */
          }
@@ -1258,7 +1258,7 @@ pgmoneta_copy_postgresql_restore(char* from, char* to, char* base, char* server,
    {
       while ((entry = readdir(d)))
       {
-         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -1281,7 +1281,7 @@ pgmoneta_copy_postgresql_restore(char* from, char* to, char* base, char* server,
          {
             if (S_ISDIR(statbuf.st_mode))
             {
-               if (!strcmp(entry->d_name, "pg_tblspc"))
+               if (pgmoneta_compare_string(entry->d_name, "pg_tblspc"))
                {
                   copy_tablespaces_restore(from, to, base, server, id, backup, workers);
                }
@@ -1297,7 +1297,7 @@ pgmoneta_copy_postgresql_restore(char* from, char* to, char* base, char* server,
                {
                   for (int i = 0; restore_last_files_names[i] != NULL; i++)
                   {
-                     file_is_excluded = !strcmp(from_buffer, restore_last_files_names[i]);
+                     file_is_excluded = pgmoneta_compare_string(from_buffer, restore_last_files_names[i]);
                   }
                   if (!file_is_excluded)
                   {
@@ -1368,7 +1368,7 @@ pgmoneta_copy_postgresql_hotstandby(int server, char* from, char* to, char* tbls
    {
       while ((entry = readdir(d)))
       {
-         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -1385,7 +1385,7 @@ pgmoneta_copy_postgresql_hotstandby(int server, char* from, char* to, char* tbls
          {
             if (S_ISDIR(statbuf.st_mode))
             {
-               if (!strcmp(entry->d_name, "pg_tblspc"))
+               if (pgmoneta_compare_string(entry->d_name, "pg_tblspc"))
                {
                   copy_tablespaces_hotstandby(server, from, to, tblspc_mappings, backup, workers);
                }
@@ -3039,7 +3039,7 @@ copy_tablespaces_restore(char* from, char* to, char* base, char* server, char* i
          char path[MAX_PATH];
          char* tblspc_name = NULL;
 
-         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -3068,7 +3068,7 @@ copy_tablespaces_restore(char* from, char* to, char* base, char* server, char* i
 
          for (uint64_t i = 0; idx == -1 && i < backup->number_of_tablespaces; i++)
          {
-            if (!strcmp(tblspc_name, backup->tablespaces[i]))
+            if (pgmoneta_compare_string(tblspc_name, backup->tablespaces[i]))
             {
                idx = i;
             }
@@ -3212,7 +3212,7 @@ copy_tablespaces_hotstandby(int server, char* from, char* to, char* tblspc_mappi
                v = strtok(NULL, "->");
                v = pgmoneta_remove_whitespace(v);
 
-               if (!strcmp(k, backup->tablespaces_oids[i]) || !strcmp(k, backup->tablespaces_paths[i]))
+               if (pgmoneta_compare_string(k, backup->tablespaces_oids[i]) || pgmoneta_compare_string(k, backup->tablespaces_paths[i]))
                {
                   dst = pgmoneta_append(dst, v);
                   found = true;

--- a/src/libpgmoneta/se_azure.c
+++ b/src/libpgmoneta/se_azure.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -236,7 +236,7 @@ azure_upload_files(char* local_root, char* azure_root, char* relative_path)
       {
          char relative_dir[1024];
 
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -2665,7 +2665,7 @@ xml_parse_s3_list_truncated(char* xml, bool* is_truncated, char** continuation_t
    if (xml_extract_tag(xml, "IsTruncated", &trunc_values) == 0 && trunc_values != NULL && pgmoneta_deque_size(trunc_values) > 0)
    {
       char* val = (char*)pgmoneta_deque_peek(trunc_values, NULL);
-      if (val != NULL && strcmp(val, "true") == 0)
+      if (val != NULL && pgmoneta_compare_string(val, "true"))
       {
          *is_truncated = true;
       }

--- a/src/libpgmoneta/se_ssh.c
+++ b/src/libpgmoneta/se_ssh.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without
@@ -637,7 +637,7 @@ sftp_copy_directory(char* local_root, char* remote_root, char* relative_path)
       {
          char relative_dir[1024];
 
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -711,7 +711,7 @@ sftp_copy_file(char* local_root, char* remote_root, char* relative_path)
 
       if ((latest_sha256 = (char*)pgmoneta_art_search(tree_map, relative_path)) != NULL)
       {
-         if (!strcmp(latest_sha256, sha256))
+         if (pgmoneta_compare_string(latest_sha256, sha256))
          {
             is_link = true;
          }

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -1769,7 +1769,7 @@ get_admin_password(char* username)
 
    for (int i = 0; i < config->common.number_of_admins; i++)
    {
-      if (!strcmp(&config->common.admins[i].username[0], username))
+      if (pgmoneta_compare_string(&config->common.admins[i].username[0], username))
       {
          return &config->common.admins[i].password[0];
       }
@@ -3021,15 +3021,15 @@ create_hash_file(char* filename, char* algorithm, char** hash)
       goto error;
    }
 
-   if (strcmp("SHA224", algorithm) == 0)
+   if (pgmoneta_compare_string("SHA224", algorithm))
    {
       hash_len = 57;
    }
-   else if (strcmp("SHA256", algorithm) == 0)
+   else if (pgmoneta_compare_string("SHA256", algorithm))
    {
       hash_len = 65;
    }
-   else if (strcmp("SHA384", algorithm) == 0)
+   else if (pgmoneta_compare_string("SHA384", algorithm))
    {
       hash_len = 97;
    }
@@ -3538,15 +3538,15 @@ pgmoneta_hasher_create(char* algorithm, struct hasher** hasher)
       goto error;
    }
 
-   if (strcmp("SHA224", algorithm) == 0)
+   if (pgmoneta_compare_string("SHA224", algorithm))
    {
       hash_len = 57;
    }
-   else if (strcmp("SHA256", algorithm) == 0)
+   else if (pgmoneta_compare_string("SHA256", algorithm))
    {
       hash_len = 65;
    }
-   else if (strcmp("SHA384", algorithm) == 0)
+   else if (pgmoneta_compare_string("SHA384", algorithm))
    {
       hash_len = 97;
    }

--- a/src/libpgmoneta/server.c
+++ b/src/libpgmoneta/server.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -444,7 +444,7 @@ pgmoneta_server_checkpoint(int srv, SSL* ssl, int socket, uint64_t* c_lsn, uint3
       goto error;
    }
 
-   if (!(response->is_command_complete && strcmp(response->tuples->data[0], "CHECKPOINT") == 0))
+   if (!(response->is_command_complete && pgmoneta_compare_string(response->tuples->data[0], "CHECKPOINT")))
    {
       goto error;
    }
@@ -527,7 +527,7 @@ pgmoneta_server_file_stat(int srv, SSL* ssl, int socket, char* relative_file_pat
    }
 
    cell_output = pgmoneta_query_response_get_data(response, 0);
-   if (cell_output == NULL || strcmp(cell_output, "") == 0)
+   if (cell_output == NULL || pgmoneta_compare_string(cell_output, ""))
    {
       goto error;
    }
@@ -537,14 +537,14 @@ pgmoneta_server_file_stat(int srv, SSL* ssl, int socket, char* relative_file_pat
    for (int i = 1; i < 5; i++)
    {
       cell_output = pgmoneta_query_response_get_data(response, i);
-      if (!(cell_output == NULL || strcmp(cell_output, "") == 0))
+      if (!(cell_output == NULL || pgmoneta_compare_string(cell_output, "")))
       {
          strptime(cell_output, "%Y-%m-%d %H:%M:%S", &stat.timetamps[i - 1]);
       }
    }
 
    cell_output = pgmoneta_query_response_get_data(response, 5);
-   if (cell_output == NULL || strcmp(cell_output, "") == 0)
+   if (cell_output == NULL || pgmoneta_compare_string(cell_output, ""))
    {
       goto error;
    }
@@ -933,7 +933,7 @@ q:
 
    pgmoneta_snprintf(&wal_level[0], sizeof(wal_level), "%s", response->tuples->data[0]);
 
-   if (!strcmp("replica", wal_level) || !strcmp("logical", wal_level))
+   if (pgmoneta_compare_string("replica", wal_level) || pgmoneta_compare_string("logical", wal_level))
    {
       *replica = true;
    }
@@ -996,7 +996,7 @@ q:
 
    pgmoneta_snprintf(&data_checksums[0], sizeof(data_checksums), "%s", response->tuples->data[0]);
 
-   if (!strcmp("on", data_checksums))
+   if (pgmoneta_compare_string("on", data_checksums))
    {
       *checksums = true;
    }
@@ -1196,7 +1196,7 @@ q:
 
    pgmoneta_snprintf(&summarize_wal[0], sizeof(summarize_wal), "%s", response->tuples->data[0]);
 
-   if (!strcmp("on", summarize_wal))
+   if (pgmoneta_compare_string("on", summarize_wal))
    {
       *sw = true;
    }
@@ -1298,7 +1298,7 @@ q:
       goto error;
    }
 
-   if (!strcmp(res, "t"))
+   if (pgmoneta_compare_string(res, "t"))
    {
       *has_role = true;
    }
@@ -1365,7 +1365,7 @@ q:
       goto error;
    }
 
-   if (!strcmp(res, "t"))
+   if (pgmoneta_compare_string(res, "t"))
    {
       *is_superuser = true;
    }
@@ -1432,7 +1432,7 @@ q:
       goto error;
    }
 
-   if (!strcmp(res, "t"))
+   if (pgmoneta_compare_string(res, "t"))
    {
       *has_privilege = true;
    }
@@ -1553,27 +1553,27 @@ transform_text_to_label_file_contents(char* text, struct label_file_contents* lf
          value++;
       }
 
-      if (!strcmp(key, "CHECKPOINT LOCATION"))
+      if (pgmoneta_compare_string(key, "CHECKPOINT LOCATION"))
       {
          memcpy(lf->checkpoint_lsn, value, strlen(value) + 1);
       }
-      else if (!strcmp(key, "BACKUP METHOD"))
+      else if (pgmoneta_compare_string(key, "BACKUP METHOD"))
       {
          memcpy(lf->backup_method, value, strlen(value) + 1);
       }
-      else if (!strcmp(key, "BACKUP FROM"))
+      else if (pgmoneta_compare_string(key, "BACKUP FROM"))
       {
          memcpy(lf->backup_from, value, strlen(value) + 1);
       }
-      else if (!strcmp(key, "START TIME"))
+      else if (pgmoneta_compare_string(key, "START TIME"))
       {
          strptime(value, "%Y-%m-%d %H:%M:%S", &lf->start_time);
       }
-      else if (!strcmp(key, "LABEL"))
+      else if (pgmoneta_compare_string(key, "LABEL"))
       {
          memcpy(lf->label, value, strlen(value) + 1);
       }
-      else if (!strcmp(key, "START TIMELINE"))
+      else if (pgmoneta_compare_string(key, "START TIMELINE"))
       {
          lf->start_tli = pgmoneta_atoi(value);
       }
@@ -1624,7 +1624,7 @@ process_server_parameters(int server, struct deque* server_parameters)
    while (pgmoneta_deque_iterator_next(iter))
    {
       pgmoneta_log_debug("%s/process server_parameter '%s'", config->common.servers[server].name, iter->tag);
-      if (!strcmp("server_version", iter->tag))
+      if (pgmoneta_compare_string("server_version", iter->tag))
       {
          char* server_version = pgmoneta_value_to_string(iter->value, FORMAT_TEXT, NULL, 0);
          if (sscanf(server_version, "%d.%d", &major, &minor) == 2)

--- a/src/libpgmoneta/status.c
+++ b/src/libpgmoneta/status.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -573,7 +573,7 @@ pgmoneta_progress(SSL* ssl, int client_fd, uint8_t compression, uint8_t encrypti
 
    for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
    {
-      if (!strcmp(config->common.servers[i].name, server))
+      if (pgmoneta_compare_string(config->common.servers[i].name, server))
       {
          srv = i;
       }

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -176,7 +176,7 @@ pgmoneta_extract_username_database(struct message* msg, char** username, char** 
 
    for (int i = 0; i < counter; i++)
    {
-      if (!strcmp(array[i], "user"))
+      if (pgmoneta_compare_string(array[i], "user"))
       {
          size = strlen(array[i + 1]) + 1;
          un = malloc(size);
@@ -185,7 +185,7 @@ pgmoneta_extract_username_database(struct message* msg, char** username, char** 
 
          *username = un;
       }
-      else if (!strcmp(array[i], "database"))
+      else if (pgmoneta_compare_string(array[i], "database"))
       {
          size = strlen(array[i + 1]) + 1;
          db = malloc(size);
@@ -194,7 +194,7 @@ pgmoneta_extract_username_database(struct message* msg, char** username, char** 
 
          *database = db;
       }
-      else if (!strcmp(array[i], "application_name"))
+      else if (pgmoneta_compare_string(array[i], "application_name"))
       {
          size = strlen(array[i + 1]) + 1;
          an = malloc(size);
@@ -678,7 +678,7 @@ pgmoneta_libev(char* engine)
 
    if (engine)
    {
-      if (!strcmp("select", engine))
+      if (pgmoneta_compare_string("select", engine))
       {
          if (engines & EVBACKEND_SELECT)
          {
@@ -689,7 +689,7 @@ pgmoneta_libev(char* engine)
             pgmoneta_log_warn("libev not available: select");
          }
       }
-      else if (!strcmp("poll", engine))
+      else if (pgmoneta_compare_string("poll", engine))
       {
          if (engines & EVBACKEND_POLL)
          {
@@ -700,7 +700,7 @@ pgmoneta_libev(char* engine)
             pgmoneta_log_warn("libev not available: poll");
          }
       }
-      else if (!strcmp("epoll", engine))
+      else if (pgmoneta_compare_string("epoll", engine))
       {
          if (engines & EVBACKEND_EPOLL)
          {
@@ -711,11 +711,11 @@ pgmoneta_libev(char* engine)
             pgmoneta_log_warn("libev not available: epoll");
          }
       }
-      else if (!strcmp("linuxaio", engine))
+      else if (pgmoneta_compare_string("linuxaio", engine))
       {
          return EVFLAG_AUTO;
       }
-      else if (!strcmp("iouring", engine))
+      else if (pgmoneta_compare_string("iouring", engine))
       {
          if (engines & EVBACKEND_IOURING)
          {
@@ -726,7 +726,7 @@ pgmoneta_libev(char* engine)
             pgmoneta_log_warn("libev not available: iouring");
          }
       }
-      else if (!strcmp("devpoll", engine))
+      else if (pgmoneta_compare_string("devpoll", engine))
       {
          if (engines & EVBACKEND_DEVPOLL)
          {
@@ -737,7 +737,7 @@ pgmoneta_libev(char* engine)
             pgmoneta_log_warn("libev not available: devpoll");
          }
       }
-      else if (!strcmp("port", engine))
+      else if (pgmoneta_compare_string("port", engine))
       {
          if (engines & EVBACKEND_PORT)
          {
@@ -748,7 +748,7 @@ pgmoneta_libev(char* engine)
             pgmoneta_log_warn("libev not available: port");
          }
       }
-      else if (!strcmp("auto", engine) || !strcmp("", engine))
+      else if (pgmoneta_compare_string("auto", engine) || pgmoneta_compare_string("", engine))
       {
          return EVFLAG_AUTO;
       }
@@ -1755,7 +1755,7 @@ pgmoneta_directory_size(char* directory)
       {
          char path[1024];
 
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -1923,7 +1923,7 @@ pgmoneta_get_directories(char* base, int* number_of_directories, char*** dirs)
 
    nod = 0;
 
-   if (base == NULL || !strcmp(base, ""))
+   if (base == NULL || pgmoneta_compare_string(base, ""))
    {
       goto error;
    }
@@ -1937,7 +1937,7 @@ pgmoneta_get_directories(char* base, int* number_of_directories, char*** dirs)
    {
       if (entry->d_type == DT_DIR)
       {
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -1959,7 +1959,7 @@ pgmoneta_get_directories(char* base, int* number_of_directories, char*** dirs)
       {
          if (entry->d_type == DT_DIR)
          {
-            if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
             {
                continue;
             }
@@ -2028,7 +2028,7 @@ pgmoneta_delete_directory(char* path)
       r = 0;
       while (!r && (entry = readdir(d)))
       {
-         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -2138,7 +2138,7 @@ pgmoneta_get_files(uint32_t file_type_mask, char* base, bool recursive, struct d
 
    while ((entry = readdir(dir)) != NULL)
    {
-      if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
       {
          continue;
       }
@@ -2431,7 +2431,7 @@ pgmoneta_copy_directory(char* from, char* to, char** restore_last_files_names, s
    {
       while ((entry = readdir(d)))
       {
-         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -2460,7 +2460,7 @@ pgmoneta_copy_directory(char* from, char* to, char** restore_last_files_names, s
                {
                   for (int i = 0; restore_last_files_names[i] != NULL; i++)
                   {
-                     file_is_excluded = !strcmp(from_buffer, restore_last_files_names[i]);
+                     file_is_excluded = pgmoneta_compare_string(from_buffer, restore_last_files_names[i]);
                   }
                   if (!file_is_excluded)
                   {
@@ -2503,7 +2503,7 @@ pgmoneta_list_directory(char* directory)
    {
       while ((entry = readdir(d)))
       {
-         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -3508,7 +3508,7 @@ pgmoneta_biggest_file(char* directory)
       {
          char path[MAX_PATH];
 
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -3610,7 +3610,7 @@ pgmoneta_ends_with(char* str, char* suffix)
       str_len = strlen(str);
       suffix_len = strlen(suffix);
 
-      return (str_len >= suffix_len) && (strcmp(str + (str_len - suffix_len), suffix) == 0);
+      return (str_len >= suffix_len) && (pgmoneta_compare_string(str + (str_len - suffix_len), suffix));
    }
 
    return false;
@@ -4226,7 +4226,7 @@ pgmoneta_permission_recursive(char* d)
    {
       while ((entry = readdir(dir)))
       {
-         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -5368,7 +5368,7 @@ pgmoneta_backtrace_string(char** s)
          }
 
          buffer[strlen(buffer) - 1] = '\0'; // Remove trailing newline
-         if (strcmp(buffer, "main") == 0)
+         if (pgmoneta_compare_string(buffer, "main"))
          {
             found_main = true;
          }

--- a/src/libpgmoneta/wal.c
+++ b/src/libpgmoneta/wal.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -147,7 +147,7 @@ pgmoneta_wal(int srv, char** argv)
    usr = -1;
    for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
    {
-      if (!strcmp(config->common.servers[srv].username, config->common.users[i].username))
+      if (pgmoneta_compare_string(config->common.servers[srv].username, config->common.users[i].username))
       {
          usr = i;
       }
@@ -1218,7 +1218,7 @@ wal_find_streaming_start(char* basedir, int segsize, uint32_t* timeline, uint32_
       // By latest we mean it has a larger xlogpos. If the xlogpos is the same(unlikely),
       // the one that's not partial is more up-to-date
       is_partial = pgmoneta_ends_with(entry->d_name, ".partial");
-      if (segname == NULL || strcmp(entry->d_name, segname) > 0 || (strcmp(entry->d_name, segname) == 0 && !is_partial))
+      if (segname == NULL || strcmp(entry->d_name, segname) > 0 || (pgmoneta_compare_string(entry->d_name, segname) && !is_partial))
       {
          segname = entry->d_name;
          high_is_partial = is_partial;
@@ -1432,7 +1432,7 @@ pgmoneta_read_mappings_from_server(int server_index)
 
    for (int i = 0; i < config->common.number_of_users; i++)
    {
-      if (strcmp(config->common.users[i].username, config->common.servers[server_index].username) == 0)
+      if (pgmoneta_compare_string(config->common.users[i].username, config->common.servers[server_index].username))
       {
          user_index = i;
          break;
@@ -1681,7 +1681,7 @@ pgmoneta_get_tablespace_oid(char* name, char** oid)
    {
       for (int i = 0; i < mappings_size; i++)
       {
-         if (oidMappings[i].type == OBJ_TABLESPACE && !strcmp(oidMappings[i].name, name))
+         if (oidMappings[i].type == OBJ_TABLESPACE && pgmoneta_compare_string(oidMappings[i].name, name))
          {
             max_digits = pgmoneta_snprintf(NULL, 0, "%d", oidMappings[i].oid) + 1;
             temp_oid = malloc(max_digits);
@@ -1725,7 +1725,7 @@ pgmoneta_get_database_oid(char* name, char** oid)
    {
       for (int i = 0; i < mappings_size; i++)
       {
-         if (oidMappings[i].type == OBJ_DATABASE && !strcmp(oidMappings[i].name, name))
+         if (oidMappings[i].type == OBJ_DATABASE && pgmoneta_compare_string(oidMappings[i].name, name))
          {
             max_digits = pgmoneta_snprintf(NULL, 0, "%d", oidMappings[i].oid) + 1;
             temp_oid = malloc(max_digits);
@@ -1769,7 +1769,7 @@ pgmoneta_get_relation_oid(char* name, char** oid)
    {
       for (int i = 0; i < mappings_size; i++)
       {
-         if (oidMappings[i].type == OBJ_RELATION && !strcmp(oidMappings[i].name, name))
+         if (oidMappings[i].type == OBJ_RELATION && pgmoneta_compare_string(oidMappings[i].name, name))
          {
             max_digits = pgmoneta_snprintf(NULL, 0, "%d", oidMappings[i].oid) + 1;
             temp_oid = malloc(max_digits);

--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -1500,7 +1500,7 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
       backup_str = get_record_block_ref_info(backup_str, record, false, true, &fpi_len, magic_value);
       char* record_desc = pgmoneta_format_and_append(NULL, "%s %s", rm_desc, backup_str);
 
-      if (rm_desc == NULL || !strcmp(rm_desc, ""))
+      if (rm_desc == NULL || pgmoneta_compare_string(rm_desc, ""))
       {
          enhanced_desc = enhance_description(backup_str, record->header.xl_rmid, record->header.xl_info);
       }
@@ -1785,7 +1785,7 @@ is_included(char* rm, struct deque* rms, uint64_t s_lsn, uint64_t start_lsn, uin
 
          v = (char*)pgmoneta_value_data(rms_iter->value);
 
-         if (!strcmp(rm, v))
+         if (pgmoneta_compare_string(rm, v))
          {
             found = true;
          }

--- a/src/libpgmoneta/wf_backup.c
+++ b/src/libpgmoneta/wf_backup.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -157,7 +157,7 @@ basebackup_execute(char* name __attribute__((unused)), struct art* nodes)
    // find the corresponding user's index of the given server
    for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
    {
-      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      if (pgmoneta_compare_string(config->common.servers[server].username, config->common.users[i].username))
       {
          usr = i;
       }
@@ -473,7 +473,7 @@ directory_size_excludes(char* directory, char** excludes)
          char path[1024];
          bool excluded = false;
 
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -482,7 +482,7 @@ directory_size_excludes(char* directory, char** excludes)
          {
             for (int i = 0; excludes[i] != NULL; i++)
             {
-               if (!strcmp(entry->d_name, excludes[i]))
+               if (pgmoneta_compare_string(entry->d_name, excludes[i]))
                {
                   excluded = true;
                   break;

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -259,7 +259,7 @@ incr_backup_execute_14_to_16(char* name __attribute__((unused)), struct art* nod
    // find the corresponding user's index of the given server
    for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
    {
-      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      if (pgmoneta_compare_string(config->common.servers[server].username, config->common.users[i].username))
       {
          usr = i;
       }
@@ -738,7 +738,7 @@ incr_backup_execute_17_plus(char* name __attribute__((unused)), struct art* node
    // find the corresponding user's index of the given server
    for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
    {
-      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      if (pgmoneta_compare_string(config->common.servers[server].username, config->common.users[i].username))
       {
          usr = i;
       }
@@ -1262,7 +1262,7 @@ parse_relation_file(char* backup_data, char* rel_file_path, struct rel_file_loca
       goto error;
    }
 
-   if (!strcmp(results[0], "base"))
+   if (pgmoneta_compare_string(results[0], "base"))
    {
       /*
           Parse the database path
@@ -1286,7 +1286,7 @@ parse_relation_file(char* backup_data, char* rel_file_path, struct rel_file_loca
 
       pgmoneta_mkdir(base_directory_path);
    }
-   else if (!strcmp(results[0], "global"))
+   else if (pgmoneta_compare_string(results[0], "global"))
    {
       rlocator.spcOid = SPCOID_PG_GLOBAL;
       rlocator.dbOid = 0;
@@ -1343,15 +1343,15 @@ parse_relation_file(char* backup_data, char* rel_file_path, struct rel_file_loca
 
    if (count == 2)
    {
-      if (!strcmp(results[1], "fsm"))
+      if (pgmoneta_compare_string(results[1], "fsm"))
       {
          frk = FSM_FORKNUM;
       }
-      else if (!strcmp(results[1], "vm"))
+      else if (pgmoneta_compare_string(results[1], "vm"))
       {
          frk = VISIBILITYMAP_FORKNUM;
       }
-      else if (!strcmp(results[1], "init"))
+      else if (pgmoneta_compare_string(results[1], "init"))
       {
          frk = INIT_FORKNUM;
       }
@@ -1815,7 +1815,7 @@ wait_for_wal_switch(char* wal_dir, char* wal_file)
       while (pgmoneta_deque_iterator_next(it))
       {
          char* file_name = (char*)it->value->data;
-         if (strcmp(file_name, wal_file) == 0)
+         if (pgmoneta_compare_string(file_name, wal_file))
          {
             loop = 0;
          }

--- a/src/libpgmoneta/wf_delete.c
+++ b/src/libpgmoneta/wf_delete.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -134,7 +134,7 @@ delete_backup_execute(char* name __attribute__((unused)), struct art* nodes)
    /* Find backup index */
    for (int i = 0; backup_index == -1 && i < number_of_backups; i++)
    {
-      if (!strcmp(backups[i]->label, label))
+      if (pgmoneta_compare_string(backups[i]->label, label))
       {
          backup_index = i;
       }

--- a/src/libpgmoneta/wf_extra.c
+++ b/src/libpgmoneta/wf_extra.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -128,7 +128,7 @@ extra_execute(char* name __attribute__((unused)), struct art* nodes)
    // find the corresponding user's index of the given server
    for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
    {
-      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      if (pgmoneta_compare_string(config->common.servers[server].username, config->common.users[i].username))
       {
          usr = i;
       }

--- a/src/libpgmoneta/wf_restore.c
+++ b/src/libpgmoneta/wf_restore.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -515,7 +515,7 @@ recovery_info_execute(char* name __attribute__((unused)), struct art* nodes)
                memcpy(&value[0], equal + 1, strlen(equal) - 1);
             }
 
-            if (!strcmp(&key[0], "current") || !strcmp(&key[0], "immediate"))
+            if (pgmoneta_compare_string(&key[0], "current") || pgmoneta_compare_string(&key[0], "immediate"))
             {
                if (!mode)
                {
@@ -526,7 +526,7 @@ recovery_info_execute(char* name __attribute__((unused)), struct art* nodes)
                   mode = true;
                }
             }
-            else if (!strcmp(&key[0], "name"))
+            else if (pgmoneta_compare_string(&key[0], "name"))
             {
                if (!mode)
                {
@@ -537,7 +537,7 @@ recovery_info_execute(char* name __attribute__((unused)), struct art* nodes)
                   mode = true;
                }
             }
-            else if (!strcmp(&key[0], "xid"))
+            else if (pgmoneta_compare_string(&key[0], "xid"))
             {
                if (!mode)
                {
@@ -548,7 +548,7 @@ recovery_info_execute(char* name __attribute__((unused)), struct art* nodes)
                   mode = true;
                }
             }
-            else if (!strcmp(&key[0], "lsn"))
+            else if (pgmoneta_compare_string(&key[0], "lsn"))
             {
                if (!mode)
                {
@@ -559,7 +559,7 @@ recovery_info_execute(char* name __attribute__((unused)), struct art* nodes)
                   mode = true;
                }
             }
-            else if (!strcmp(&key[0], "time"))
+            else if (pgmoneta_compare_string(&key[0], "time"))
             {
                if (!mode)
                {
@@ -570,23 +570,23 @@ recovery_info_execute(char* name __attribute__((unused)), struct art* nodes)
                   mode = true;
                }
             }
-            else if (!strcmp(&key[0], "primary") || !strcmp(&key[0], "replica"))
+            else if (pgmoneta_compare_string(&key[0], "primary") || pgmoneta_compare_string(&key[0], "replica"))
             {
                /* Ok */
             }
-            else if (!strcmp(&key[0], "inclusive"))
+            else if (pgmoneta_compare_string(&key[0], "inclusive"))
             {
                memset(&line[0], 0, sizeof(line));
                pgmoneta_snprintf(&line[0], sizeof(line), "recovery_target_inclusive = %s\n", strlen(value) > 0 ? &value[0] : "on");
                fputs(&line[0], tfile);
             }
-            else if (!strcmp(&key[0], "timeline"))
+            else if (pgmoneta_compare_string(&key[0], "timeline"))
             {
                memset(&line[0], 0, sizeof(line));
                pgmoneta_snprintf(&line[0], sizeof(line), "recovery_target_timeline = \'%s\'\n", strlen(value) > 0 ? &value[0] : "latest");
                fputs(&line[0], tfile);
             }
-            else if (!strcmp(&key[0], "action"))
+            else if (pgmoneta_compare_string(&key[0], "action"))
             {
                memset(&line[0], 0, sizeof(line));
                pgmoneta_snprintf(&line[0], sizeof(line), "recovery_target_action = \'%s\'\n", strlen(value) > 0 ? &value[0] : "pause");
@@ -986,7 +986,7 @@ get_user_password(char* username)
 
    for (int i = 0; i < config->common.number_of_users; i++)
    {
-      if (!strcmp(&config->common.users[i].username[0], username))
+      if (pgmoneta_compare_string(&config->common.users[i].username[0], username))
       {
          return &config->common.users[i].password[0];
       }

--- a/src/libpgmoneta/yaml_utils.c
+++ b/src/libpgmoneta/yaml_utils.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -28,6 +28,7 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <utils.h>
 #include <yaml_utils.h>
 
 /* system */
@@ -107,21 +108,21 @@ pgmoneta_parse_yaml_config(const char* filename, config_t* config)
 
          case YAML_SEQUENCE_START_EVENT:
             if (state == STATE_ROOT && current_key &&
-                strcmp(current_key, "rules") == 0)
+                pgmoneta_compare_string(current_key, "rules"))
             {
                state = STATE_RULES_SEQUENCE;
                free(current_key);
                current_key = NULL;
             }
             else if (state == STATE_RULE_MAPPING && current_key &&
-                     strcmp(current_key, "operations") == 0)
+                     pgmoneta_compare_string(current_key, "operations"))
             {
                state = STATE_OPERATIONS_SEQUENCE;
                free(current_key);
                current_key = NULL;
             }
             else if (state == STATE_RULE_MAPPING && current_key &&
-                     strcmp(current_key, "xids") == 0)
+                     pgmoneta_compare_string(current_key, "xids"))
             {
                state = STATE_XIDS_SEQUENCE;
                free(current_key);
@@ -185,23 +186,23 @@ handle_scalar_event(yaml_event_t* event, parser_state_t* state,
          }
          else
          {
-            if (strcmp(*current_key, "source_dir") == 0)
+            if (pgmoneta_compare_string(*current_key, "source_dir"))
             {
                config->source_dir = strdup(value);
             }
-            else if (strcmp(*current_key, "target_dir") == 0)
+            else if (pgmoneta_compare_string(*current_key, "target_dir"))
             {
                config->target_dir = strdup(value);
             }
-            else if (strcmp(*current_key, "encryption") == 0)
+            else if (pgmoneta_compare_string(*current_key, "encryption"))
             {
                config->encryption = strdup(value);
             }
-            else if (strcmp(*current_key, "compression") == 0)
+            else if (pgmoneta_compare_string(*current_key, "compression"))
             {
                config->compression = strdup(value);
             }
-            else if (strcmp(*current_key, "configuration_file") == 0)
+            else if (pgmoneta_compare_string(*current_key, "configuration_file"))
             {
                config->configuration_file = strdup(value);
             }

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -340,31 +340,31 @@ main(int argc, char** argv)
       {
          break;
       }
-      else if (!strcmp(optname, "c") || !strcmp(optname, "config"))
+      else if (pgmoneta_compare_string(optname, "c") || pgmoneta_compare_string(optname, "config"))
       {
          configuration_path = optarg;
       }
-      else if (!strcmp(optname, "u") || !strcmp(optname, "users"))
+      else if (pgmoneta_compare_string(optname, "u") || pgmoneta_compare_string(optname, "users"))
       {
          users_path = optarg;
       }
-      else if (!strcmp(optname, "A") || !strcmp(optname, "admins"))
+      else if (pgmoneta_compare_string(optname, "A") || pgmoneta_compare_string(optname, "admins"))
       {
          admins_path = optarg;
       }
-      else if (!strcmp(optname, "d") || !strcmp(optname, "daemon"))
+      else if (pgmoneta_compare_string(optname, "d") || pgmoneta_compare_string(optname, "daemon"))
       {
          daemon = true;
       }
-      else if (!strcmp(optname, "D") || !strcmp(optname, "directory"))
+      else if (pgmoneta_compare_string(optname, "D") || pgmoneta_compare_string(optname, "directory"))
       {
          directory_path = optarg;
       }
-      else if (!strcmp(optname, "V") || !strcmp(optname, "version"))
+      else if (pgmoneta_compare_string(optname, "V") || pgmoneta_compare_string(optname, "version"))
       {
          version();
       }
-      else if (!strcmp(optname, "?") || !strcmp(optname, "help"))
+      else if (pgmoneta_compare_string(optname, "?") || pgmoneta_compare_string(optname, "help"))
       {
          usage();
          exit(0);
@@ -405,7 +405,7 @@ main(int argc, char** argv)
 
    if (directory_path != NULL)
    {
-      if (!strcmp(directory_path, "/etc/pgmoneta"))
+      if (pgmoneta_compare_string(directory_path, "/etc/pgmoneta"))
       {
          pgmoneta_log_warn("Using the default configuration directory %s, -D can be omitted.", directory_path);
       }
@@ -1134,7 +1134,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1186,7 +1186,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1227,7 +1227,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1271,7 +1271,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1315,7 +1315,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1357,7 +1357,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1399,7 +1399,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1440,7 +1440,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1481,7 +1481,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1718,7 +1718,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1759,7 +1759,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1926,7 +1926,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -1967,7 +1967,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -2020,7 +2020,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
       srv = -1;
       for (int i = 0; srv == -1 && i < config->common.number_of_servers; i++)
       {
-         if (!strcmp(config->common.servers[i].name, server))
+         if (pgmoneta_compare_string(config->common.servers[i].name, server))
          {
             srv = i;
          }
@@ -2028,7 +2028,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 
       if (srv != -1)
       {
-         if (!strcmp(action, "offline"))
+         if (pgmoneta_compare_string(action, "offline"))
          {
             pgmoneta_server_set_online(srv, false);
 
@@ -2056,7 +2056,7 @@ accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
                goto error;
             }
          }
-         else if (!strcmp(action, "online"))
+         else if (pgmoneta_compare_string(action, "online"))
          {
             pgmoneta_server_set_online(srv, true);
 
@@ -2662,7 +2662,7 @@ valid_cb(struct ev_loop* loop __attribute__((unused)), ev_periodic* w __attribut
 
             for (int j = 0; usr == -1 && j < config->common.number_of_users; j++)
             {
-               if (!strcmp(config->common.servers[i].username, config->common.users[j].username))
+               if (pgmoneta_compare_string(config->common.servers[i].username, config->common.users[j].username))
                {
                   usr = i;
                }
@@ -2731,7 +2731,7 @@ wal_streaming_cb(struct ev_loop* loop __attribute__((unused)), ev_periodic* w __
                for (int j = 0;
                     follow == -1 && j < config->common.number_of_servers; j++)
                {
-                  if (!strcmp(config->common.servers[j].follow, config->common.servers[i].name))
+                  if (pgmoneta_compare_string(config->common.servers[j].follow, config->common.servers[i].name))
                   {
                      follow = j;
                   }
@@ -2751,7 +2751,7 @@ wal_streaming_cb(struct ev_loop* loop __attribute__((unused)), ev_periodic* w __
                for (int j = 0; !start && j < config->common.number_of_servers;
                     j++)
                {
-                  if (!strcmp(config->common.servers[i].follow, config->common.servers[j].name) &&
+                  if (pgmoneta_compare_string(config->common.servers[i].follow, config->common.servers[j].name) &&
                       config->common.servers[j].wal_streaming <= 0)
                   {
                      start = true;
@@ -3015,7 +3015,7 @@ init_replication_slot(int server)
    usr = -1;
    for (int i = 0; usr == -1 && i < config->common.number_of_users; i++)
    {
-      if (!strcmp(config->common.servers[server].username, config->common.users[i].username))
+      if (pgmoneta_compare_string(config->common.servers[server].username, config->common.users[i].username))
       {
          usr = i;
       }

--- a/src/walfilter.c
+++ b/src/walfilter.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -549,7 +549,7 @@ main(int argc, char* argv[])
       {
          break;
       }
-      else if (!strcmp(optname, "c") || !strcmp(optname, "config"))
+      else if (pgmoneta_compare_string(optname, "c") || pgmoneta_compare_string(optname, "config"))
       {
          configuration_path = optarg;
       }
@@ -881,7 +881,7 @@ main(int argc, char* argv[])
    {
       for (int i = 0; i < yaml_config.operation_count; i++)
       {
-         if (!strcmp(yaml_config.operations[i], OPERATION_DELETE))
+         if (pgmoneta_compare_string(yaml_config.operations[i], OPERATION_DELETE))
          {
             if (pgmoneta_filter_operation_delete(&walfile_count, &walfiles))
             {

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2026 The pgmoneta community
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -3906,7 +3906,7 @@ show_wal_file_selector(struct ui_state* state)
       struct dirent* entry;
       while ((entry = readdir(dir)) != NULL)
       {
-         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
          {
             continue;
          }
@@ -4073,7 +4073,7 @@ show_wal_file_selector(struct ui_state* state)
                   char target_dir[MAX_PATH * 2];
                   char* first_wal_path = NULL;
 
-                  if (strcmp(entries[selected].name, "..") == 0)
+                  if (pgmoneta_compare_string(entries[selected].name, ".."))
                   {
                      pgmoneta_snprintf(target_dir, sizeof(target_dir), "%s", current_dir);
 
@@ -4091,7 +4091,7 @@ show_wal_file_selector(struct ui_state* state)
                   {
                      pgmoneta_snprintf(target_dir, sizeof(target_dir), "%s%s%s",
                                        current_dir,
-                                       strcmp(current_dir, "/") == 0 ? "" : "/",
+                                       pgmoneta_compare_string(current_dir, "/") ? "" : "/",
                                        entries[selected].name);
 
                      if (wal_interactive_get_first_wal_path(target_dir, &first_wal_path) == 0)
@@ -4211,7 +4211,7 @@ show_previous_wal_file(struct ui_state* state)
 
    for (int i = 0; i < num_files; i++)
    {
-      if (strcmp(file_list[i], current_basename) == 0)
+      if (pgmoneta_compare_string(file_list[i], current_basename))
       {
          current_index = i;
          break;
@@ -4323,7 +4323,7 @@ show_next_wal_file(struct ui_state* state)
 
    for (int i = 0; i < num_files; i++)
    {
-      if (strcmp(file_list[i], current_basename) == 0)
+      if (pgmoneta_compare_string(file_list[i], current_basename))
       {
          current_index = i;
          break;
@@ -5154,23 +5154,23 @@ main(int argc, char** argv)
       {
          break;
       }
-      else if (!strcmp(optname, "c") || !strcmp(optname, "config"))
+      else if (pgmoneta_compare_string(optname, "c") || pgmoneta_compare_string(optname, "config"))
       {
          configuration_path = optarg;
       }
-      else if (!strcmp(optname, "I") || !strcmp(optname, "interactive"))
+      else if (pgmoneta_compare_string(optname, "I") || pgmoneta_compare_string(optname, "interactive"))
       {
          interactive = true;
       }
-      else if (!strcmp(optname, "o") || !strcmp(optname, "output"))
+      else if (pgmoneta_compare_string(optname, "o") || pgmoneta_compare_string(optname, "output"))
       {
          output = optarg;
       }
-      else if (!strcmp(optname, "F") || !strcmp(optname, "format"))
+      else if (pgmoneta_compare_string(optname, "F") || pgmoneta_compare_string(optname, "format"))
       {
          format = optarg;
 
-         if (!strcmp(format, "json"))
+         if (pgmoneta_compare_string(format, "json"))
          {
             type = ValueJSON;
          }
@@ -5179,17 +5179,17 @@ main(int argc, char** argv)
             type = ValueString;
          }
       }
-      else if (!strcmp(optname, "L") || !strcmp(optname, "logfile"))
+      else if (pgmoneta_compare_string(optname, "L") || pgmoneta_compare_string(optname, "logfile"))
       {
          logfile = optarg;
       }
-      else if (!strcmp(optname, "q") || !strcmp(optname, "quiet"))
+      else if (pgmoneta_compare_string(optname, "q") || pgmoneta_compare_string(optname, "quiet"))
       {
          quiet = true;
       }
-      else if (!strcmp(optname, "color"))
+      else if (pgmoneta_compare_string(optname, "color"))
       {
-         if (!strcmp(optarg, "off"))
+         if (pgmoneta_compare_string(optarg, "off"))
          {
             color = false;
          }
@@ -5198,7 +5198,7 @@ main(int argc, char** argv)
             color = true;
          }
       }
-      else if (!strcmp(optname, "r") || !strcmp(optname, "rmgr"))
+      else if (pgmoneta_compare_string(optname, "r") || pgmoneta_compare_string(optname, "rmgr"))
       {
          if (rms == NULL)
          {
@@ -5210,7 +5210,7 @@ main(int argc, char** argv)
 
          pgmoneta_deque_add(rms, NULL, (uintptr_t)optarg, ValueString);
       }
-      else if (!strcmp(optname, "s") || !strcmp(optname, "start"))
+      else if (pgmoneta_compare_string(optname, "s") || pgmoneta_compare_string(optname, "start"))
       {
          if (strchr(optarg, '/'))
          {
@@ -5230,7 +5230,7 @@ main(int argc, char** argv)
             start_lsn = strtoull(optarg, NULL, 10); // Assuming optarg is a decimal number
          }
       }
-      else if (!strcmp(optname, "e") || !strcmp(optname, "end"))
+      else if (pgmoneta_compare_string(optname, "e") || pgmoneta_compare_string(optname, "end"))
       {
          if (strchr(optarg, '/'))
          {
@@ -5250,7 +5250,7 @@ main(int argc, char** argv)
             end_lsn = strtoull(optarg, NULL, 10); // Assuming optarg is a decimal number
          }
       }
-      else if (!strcmp(optname, "x") || !strcmp(optname, "xid"))
+      else if (pgmoneta_compare_string(optname, "x") || pgmoneta_compare_string(optname, "xid"))
       {
          if (xids == NULL)
          {
@@ -5262,57 +5262,57 @@ main(int argc, char** argv)
 
          pgmoneta_deque_add(xids, NULL, (uintptr_t)pgmoneta_atoi(optarg), ValueUInt32);
       }
-      else if (!strcmp(optname, "l") || !strcmp(optname, "limit"))
+      else if (pgmoneta_compare_string(optname, "l") || pgmoneta_compare_string(optname, "limit"))
       {
          limit = pgmoneta_atoi(optarg);
       }
-      else if (!strcmp(optname, "m") || !strcmp(optname, "mapping"))
+      else if (pgmoneta_compare_string(optname, "m") || pgmoneta_compare_string(optname, "mapping"))
       {
          enable_mapping = true;
          mappings_path = optarg;
       }
-      else if (!strcmp(optname, "t") || !strcmp(optname, "translate"))
+      else if (pgmoneta_compare_string(optname, "t") || pgmoneta_compare_string(optname, "translate"))
       {
          enable_mapping = true;
       }
-      else if (!strcmp(optname, "RT") || !strcmp(optname, "tablespaces"))
+      else if (pgmoneta_compare_string(optname, "RT") || pgmoneta_compare_string(optname, "tablespaces"))
       {
          tablespaces = optarg;
          filtering_enabled = true;
       }
-      else if (!strcmp(optname, "RD") || !strcmp(optname, "databases"))
+      else if (pgmoneta_compare_string(optname, "RD") || pgmoneta_compare_string(optname, "databases"))
       {
          databases = optarg;
          filtering_enabled = true;
       }
-      else if (!strcmp(optname, "RR") || !strcmp(optname, "relations"))
+      else if (pgmoneta_compare_string(optname, "RR") || pgmoneta_compare_string(optname, "relations"))
       {
          relations = optarg;
          filtering_enabled = true;
       }
-      else if (!strcmp(optname, "R") || !strcmp(optname, "filter"))
+      else if (pgmoneta_compare_string(optname, "R") || pgmoneta_compare_string(optname, "filter"))
       {
          filters = optarg;
          filtering_enabled = true;
       }
-      else if (!strcmp(optname, "u") || !strcmp(optname, "users"))
+      else if (pgmoneta_compare_string(optname, "u") || pgmoneta_compare_string(optname, "users"))
       {
          users_path = optarg;
       }
-      else if (!strcmp(optname, "v") || !strcmp(optname, "verbose"))
+      else if (pgmoneta_compare_string(optname, "v") || pgmoneta_compare_string(optname, "verbose"))
       {
          verbose = true;
       }
-      else if (!strcmp(optname, "S") || !strcmp(optname, "summary"))
+      else if (pgmoneta_compare_string(optname, "S") || pgmoneta_compare_string(optname, "summary"))
       {
          summary = true;
       }
-      else if (!strcmp(optname, "V") || !strcmp(optname, "version"))
+      else if (pgmoneta_compare_string(optname, "V") || pgmoneta_compare_string(optname, "version"))
       {
          version();
          exit(0);
       }
-      else if (!strcmp(optname, "?") || !strcmp(optname, "help"))
+      else if (pgmoneta_compare_string(optname, "?") || pgmoneta_compare_string(optname, "help"))
       {
          usage();
          exit(0);


### PR DESCRIPTION
…alityFixes #1151

Replace all strcmp-based string equality checks with pgmoneta_compare_string.

Changes:
- src/cli.c — option parsing and command dispatch
- src/admin.c — option parsing and username matching  
- src/config.c — section and key matching
- src/libpgmoneta/configuration.c — config key/value/section parsing

Note: Ordering comparisons (e.g., strcmp used as boolean for inequality)
were intentionally preserved.
