### PR TITLE
[#1162] Propagate extraction failures to worker outcome deque

### DIFF
--- a/src/include/extraction.h
+++ b/src/include/extraction.h
@@ -29,6 +29,8 @@
 #ifndef PGMONETA_EXTRACTION_H
 #define PGMONETA_EXTRACTION_H
 
+#include <deque.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -49,30 +51,31 @@ extern "C" {
  * @param file_path The source file path
  * @param type The file type bitmask (PGMONETA_FILE_TYPE_*), or 0 for auto-detect
  * @param copy If true, extract to destination path. If false, extract archive to destination directory.
+ * @param failures The failure deque
  * @param destination When copy is true, points to the destination path (updated to final extracted path).
  *                    When copy is false, points to the output directory for extraction (not modified).
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_extract_file(char* file_path, uint32_t type, bool copy, char** destination);
+pgmoneta_extract_file(char* file_path, uint32_t type, bool copy, struct deque* failures, char** destination);
 
 /**
  * Extract a file from a backup to a target location.
  * Wrapper around pgmoneta_extract_file for backup-relative paths.
  *
  * Builds the source path from backup data directory + relative_file_path,
- * and the destination from target_directory (or workspace if NULL) + relative_file_path.
+ * and the destination from workspace/label/ + relative_file_path.
  * Then calls pgmoneta_extract_file(from, 0, true, &to).
  *
  * @param server The server index
  * @param label The backup label
  * @param relative_file_path The file path relative to the backup data directory
- * @param target_directory The target directory (NULL to use workspace/label/)
+ * @param failures The failure deque
  * @param target_file [out] The final extracted file path (caller must free)
  * @return 0 upon success, otherwise 1
  */
 int
-pgmoneta_extract_backup_file(int server, char* label, char* relative_file_path, char* target_directory, char** target_file);
+pgmoneta_extract_backup_file(int server, char* label, char* relative_file_path, struct deque* failures, char** target_file);
 
 #ifdef __cplusplus
 }

--- a/src/include/rfile.h
+++ b/src/include/rfile.h
@@ -33,6 +33,8 @@
 extern "C" {
 #endif
 
+#include <deque.h>
+
 #include <stdint.h>
 #include <stdio.h>
 
@@ -68,11 +70,12 @@ struct rfile
  * @param base_file_name The file name
  * @param encryption The encryption method
  * @param compression The compression method
+ * @param failures The failure deque
  * @param rfile [out] The rfile
  * @return 0 if success, otherwise 1
  */
 int
-pgmoneta_rfile_create(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct rfile** rfile);
+pgmoneta_rfile_create(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct deque* failures, struct rfile** rfile);
 
 /**
  * Destroy the rfile structure
@@ -89,11 +92,12 @@ pgmoneta_rfile_destroy(struct rfile* rf);
  * @param base_file_name The file name
  * @param encryption The encryption method
  * @param compression The compression method
+ * @param failures The failure deque
  * @param rfile [out] The rfile
  * @return 0 if success, otherwise 1
  */
 int
-pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct rfile** rfile);
+pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct deque* failures, struct rfile** rfile);
 
 #ifdef __cplusplus
 }

--- a/src/include/workers.h
+++ b/src/include/workers.h
@@ -37,6 +37,7 @@ extern "C" {
 #include <deque.h>
 
 #include <pthread.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -150,12 +151,12 @@ bool
 pgmoneta_workers_outcome_ok(struct workers* workers);
 
 /**
- * Record a failure message on the workers outcome deque (thread-safe).
- * @param workers The workers
- * @param message Message to append (copied)
+ * Record a formatted failure message into a failure deque (thread-safe).
+ * @param failures The failure deque
+ * @param fmt printf-style format string
  */
 void
-pgmoneta_workers_record_failure(struct workers* workers, char* message);
+pgmoneta_record_failure(struct deque* failures, char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
 /**
  * Log all failure messages collected in the outcome deque.

--- a/src/libpgmoneta/aes.c
+++ b/src/libpgmoneta/aes.c
@@ -299,13 +299,7 @@ do_encrypt_file(struct worker_common* wc)
    else
    {
       pgmoneta_log_warn("do_encrypt_file: %s -> %s", wi->from, wi->to);
-      if (wi->common.workers != NULL)
-      {
-         char* msg = NULL;
-         msg = pgmoneta_format_and_append(msg, "AES encrypt failed: %s", wi->from);
-         pgmoneta_workers_record_failure(wi->common.workers, msg);
-         free(msg);
-      }
+      pgmoneta_record_failure(wi->common.workers != NULL ? wi->common.workers->outcome : NULL, "AES encrypt failed: %s", wi->from);
    }
 
    free(wi);
@@ -667,13 +661,7 @@ do_decrypt_file(struct worker_common* wc)
    else
    {
       pgmoneta_log_warn("do_decrypt_file: %s -> %s", wi->from, wi->to);
-      if (wi->common.workers != NULL)
-      {
-         char* msg = NULL;
-         msg = pgmoneta_format_and_append(msg, "AES decrypt failed: %s", wi->from);
-         pgmoneta_workers_record_failure(wi->common.workers, msg);
-         free(msg);
-      }
+      pgmoneta_record_failure(wi->common.workers != NULL ? wi->common.workers->outcome : NULL, "AES decrypt failed: %s", wi->from);
    }
 
    free(wi);
@@ -2418,14 +2406,10 @@ do_aes_operation(struct worker_common* wc)
       result = pgmoneta_decrypt_file(task->from, task->to, NULL);
    }
 
-   if (result != 0 && task->common.workers != NULL)
+   if (result != 0)
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "AES %s failed: %s",
-                                       task->enc ? "encrypt" : "decrypt",
-                                       task->from);
-      pgmoneta_workers_record_failure(task->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(task->common.workers != NULL ? task->common.workers->outcome : NULL,
+                              "AES %s failed: %s", task->enc ? "encrypt" : "decrypt", task->from);
    }
 
    if (task->progress_enabled)

--- a/src/libpgmoneta/compression.c
+++ b/src/libpgmoneta/compression.c
@@ -329,14 +329,10 @@ do_compression_operation(struct worker_common* wc)
       result = pgmoneta_compress_file(task->from, task->to, task->type, NULL);
    }
 
-   if (result != 0 && task->common.workers != NULL)
+   if (result != 0)
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "%s failed: %s",
-                                       task->decompress ? "Decompress" : "Compress",
-                                       task->from);
-      pgmoneta_workers_record_failure(task->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(task->common.workers != NULL ? task->common.workers->outcome : NULL,
+                              "%s failed: %s", task->decompress ? "Decompress" : "Compress", task->from);
    }
 
    if (task->progress_enabled)

--- a/src/libpgmoneta/extraction.c
+++ b/src/libpgmoneta/extraction.c
@@ -36,6 +36,7 @@
 #include <tar.h>
 #include <utils.h>
 #include <vfile.h>
+#include <workers.h>
 
 #include <libgen.h>
 #include <stdint.h>
@@ -126,10 +127,11 @@ bitmask_to_encryption(uint32_t file_type)
  * @param dst The destination file path (e.g. "file")
  * @param encryption The encryption type (ENCRYPTION_* constant)
  * @param compression The compression type (COMPRESSION_* constant)
+ * @param failures The failure deque
  * @return 0 upon success, otherwise 1
  */
 static int
-stream_restore_file(char* src, char* dst, int encryption, int compression)
+stream_restore_file(char* src, char* dst, int encryption, int compression, struct deque* failures)
 {
    struct streamer* strm = NULL;
    struct vfile* reader = NULL;
@@ -202,6 +204,7 @@ stream_restore_file(char* src, char* dst, int encryption, int compression)
    return 0;
 
 error:
+   pgmoneta_record_failure(failures, "extraction: failed to restore %s", src);
    pgmoneta_vfile_destroy(reader);
    if (!writer_added)
    {
@@ -224,7 +227,7 @@ error:
  *   Simple file copy.
  */
 static int
-extract_file_to_path(char* file_path, uint32_t type, char** destination)
+extract_file_to_path(char* file_path, uint32_t type, struct deque* failures, char** destination)
 {
    char* dest_name = NULL;
    uint32_t file_type = type;
@@ -269,7 +272,7 @@ extract_file_to_path(char* file_path, uint32_t type, char** destination)
    }
 
    /* Stream-restore: decrypt+decompress in one pass, no temp files */
-   if (stream_restore_file(file_path, dest_name, encryption, compression))
+   if (stream_restore_file(file_path, dest_name, encryption, compression, failures))
    {
       goto error;
    }
@@ -294,7 +297,7 @@ error:
  *   3. Clean up temp tar
  */
 static int
-extract_archive_to_directory(char* file_path, uint32_t type, char* destination)
+extract_archive_to_directory(char* file_path, uint32_t type, struct deque* failures, char* destination)
 {
    char* archive_path = NULL;
    bool is_generated_archive = false;
@@ -335,7 +338,7 @@ extract_archive_to_directory(char* file_path, uint32_t type, char* destination)
       is_generated_archive = true;
 
       /* Stream-restore: decrypt+decompress in one pass to temp tar */
-      if (stream_restore_file(file_path, archive_path, encryption, compression))
+      if (stream_restore_file(file_path, archive_path, encryption, compression, failures))
       {
          goto error;
       }
@@ -380,11 +383,11 @@ error:
 }
 
 int
-pgmoneta_extract_file(char* file_path, uint32_t type, bool copy, char** destination)
+pgmoneta_extract_file(char* file_path, uint32_t type, bool copy, struct deque* failures, char** destination)
 {
    if (copy)
    {
-      return extract_file_to_path(file_path, type, destination);
+      return extract_file_to_path(file_path, type, failures, destination);
    }
 
    if (destination == NULL || *destination == NULL)
@@ -392,11 +395,11 @@ pgmoneta_extract_file(char* file_path, uint32_t type, bool copy, char** destinat
       return 1;
    }
 
-   return extract_archive_to_directory(file_path, type, *destination);
+   return extract_archive_to_directory(file_path, type, failures, *destination);
 }
 
 int
-pgmoneta_extract_backup_file(int server, char* label, char* relative_file_path, char* target_directory, char** target_file)
+pgmoneta_extract_backup_file(int server, char* label, char* relative_file_path, struct deque* failures, char** target_file)
 {
    char* from = NULL;
    char* to = NULL;
@@ -425,16 +428,9 @@ pgmoneta_extract_backup_file(int server, char* label, char* relative_file_path, 
       goto error;
    }
 
-   if (target_directory == NULL || strlen(target_directory) == 0)
-   {
-      to = pgmoneta_get_server_workspace(server);
-      to = pgmoneta_append(to, label);
-      to = pgmoneta_append(to, "/");
-   }
-   else
-   {
-      to = pgmoneta_append(to, target_directory);
-   }
+   to = pgmoneta_get_server_workspace(server);
+   to = pgmoneta_append(to, label);
+   to = pgmoneta_append(to, "/");
 
    if (!pgmoneta_ends_with(to, "/"))
    {
@@ -442,8 +438,9 @@ pgmoneta_extract_backup_file(int server, char* label, char* relative_file_path, 
    }
    to = pgmoneta_append(to, relative_file_path);
 
-   if (pgmoneta_extract_file(from, 0, true, &to))
+   if (pgmoneta_extract_file(from, 0, true, failures, &to))
    {
+      pgmoneta_record_failure(failures, "extract_backup_file: failed to extract %s from label %s", relative_file_path, label);
       goto error;
    }
 

--- a/src/libpgmoneta/info.c
+++ b/src/libpgmoneta/info.c
@@ -1504,7 +1504,7 @@ pgmoneta_backup_size(int server, char* label, unsigned long* size, uint64_t* big
             goto error;
          }
 
-         if (pgmoneta_incremental_rfile_initialize(server, label, relative_path, bare_file_name, config->common.encryption, config->compression_type, &rf))
+         if (pgmoneta_incremental_rfile_initialize(server, label, relative_path, bare_file_name, config->common.encryption, config->compression_type, NULL, &rf))
          {
             pgmoneta_log_error("Unable to create rfile %s", bare_file_name);
             goto error;

--- a/src/libpgmoneta/manifest.c
+++ b/src/libpgmoneta/manifest.c
@@ -542,10 +542,7 @@ do_file_manifest(struct worker_common* wc)
 
    if (pgmoneta_get_file_manifest(wi->from, wi->to, &file))
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "Manifest failed: %s", wi->from);
-      pgmoneta_workers_record_failure(wi->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(wi->common.workers->outcome, "Manifest failed: %s", wi->from);
       goto done;
    }
 

--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -139,7 +139,8 @@ reconstruct_backup_file(int server,
                         struct deque* prior_labels,
                         struct art* backups,
                         bool incremental,
-                        struct json* files);
+                        struct json* files,
+                        struct deque* failures);
 
 static void
 do_reconstruct_backup_file(struct worker_common* wc);
@@ -166,6 +167,7 @@ create_reconstruct_backup_file_input(int server,
  * @param relative_dir The directory containing the file relative to the root dir, should be the same across all backups
  * @param file_name The name of the file
  * @param exclude Whether to exclude some of the files
+ * @param failures The failure deque
  * @return 0 on success, 1 if otherwise
  */
 static int
@@ -174,7 +176,8 @@ copy_backup_file(int server,
                  char* output_dir,
                  char* relative_dir,
                  char* file_name,
-                 bool exclude);
+                 bool exclude,
+                 struct deque* failures);
 
 static void
 do_copy_backup_file(struct worker_common* wc);
@@ -1606,7 +1609,8 @@ combine_backups_recursive(uint32_t tsoid,
                                         prior_labels,
                                         backups,
                                         incremental,
-                                        files))
+                                        files,
+                                        workers != NULL ? workers->outcome : NULL))
             {
                pgmoneta_log_error("unable to reconstruct file %s%s", relative_prefix, entry->d_name + INCREMENTAL_PREFIX_LENGTH);
                goto error;
@@ -1631,7 +1635,7 @@ combine_backups_recursive(uint32_t tsoid,
          }
          else
          {
-            if (copy_backup_file(server, label, ofulldir, relative_prefix, entry->d_name, exclude))
+            if (copy_backup_file(server, label, ofulldir, relative_prefix, entry->d_name, exclude, NULL))
             {
                pgmoneta_log_error("unable to copy file %s%s", relative_prefix, entry->d_name);
                goto error;
@@ -1663,7 +1667,8 @@ reconstruct_backup_file(int server,
                         struct deque* prior_labels,
                         struct art* backups,
                         bool incremental,
-                        struct json* files)
+                        struct json* files,
+                        struct deque* failures)
 {
    struct deque* sources = NULL;             // bookkeeping of each incr/full backup rfile, so that we can free them conveniently
    struct deque_iterator* label_iter = NULL; // the iterator for backup directories
@@ -1708,7 +1713,7 @@ reconstruct_backup_file(int server,
    pgmoneta_snprintf(incr_file_name, MAX_PATH, "%s%s", INCREMENTAL_PREFIX, base_file_name);
    // handle the latest file specially, it is the only file that can only be incremental
    bck = (struct backup*)pgmoneta_art_search(backups, label);
-   if (pgmoneta_incremental_rfile_initialize(server, label, relative_dir, incr_file_name, bck->encryption, bck->compression, &latest_source))
+   if (pgmoneta_incremental_rfile_initialize(server, label, relative_dir, incr_file_name, bck->encryption, bck->compression, failures, &latest_source))
    {
       goto error;
    }
@@ -1754,6 +1759,7 @@ reconstruct_backup_file(int server,
    // There could be blocks that cannot be sourced. This is probably because the block gets truncated
    // during the backup process before it gets backed up. In this case just zero fill the block later,
    // the WAL replay will fix the inconsistency since it's getting truncated in the first place.
+
    pgmoneta_deque_iterator_create(prior_labels, &label_iter);
    while (pgmoneta_deque_iterator_next(label_iter))
    {
@@ -1766,10 +1772,12 @@ reconstruct_backup_file(int server,
       // 2. final base name (with compression/encryption suffix, no incremental prefix)
       // 3. base incr name (without compression/encryption suffix, with incremental prefix)
       // 4. final incr name (with compression/encryption suffix, and incremental prefix)
-      if (pgmoneta_rfile_create(server, prior_label, relative_dir, base_file_name, bck->encryption, bck->compression, &rf))
+      if (pgmoneta_rfile_create(server, prior_label, relative_dir, base_file_name, bck->encryption, bck->compression, NULL, &rf))
       {
-         if (pgmoneta_incremental_rfile_initialize(server, prior_label, relative_dir, incr_file_name, bck->encryption, bck->compression, &rf))
+         if (pgmoneta_incremental_rfile_initialize(server, prior_label, relative_dir, incr_file_name, bck->encryption, bck->compression, NULL, &rf))
          {
+            pgmoneta_log_error("reconstruct: unable to find file %s%s in prior backup %s", relative_dir, base_file_name, prior_label);
+            pgmoneta_record_failure(failures, "reconstruct: %s%s missing from prior backup %s", relative_dir, base_file_name, prior_label);
             goto error;
          }
       }
@@ -1900,7 +1908,8 @@ copy_backup_file(int server,
                  char* output_dir,
                  char* relative_dir,
                  char* file_name,
-                 bool exclude)
+                 bool exclude,
+                 struct deque* failures)
 {
    bool excluded = false;
    char ofullpath[MAX_PATH_CONCAT];
@@ -1921,7 +1930,7 @@ copy_backup_file(int server,
    // copy the full file from input dir to output dir
    // extract before copy
    pgmoneta_snprintf(manifest_path, MAX_PATH_CONCAT, "%s%s", relative_dir, file_name);
-   if (pgmoneta_extract_backup_file(server, label, manifest_path, NULL, &extracted_file_path))
+   if (pgmoneta_extract_backup_file(server, label, manifest_path, failures, &extracted_file_path))
    {
       goto error;
    }
@@ -2882,7 +2891,8 @@ static void
 do_reconstruct_backup_file(struct worker_common* wc)
 {
    struct build_backup_file_input* input = (struct build_backup_file_input*)wc;
-   char* msg = NULL;
+   struct workers* workers = input->common.workers;
+   struct deque* failures = workers != NULL ? workers->outcome : NULL;
 
    if (reconstruct_backup_file(input->server,
                                input->label,
@@ -2892,7 +2902,8 @@ do_reconstruct_backup_file(struct worker_common* wc)
                                input->prior_labels,
                                input->backups,
                                input->incremental,
-                               input->files))
+                               input->files,
+                               failures))
    {
       goto error;
    }
@@ -2900,11 +2911,9 @@ do_reconstruct_backup_file(struct worker_common* wc)
    return;
 
 error:
-   pgmoneta_log_error("Unable to construct file %s/%s", input->label, input->relative_dir, input->file_name);
-   msg = pgmoneta_format_and_append(msg, "Reconstruct failed: %s/%s",
-                                    input->relative_dir, input->file_name);
-   pgmoneta_workers_record_failure(input->common.workers, msg);
-   free(msg);
+   pgmoneta_log_error("Unable to construct file %s/%s/%s", input->label, input->relative_dir, input->file_name);
+   pgmoneta_record_failure(failures, "Reconstruct failed: %s/%s",
+                           input->relative_dir, input->file_name);
    free(input);
    return;
 }
@@ -2913,14 +2922,16 @@ static void
 do_copy_backup_file(struct worker_common* wc)
 {
    struct build_backup_file_input* input = (struct build_backup_file_input*)wc;
-   char* msg = NULL;
+   struct workers* workers = input->common.workers;
+   struct deque* failures = workers != NULL ? workers->outcome : NULL;
 
    if (copy_backup_file(input->server,
                         input->label,
                         input->output_dir,
                         input->relative_dir,
                         input->file_name,
-                        input->exclude))
+                        input->exclude,
+                        failures))
    {
       goto error;
    }
@@ -2928,11 +2939,9 @@ do_copy_backup_file(struct worker_common* wc)
    return;
 
 error:
-   pgmoneta_log_error("Unable to construct file %s/%s", input->label, input->relative_dir, input->file_name);
-   msg = pgmoneta_format_and_append(msg, "Copy failed: %s/%s",
-                                    input->relative_dir, input->file_name);
-   pgmoneta_workers_record_failure(input->common.workers, msg);
-   free(msg);
+   pgmoneta_log_error("Unable to construct file %s/%s/%s", input->label, input->relative_dir, input->file_name);
+   pgmoneta_record_failure(failures, "Copy failed: %s/%s",
+                           input->relative_dir, input->file_name);
    free(input);
    return;
 }

--- a/src/libpgmoneta/rfile.c
+++ b/src/libpgmoneta/rfile.c
@@ -34,6 +34,7 @@
 #include <pgmoneta.h>
 #include <rfile.h>
 #include <utils.h>
+#include <workers.h>
 
 /* system */
 #include <stdint.h>
@@ -78,7 +79,7 @@ error:
 }
 
 int
-pgmoneta_rfile_create(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct rfile** rfile)
+pgmoneta_rfile_create(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct deque* failures, struct rfile** rfile)
 {
    struct rfile* rf = NULL;
    char* extracted_file_path = NULL;
@@ -96,14 +97,15 @@ pgmoneta_rfile_create(int server, char* label, char* relative_dir, char* base_fi
       pgmoneta_snprintf(base_relative_path, MAX_PATH, "%s/%s", relative_dir, base_file_name);
    }
 
-   /* try both base and final relative path */
-   if (pgmoneta_extract_backup_file(server, label, base_relative_path, NULL, &extracted_file_path))
+   /* try both base path and suffix-decorated path */
+   if (pgmoneta_extract_backup_file(server, label, base_relative_path, failures, &extracted_file_path))
    {
       free(extracted_file_path);
       extracted_file_path = NULL;
       file_final_name(base_relative_path, encryption, compression, &final_relative_path);
-      if (pgmoneta_extract_backup_file(server, label, final_relative_path, NULL, &extracted_file_path))
+      if (pgmoneta_extract_backup_file(server, label, final_relative_path, failures, &extracted_file_path))
       {
+         pgmoneta_record_failure(failures, "rfile_create: file not found in backup %s: %s/%s", label, relative_dir, base_file_name);
          goto error;
       }
    }
@@ -111,6 +113,7 @@ pgmoneta_rfile_create(int server, char* label, char* relative_dir, char* base_fi
 
    if (fp == NULL)
    {
+      pgmoneta_record_failure(failures, "rfile_create: cannot open extracted file %s (label %s)", extracted_file_path, label);
       goto error;
    }
    rf = (struct rfile*)malloc(sizeof(struct rfile));
@@ -152,7 +155,7 @@ pgmoneta_rfile_destroy(struct rfile* rf)
 }
 
 int
-pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct rfile** rfile)
+pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_dir, char* base_file_name, int encryption, int compression, struct deque* failures, struct rfile** rfile)
 {
    uint32_t magic = 0;
    uint32_t nread = 0;
@@ -166,7 +169,7 @@ pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_di
    relsegsz = config->common.servers[server].relseg_size;
    blocksz = config->common.servers[server].block_size;
 
-   if (pgmoneta_rfile_create(server, label, relative_dir, base_file_name, encryption, compression, &rf))
+   if (pgmoneta_rfile_create(server, label, relative_dir, base_file_name, encryption, compression, failures, &rf))
    {
       pgmoneta_log_error("rfile initialize: failed to open incremental backup (label %s) file at %s/%s", label, relative_dir, base_file_name);
       goto error;
@@ -176,12 +179,14 @@ pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_di
    if (nread != sizeof(uint32_t))
    {
       pgmoneta_log_error("rfile initialize: incomplete file header at %s, cannot read magic number", rf->filepath);
+      pgmoneta_record_failure(failures, "rfile_initialize: corrupt header in %s (label %s) - cannot read magic", rf->filepath, label);
       goto error;
    }
 
    if (magic != INCREMENTAL_MAGIC)
    {
       pgmoneta_log_error("rfile initialize: incorrect magic number, getting %X, expecting %X", magic, INCREMENTAL_MAGIC);
+      pgmoneta_record_failure(failures, "rfile_initialize: bad magic in %s (label %s): got %X expected %X", rf->filepath, label, magic, INCREMENTAL_MAGIC);
       goto error;
    }
 
@@ -189,11 +194,13 @@ pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_di
    if (nread != sizeof(uint32_t))
    {
       pgmoneta_log_error("rfile initialize: incomplete file header at %s%s, cannot read block count", relative_dir, base_file_name);
+      pgmoneta_record_failure(failures, "rfile_initialize: corrupt header in %s/%s (label %s) - cannot read block count", relative_dir, base_file_name, label);
       goto error;
    }
    if (rf->num_blocks > relsegsz)
    {
       pgmoneta_log_error("rfile initialize: file has %d blocks which is more than server's segment size", rf->num_blocks);
+      pgmoneta_record_failure(failures, "rfile_initialize: block count %u > segment size in %s/%s (label %s)", rf->num_blocks, relative_dir, base_file_name, label);
       goto error;
    }
 
@@ -201,11 +208,13 @@ pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_di
    if (nread != sizeof(uint32_t))
    {
       pgmoneta_log_error("rfile initialize: incomplete file header at %s%s, cannot read truncation block length", relative_dir, base_file_name);
+      pgmoneta_record_failure(failures, "rfile_initialize: corrupt header in %s/%s (label %s) - cannot read truncation length", relative_dir, base_file_name, label);
       goto error;
    }
    if (rf->truncation_block_length > relsegsz)
    {
       pgmoneta_log_error("rfile initialize: file has truncation block length of %d which is more than server's segment size", rf->truncation_block_length);
+      pgmoneta_record_failure(failures, "rfile_initialize: truncation length %u > segment size in %s/%s (label %s)", rf->truncation_block_length, relative_dir, base_file_name, label);
       goto error;
    }
 
@@ -216,6 +225,7 @@ pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_di
       if (nread != rf->num_blocks)
       {
          pgmoneta_log_error("rfile initialize: incomplete file header at %s, cannot read relative block numbers", rf->filepath);
+         pgmoneta_record_failure(failures, "rfile_initialize: corrupt header in %s (label %s) - cannot read block numbers", rf->filepath, label);
          goto error;
       }
    }

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -1220,12 +1220,9 @@ do_download_file(struct worker_common* wc)
 {
    struct s3_transfer_task* task = (struct s3_transfer_task*)wc;
 
-   if (s3_download_one_file(task) && task->common.workers != NULL)
+   if (s3_download_one_file(task))
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "S3 download failed: %s", task->remote_path);
-      pgmoneta_workers_record_failure(task->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(task->common.workers != NULL ? task->common.workers->outcome : NULL, "S3 download failed: %s", task->remote_path);
    }
 
    free(task);
@@ -1272,12 +1269,9 @@ do_upload_file(struct worker_common* wc)
 {
    struct s3_transfer_task* task = (struct s3_transfer_task*)wc;
 
-   if (s3_upload_one_file(task) && task->common.workers != NULL)
+   if (s3_upload_one_file(task))
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "S3 upload failed: %s", task->remote_path);
-      pgmoneta_workers_record_failure(task->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(task->common.workers != NULL ? task->common.workers->outcome : NULL, "S3 upload failed: %s", task->remote_path);
    }
 
    free(task);

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -2845,13 +2845,7 @@ error:
 
    errno = 0;
 
-   if (fi->common.workers != NULL)
-   {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "File copy failed: %s", fi->from);
-      pgmoneta_workers_record_failure(fi->common.workers, msg);
-      free(msg);
-   }
+   pgmoneta_record_failure(fi->common.workers != NULL ? fi->common.workers->outcome : NULL, "File copy failed: %s", fi->from);
 
    free(dn);
    free(from);

--- a/src/libpgmoneta/walfile/wal_summary.c
+++ b/src/libpgmoneta/walfile/wal_summary.c
@@ -200,7 +200,7 @@ summarize_walfile(char* path, uint64_t start_lsn, uint64_t end_lsn, block_ref_ta
    to = pgmoneta_append(to, "/tmp/");
    to = pgmoneta_append(to, basename(path));
 
-   if (pgmoneta_extract_file(from, 0, true, &to))
+   if (pgmoneta_extract_file(from, 0, true, NULL, &to))
    {
       pgmoneta_log_error("Failed to extract WAL file from %s to %s", from, to);
       goto error;

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -1755,7 +1755,7 @@ copy_wal_from_archive(char* start_wal_file, char* wal_dir, char* backup_data)
          }
 
          // copy and extract
-         if (pgmoneta_extract_file(src_file, 0, true, &dst_file))
+         if (pgmoneta_extract_file(src_file, 0, true, NULL, &dst_file))
          {
             goto error;
          }

--- a/src/libpgmoneta/wf_restore.c
+++ b/src/libpgmoneta/wf_restore.c
@@ -858,7 +858,7 @@ restore_excluded_files_execute(char* name __attribute__((unused)), struct art* n
 
       pgmoneta_log_trace("Excluded: %s -> %s", from_file, to_file);
 
-      if (pgmoneta_extract_file(from_file, 0, true, &to_file))
+      if (pgmoneta_extract_file(from_file, 0, true, NULL, &to_file))
       {
          pgmoneta_log_error("Restore: Could not copy file %s to %s", from_file, to_file);
          free(from_file);

--- a/src/libpgmoneta/wf_sha256.c
+++ b/src/libpgmoneta/wf_sha256.c
@@ -214,19 +214,13 @@ do_sha256(struct worker_common* wc)
 
    if (pgmoneta_create_sha256_file(wi->from, &sha256))
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "SHA256 failed: %s", wi->from);
-      pgmoneta_workers_record_failure(wi->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(wi->common.workers->outcome, "SHA256 failed: %s", wi->from);
       goto done;
    }
 
    if (pgmoneta_json_create(&result))
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "SHA256 allocation failed: %s", wi->from);
-      pgmoneta_workers_record_failure(wi->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(wi->common.workers->outcome, "SHA256 allocation failed: %s", wi->from);
       goto done;
    }
 

--- a/src/libpgmoneta/wf_sha512.c
+++ b/src/libpgmoneta/wf_sha512.c
@@ -252,20 +252,14 @@ do_sha512(struct worker_common* wc)
 
    if (pgmoneta_create_sha512_file(wi->from, &sha512))
    {
-      char* msg = NULL;
       pgmoneta_log_error("SHA512 failed for file: %s", wi->from);
-      msg = pgmoneta_format_and_append(msg, "SHA512 failed: %s", wi->from);
-      pgmoneta_workers_record_failure(wi->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(wi->common.workers->outcome, "SHA512 failed: %s", wi->from);
       goto done;
    }
 
    if (pgmoneta_json_create(&result))
    {
-      char* msg = NULL;
-      msg = pgmoneta_format_and_append(msg, "SHA512 allocation failed: %s", wi->from);
-      pgmoneta_workers_record_failure(wi->common.workers, msg);
-      free(msg);
+      pgmoneta_record_failure(wi->common.workers->outcome, "SHA512 allocation failed: %s", wi->from);
       goto done;
    }
 

--- a/src/libpgmoneta/workers.c
+++ b/src/libpgmoneta/workers.c
@@ -157,14 +157,33 @@ pgmoneta_workers_outcome_ok(struct workers* workers)
 }
 
 void
-pgmoneta_workers_record_failure(struct workers* workers, char* message)
+pgmoneta_record_failure(struct deque* failures, char* fmt, ...)
 {
-   if (workers == NULL || workers->outcome == NULL || message == NULL)
+   char* msg = NULL;
+   va_list ap;
+   int size_needed;
+
+   if (failures == NULL || fmt == NULL)
    {
       return;
    }
 
-   pgmoneta_deque_add(workers->outcome, NULL, (uintptr_t)message, ValueString);
+   va_start(ap, fmt);
+   size_needed = vsnprintf(NULL, 0, fmt, ap) + 1;
+   va_end(ap);
+
+   msg = malloc(size_needed);
+   if (msg == NULL)
+   {
+      return;
+   }
+
+   va_start(ap, fmt);
+   vsnprintf(msg, size_needed, fmt, ap);
+   va_end(ap);
+
+   pgmoneta_deque_add(failures, NULL, (uintptr_t)msg, ValueString);
+   free(msg);
 }
 
 void

--- a/src/walfilter.c
+++ b/src/walfilter.c
@@ -776,7 +776,7 @@ main(int argc, char* argv[])
             continue;
          }
 
-         if (pgmoneta_extract_file(tar_archive_copy, 0, false, &tar_temp_dir))
+         if (pgmoneta_extract_file(tar_archive_copy, 0, false, NULL, &tar_temp_dir))
          {
             pgmoneta_log_error("Failed to extract TAR archive: %s", current_file);
             free(tar_archive_copy);
@@ -850,7 +850,7 @@ main(int argc, char* argv[])
          tmp_wal = NULL;
          tmp_wal = pgmoneta_format_and_append(tmp_wal, "/tmp/%s", basename(wal_path));
 
-         if (pgmoneta_extract_file(wal_path, 0, true, &tmp_wal))
+         if (pgmoneta_extract_file(wal_path, 0, true, NULL, &tmp_wal))
          {
             pgmoneta_log_fatal("Failed to extract WAL file at %s", file_path);
             goto error;

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -1034,7 +1034,7 @@ wal_interactive_load_records(struct ui_state* state, char* wal_filename)
    to = pgmoneta_append(to, "/tmp/");
    to = pgmoneta_append(to, basename((char*)wal_filename));
 
-   if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, &to))
+   if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, NULL, &to))
    {
       free(from);
       free(to);
@@ -1889,7 +1889,7 @@ wal_search(struct ui_state* state, struct wal_search_criteria* criteria)
       to = pgmoneta_append(NULL, "/tmp/");
       to = pgmoneta_append(to, filename);
 
-      if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, &to) != 0)
+      if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, NULL, &to) != 0)
       {
          pgmoneta_log_error("Failed to extract file: %s", filename);
          goto cleanup_iteration;
@@ -6006,7 +6006,7 @@ describe_walfile_internal(char* path, enum value_type type, FILE* out, bool quie
    to = pgmoneta_append(to, "/tmp/");
    to = pgmoneta_append(to, basename(path));
 
-   if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, &to))
+   if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, NULL, &to))
    {
       pgmoneta_log_error("Failed to extract WAL file from %s to %s", from, to);
       goto error;
@@ -6133,7 +6133,7 @@ describe_walfiles_in_directory(char* dir_path, enum value_type type, FILE* outpu
          to = pgmoneta_append(to, "/tmp/");
          to = pgmoneta_append(to, basename(file_path));
 
-         if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, &to))
+         if (pgmoneta_extract_file(from, PGMONETA_FILE_TYPE_UNKNOWN, true, NULL, &to))
          {
             free(from);
             free(to);
@@ -6262,7 +6262,7 @@ prepare_wal_files_from_tar_archive(char* path, char** temp_dir, struct deque** w
       goto error;
    }
 
-   if (pgmoneta_extract_file(archive_copy_path, PGMONETA_FILE_TYPE_UNKNOWN, false, &local_temp_dir))
+   if (pgmoneta_extract_file(archive_copy_path, PGMONETA_FILE_TYPE_UNKNOWN, false, NULL, &local_temp_dir))
    {
       pgmoneta_log_error("Failed to extract TAR archive: %s", path);
       goto error;

--- a/test/testcases/test_extraction.c
+++ b/test/testcases/test_extraction.c
@@ -301,7 +301,7 @@ MCTF_TEST(test_extraction_layered_archive)
    file_type = pgmoneta_extraction_get_file_type(encrypted_path);
    {
       char* dest = out_dir;
-      MCTF_ASSERT_INT_EQ(pgmoneta_extract_file(encrypted_path, file_type, false, &dest), 0, cleanup, "extract_file failed");
+      MCTF_ASSERT_INT_EQ(pgmoneta_extract_file(encrypted_path, file_type, false, NULL, &dest), 0, cleanup, "extract_file failed");
    }
    MCTF_ASSERT(pgmoneta_exists(extracted_path), cleanup, "extracted WAL file missing");
 

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -1551,7 +1551,7 @@ MCTF_TEST(test_utils_files_advanced)
 
    to_ptr = strdup(file_dst);
    MCTF_ASSERT_PTR_NONNULL(to_ptr, cleanup, "strdup failed");
-   MCTF_ASSERT_INT_EQ(pgmoneta_extract_file(file_src, 0, true, &to_ptr), 0, cleanup, "extract_file copy failed");
+   MCTF_ASSERT_INT_EQ(pgmoneta_extract_file(file_src, 0, true, NULL, &to_ptr), 0, cleanup, "extract_file copy failed");
    MCTF_ASSERT(pgmoneta_exists(file_dst), cleanup, "copied file should exist");
    free(to_ptr);
    to_ptr = NULL;


### PR DESCRIPTION
- closes #1162

this pr adds an optional workers handle to the extraction and rfile interfaces so extraction failures can be recorded in the worker outcome and reported to the user,

example result: 

```
Outcome:
  Error: 107
  Status: false
  WorkerErrors:
    - File copy failed: /tmp/pgmoneta-test/base/backup/primary/backup/20260605003432/data/global/pg_control
    - File copy failed: /tmp/pgmoneta-test/base/backup/primary/backup/20260605003432/data/pg_wal/archive_status/000000010000000000000007.done
  Workflow: Hot standby
Request:
```