### PR TITLE
[#1070]feat(s3): add S3 metadata verification and scheduled verify integration

### DIFF
--- a/src/include/storage.h
+++ b/src/include/storage.h
@@ -35,6 +35,7 @@ extern "C" {
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <info.h>
 #include <workflow.h>
 
 /* system */
@@ -73,6 +74,20 @@ pgmoneta_storage_create_s3(int workflow_type);
 */
 int
 pgmoneta_storage_list_backup_labels(int server, struct deque** labels);
+
+/**
+ * Verify a backup label in the configured storage engine.
+ *
+ * This is backend-specific scheduled verification, not necessarily full
+ * file-content verification. For S3 this verifies metadata integrity and
+ * manifest-listed object presence without downloading data objects.
+ *
+ * @param server The server index
+ * @param backup_info The backup info
+ * @return 0 on success, otherwise 1
+*/
+int
+pgmoneta_storage_verify_backup(int server, struct backup* backup_info);
 
 /**
  * Create a workflow for the Azure storage engine

--- a/src/include/verify.h
+++ b/src/include/verify.h
@@ -35,6 +35,7 @@ extern "C" {
 
 #include <pgmoneta.h>
 #include <json.h>
+#include <storage.h>
 
 #include <stdlib.h>
 

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -48,6 +48,7 @@
 #include <assert.h>
 #include <dirent.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -71,6 +72,7 @@ static int s3_list_objects(char* relative_path, char* s3_list, int server, bool 
 static int s3_delete_all_objects(char* relative_path, char* s3_list, int server, struct art*) __attribute__((unused));
 static int s3_send_list_request(char* relative_path, char* s3_list, int server, char* continuationToken, bool common_prefixes, struct http_response** response);
 static int s3_list_backup_prefixes(int server, struct deque** labels);
+static int s3_verify_backup(int server, struct backup* backup_info);
 
 static int s3_send_delete_request(char* relative_path, char* s3_list, int server, char* xml_body, struct http_response** response);
 static int s3_send_get_request(char* relative_path, char* s3_root, int server, long range_start, long range_end, struct http_response** response);
@@ -179,8 +181,20 @@ pgmoneta_storage_list_backup_labels(int server, struct deque** labels)
    {
       return s3_list_backup_prefixes(server, labels);
    }
-   // it does not support listing
-   return 1;
+   return 0;
+}
+
+int
+pgmoneta_storage_verify_backup(int server, struct backup* backup_info)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   if (config->storage_engine & STORAGE_ENGINE_S3)
+   {
+      return s3_verify_backup(server, backup_info);
+   }
+
+   return 0;
 }
 
 static char*
@@ -593,6 +607,196 @@ error:
    free(s3_root);
    return 1;
 }
+
+static int
+s3_verify_backup(int server, struct backup* backup_info)
+{
+   char* s3_root = NULL;
+   char* local_root = NULL;
+   char* manifest_tmp = NULL;
+   char* sha512_tmp = NULL;
+   char* info_tmp = NULL;
+   char* suffix = NULL;
+   struct deque* paths = NULL;
+   struct deque* objects = NULL;
+   struct deque_iterator* iter = NULL;
+   struct art* remote = NULL;
+
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   pgmoneta_log_debug("S3 storage engine (verify): %s/%s",
+                      config->common.servers[server].name, backup_info->label);
+   pgmoneta_log_debug("S3 effective config: bucket=%s, region=%s, endpoint=%s",
+                      s3_get_effective_bucket(server),
+                      s3_get_effective_region(server),
+                      s3_get_effective_endpoint(server));
+
+   s3_root = s3_get_basepath(server, backup_info->label);
+   local_root = pgmoneta_get_server_backup_identifier(server, backup_info->label);
+
+   if (s3_bootstrap(s3_root, server, local_root))
+   {
+      pgmoneta_log_error("S3 verify: failed to bootstrap");
+      goto error;
+   }
+   if (pgmoneta_extraction_get_suffix(backup_info->compression, backup_info->encryption, &suffix))
+   {
+      pgmoneta_log_error("S3 verify: failed to get suffix");
+      goto error;
+   }
+
+   info_tmp = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.info.tmp");
+   manifest_tmp = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.manifest.tmp");
+   sha512_tmp = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.sha512.tmp");
+
+   // load the manifest temp file
+   if (pgmoneta_manifest_get_paths(manifest_tmp, &paths))
+   {
+      pgmoneta_log_error("S3 verify: failed to read manifest %s", manifest_tmp);
+      goto error;
+   }
+
+   if (s3_list_objects("", s3_root, server, false, &objects))
+   {
+      pgmoneta_log_error("S3 verify: failed to list objects");
+      goto error;
+   }
+   if (pgmoneta_art_create(&remote))
+   {
+      pgmoneta_log_error("S3 verify: failed to create art");
+      goto error;
+   }
+
+   if (pgmoneta_deque_iterator_create(objects, &iter))
+   {
+      pgmoneta_log_error("S3 verify: failed to create iterator");
+      goto error;
+   }
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      char* key = (char*)pgmoneta_value_data(iter->value);
+      pgmoneta_art_insert(remote, key, (uintptr_t)true, ValueBool);
+   }
+   pgmoneta_deque_iterator_destroy(iter);
+   iter = NULL;
+   if (pgmoneta_deque_iterator_create(paths, &iter))
+   {
+      pgmoneta_log_error("S3 verify: failed to create iterator local paths");
+      goto error;
+   }
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      char* file_path = iter->tag;
+      char* expected = NULL;
+      char* key_root = s3_root;
+      if (strlen(s3_get_effective_endpoint(server)) > 0)
+      {
+         char* slash = strchr(s3_root, '/');
+         if (slash != NULL)
+            key_root = slash + 1;
+      }
+
+      expected = pgmoneta_append(expected, key_root);
+      if (!pgmoneta_ends_with(expected, "/"))
+      {
+         expected = pgmoneta_append_char(expected, '/');
+      }
+      expected = pgmoneta_append(expected, "data/");
+      expected = pgmoneta_append(expected, file_path);
+      if (suffix != NULL &&
+          !pgmoneta_ends_with(file_path, "backup_label") &&
+          !pgmoneta_ends_with(file_path, "backup_manifest"))
+      {
+         expected = pgmoneta_append(expected, suffix);
+      }
+
+      if (!pgmoneta_art_contains_key(remote, expected))
+      {
+         pgmoneta_log_error("S3 verify: missing object %s", expected);
+         free(expected);
+         goto error;
+      }
+
+      free(expected);
+   }
+   // check the files in the mainfest against the one in the backupe
+
+   if (pgmoneta_delete_file(info_tmp, NULL))
+   {
+      pgmoneta_log_error("Failed to delete info file");
+      goto error;
+   }
+   if (pgmoneta_delete_file(manifest_tmp, NULL))
+   {
+      pgmoneta_log_error("Failed to delete manifest file");
+      goto error;
+   }
+   if (pgmoneta_delete_file(sha512_tmp, NULL))
+   {
+      pgmoneta_log_error("Failed to delete sha512 file");
+      goto error;
+   }
+
+   pgmoneta_log_info("S3 verify: %s/%s completed", config->common.servers[server].name, backup_info->label);
+
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(paths);
+   pgmoneta_deque_destroy(objects);
+   pgmoneta_art_destroy(remote);
+   free(s3_root);
+   free(local_root);
+   free(manifest_tmp);
+   free(sha512_tmp);
+   free(info_tmp);
+   free(suffix);
+
+   return 0;
+
+error:
+
+   if (local_root != NULL)
+   {
+      char* cleanup = NULL;
+
+      cleanup = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.manifest.tmp");
+      if (pgmoneta_exists(cleanup))
+      {
+         pgmoneta_delete_file(cleanup, NULL);
+      }
+      free(cleanup);
+
+      cleanup = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.sha512.tmp");
+      if (pgmoneta_exists(cleanup))
+      {
+         pgmoneta_delete_file(cleanup, NULL);
+      }
+      free(cleanup);
+
+      cleanup = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.info.tmp");
+      if (pgmoneta_exists(cleanup))
+      {
+         pgmoneta_delete_file(cleanup, NULL);
+      }
+      free(cleanup);
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(paths);
+   pgmoneta_deque_destroy(objects);
+   pgmoneta_art_destroy(remote);
+   free(s3_root);
+   free(local_root);
+   free(manifest_tmp);
+   free(sha512_tmp);
+   free(info_tmp);
+   free(suffix);
+
+   return 1;
+}
+
 static int
 s3_storage_restore(char* name __attribute__((unused)), struct art* nodes)
 {
@@ -1822,6 +2026,7 @@ s3_send_list_request(char* relative_path, char* s3_root, int server, char* conti
    char* s3_path = NULL;
    char* request_path = NULL;
    char* query_string = NULL;
+   char* body_hash = NULL;
    char* canonical_uri = NULL;
    struct deque* sign_headers = NULL;
    struct http* connection = NULL;
@@ -1864,25 +2069,40 @@ s3_send_list_request(char* relative_path, char* s3_root, int server, char* conti
       goto error;
    }
 
+   if (pgmoneta_generate_string_sha256_hash("", &body_hash))
+   {
+      goto error;
+   }
+
    s3_host = s3_get_host(server);
+
+   // Build query string with parameters in lexicographic order
+   // Required order: continuation-token, delimiter, list-type, prefix
 
    if (continuationToken != NULL)
    {
       char* encoded_token = s3_url_encode(continuationToken);
       query_string = pgmoneta_append(query_string, "continuation-token=");
       query_string = pgmoneta_append(query_string, encoded_token);
-      query_string = pgmoneta_append(query_string, "&");
       free(encoded_token);
    }
+
+   if (common_prefixes)
+   {
+      if (query_string != NULL)
+      {
+         query_string = pgmoneta_append(query_string, "&");
+      }
+      query_string = pgmoneta_append(query_string, "delimiter=%2F");
+   }
+
+   if (query_string != NULL)
+      query_string = pgmoneta_append(query_string, "&");
+
    char* encoded_prefix = s3_url_encode(prefix);
    query_string = pgmoneta_append(query_string, "list-type=2&prefix=");
    query_string = pgmoneta_append(query_string, encoded_prefix);
    free(encoded_prefix);
-   if (common_prefixes)
-   {
-      query_string = pgmoneta_append(query_string, "&delimiter=%2F");
-   }
-
    /* Build canonical URI */
    canonical_uri = pgmoneta_append(canonical_uri, "/");
    if (path_style)
@@ -1896,11 +2116,11 @@ s3_send_list_request(char* relative_path, char* s3_root, int server, char* conti
       goto error;
    }
    pgmoneta_deque_add(sign_headers, "host", (uintptr_t)s3_host, ValueStringRef);
-   pgmoneta_deque_add(sign_headers, "x-amz-content-sha256", (uintptr_t)"UNSIGNED-PAYLOAD", ValueStringRef);
+   pgmoneta_deque_add(sign_headers, "x-amz-content-sha256", (uintptr_t)body_hash, ValueStringRef);
    pgmoneta_deque_add(sign_headers, "x-amz-date", (uintptr_t)long_date, ValueStringRef);
 
    if (s3_sign_request("GET", canonical_uri, query_string,
-                       sign_headers, "UNSIGNED-PAYLOAD",
+                       sign_headers, body_hash,
                        effective_access_key_id, effective_secret_access_key, effective_region,
                        short_date, long_date, &auth_value))
    {
@@ -1973,6 +2193,7 @@ s3_send_list_request(char* relative_path, char* s3_root, int server, char* conti
    free(s3_path);
    free(auth_value);
    free(query_string);
+   free(body_hash);
    free(canonical_uri);
    pgmoneta_deque_destroy(sign_headers);
    pgmoneta_http_request_destroy(request);
@@ -1987,6 +2208,7 @@ error:
    free(s3_path);
    free(auth_value);
    free(query_string);
+   free(body_hash);
    free(canonical_uri);
    pgmoneta_deque_destroy(sign_headers);
 

--- a/src/libpgmoneta/verify.c
+++ b/src/libpgmoneta/verify.c
@@ -28,12 +28,15 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <art.h>
 #include <backup.h>
+#include <deque.h>
 #include <info.h>
 #include <logging.h>
 #include <management.h>
 #include <network.h>
 #include <security.h>
+#include <storage.h>
 #include <utils.h>
 #include <workflow.h>
 
@@ -320,6 +323,8 @@ pgmoneta_sha512_verification(char** argv)
    char* backup_dir = NULL;
    int number_of_backups = 0;
    struct backup** backups = NULL;
+   struct deque* labels = NULL;
+   struct art* s3_labels = NULL;
    char* sha512_path = NULL;
    FILE* sha512_file = NULL;
    char buffer[4096];
@@ -370,6 +375,35 @@ pgmoneta_sha512_verification(char** argv)
          err = 1;
          goto server_cleanup;
       }
+      if (pgmoneta_deque_create(true, &labels))
+      {
+         goto server_cleanup;
+      }
+      if (pgmoneta_storage_list_backup_labels(server, &labels))
+      {
+         goto server_cleanup;
+      }
+
+      if (pgmoneta_deque_size(labels) > 0)
+      {
+         struct deque_iterator* liter = NULL;
+
+         if (pgmoneta_art_create(&s3_labels))
+         {
+            goto server_cleanup;
+         }
+         if (pgmoneta_deque_iterator_create(labels, &liter))
+         {
+            goto server_cleanup;
+         }
+         while (pgmoneta_deque_iterator_next(liter))
+         {
+            char* label = (char*)pgmoneta_value_data(liter->value);
+
+            pgmoneta_art_insert(s3_labels, label, (uintptr_t)true, ValueBool);
+         }
+         pgmoneta_deque_iterator_destroy(liter);
+      }
 
       for (int i = 0; i < number_of_backups; i++)
       {
@@ -389,99 +423,113 @@ pgmoneta_sha512_verification(char** argv)
          }
          root = pgmoneta_get_server_backup_identifier(server, backups[i]->label);
 
-         sha512_path = pgmoneta_append(sha512_path, root);
-         if (!pgmoneta_ends_with(sha512_path, "/"))
+         if ((config->storage_engine & STORAGE_ENGINE_S3) &&
+             s3_labels != NULL && pgmoneta_art_contains_key(s3_labels, backups[i]->label))
          {
-            sha512_path = pgmoneta_append_char(sha512_path, '/');
+            if (pgmoneta_storage_verify_backup(server, backups[i]))
+            {
+               pgmoneta_log_error("Verification: %s/%s S3 verification failed",
+                                  config->common.servers[server].name, backups[i]->label);
+               err = 1;
+               success = false;
+            }
          }
-         sha512_path = pgmoneta_append(sha512_path, "backup.sha512");
-
-         sha512_file = fopen(sha512_path, "r");
-         if (sha512_file == NULL)
+         else
          {
-            pgmoneta_log_error("Verification: %s / Could not open file %s: %s",
-                               config->common.servers[server].name, sha512_path,
-                               strerror(errno));
-            err = 1;
-            success = false;
-            goto backup_cleanup;
-         }
-
-         line = 0;
-         while (fgets(&buffer[0], sizeof(buffer), sha512_file) != NULL)
-         {
-            char* entry = NULL;
-
-            line++;
-            entry = strtok(&buffer[0], " ");
-            if (entry == NULL)
+            sha512_path = pgmoneta_append(sha512_path, root);
+            if (!pgmoneta_ends_with(sha512_path, "/"))
             {
-               pgmoneta_log_error("Verification: %s / %s: formatting error at line %d",
-                                  config->common.servers[server].name, sha512_path, sha512_path,
-                                  line);
+               sha512_path = pgmoneta_append_char(sha512_path, '/');
+            }
+            sha512_path = pgmoneta_append(sha512_path, "backup.sha512");
+
+            sha512_file = fopen(sha512_path, "r");
+            if (sha512_file == NULL)
+            {
+               pgmoneta_log_error("Verification: %s / Could not open file %s: %s",
+                                  config->common.servers[server].name, sha512_path,
+                                  strerror(errno));
                err = 1;
                success = false;
-               goto cleanup;
+               goto backup_cleanup;
             }
 
-            hash = strdup(entry);
-            if (hash == NULL)
+            line = 0;
+            while (fgets(&buffer[0], sizeof(buffer), sha512_file) != NULL)
             {
-               pgmoneta_log_error("Verification: %s / Memory allocation error for hash",
-                                  config->common.servers[server].name);
-               err = 1;
-               success = false;
-               goto cleanup;
-            }
+               char* entry = NULL;
 
-            entry = strtok(NULL, "\n");
-            if (entry == NULL || strlen(entry) < 3)
-            {
-               pgmoneta_log_error("Verification: %s/%s %s formatting error at line %d",
-                                  config->common.servers[server].name,
-                                  backups[i]->label, sha512_path, line);
-               err = 1;
-               success = false;
-               goto cleanup;
-            }
+               line++;
+               entry = strtok(&buffer[0], " ");
+               if (entry == NULL)
+               {
+                  pgmoneta_log_error("Verification: %s / %s: formatting error at line %d",
+                                     config->common.servers[server].name, sha512_path, sha512_path,
+                                     line);
+                  err = 1;
+                  success = false;
+                  goto cleanup;
+               }
 
-            // skip the " *." or " */"
-            filename = entry + 3;
+               hash = strdup(entry);
+               if (hash == NULL)
+               {
+                  pgmoneta_log_error("Verification: %s / Memory allocation error for hash",
+                                     config->common.servers[server].name);
+                  err = 1;
+                  success = false;
+                  goto cleanup;
+               }
 
-            absolute_file_path = pgmoneta_append(absolute_file_path, root);
-            if (!pgmoneta_ends_with(absolute_file_path, "/"))
-            {
-               absolute_file_path = pgmoneta_append(absolute_file_path, "/");
-            }
+               entry = strtok(NULL, "\n");
+               if (entry == NULL || strlen(entry) < 3)
+               {
+                  pgmoneta_log_error("Verification: %s/%s %s formatting error at line %d",
+                                     config->common.servers[server].name,
+                                     backups[i]->label, sha512_path, line);
+                  err = 1;
+                  success = false;
+                  goto cleanup;
+               }
 
-            absolute_file_path = pgmoneta_append(absolute_file_path, filename);
+               // skip the " *." or " */"
+               filename = entry + 3;
 
-            if (pgmoneta_create_sha512_file(absolute_file_path, &calculated_hash))
-            {
-               pgmoneta_log_error("Verification: %s / Could not create hash for %s",
-                                  config->common.servers[server].name, absolute_file_path);
-               err = 1;
-               success = false;
-               goto cleanup;
-            }
+               absolute_file_path = pgmoneta_append(absolute_file_path, root);
+               if (!pgmoneta_ends_with(absolute_file_path, "/"))
+               {
+                  absolute_file_path = pgmoneta_append(absolute_file_path, "/");
+               }
 
-            if (strcmp(hash, calculated_hash) != 0)
-            {
-               pgmoneta_log_error("Verification: %s / Hash mismatch for %s | Expected: %s | Got: %s",
-                                  config->common.servers[server].name,
-                                  absolute_file_path, hash, calculated_hash);
-               err = 1;
-            }
+               absolute_file_path = pgmoneta_append(absolute_file_path, filename);
+
+               if (pgmoneta_create_sha512_file(absolute_file_path, &calculated_hash))
+               {
+                  pgmoneta_log_error("Verification: %s / Could not create hash for %s",
+                                     config->common.servers[server].name, absolute_file_path);
+                  err = 1;
+                  success = false;
+                  goto cleanup;
+               }
+
+               if (strcmp(hash, calculated_hash) != 0)
+               {
+                  pgmoneta_log_error("Verification: %s / Hash mismatch for %s | Expected: %s | Got: %s",
+                                     config->common.servers[server].name,
+                                     absolute_file_path, hash, calculated_hash);
+                  err = 1;
+               }
 
 cleanup:
-            free(hash);
-            hash = NULL;
+               free(hash);
+               hash = NULL;
 
-            free(absolute_file_path);
-            absolute_file_path = NULL;
+               free(absolute_file_path);
+               absolute_file_path = NULL;
 
-            free(calculated_hash);
-            calculated_hash = NULL;
+               free(calculated_hash);
+               calculated_hash = NULL;
+            }
          }
 
 #ifdef HAVE_FREEBSD
@@ -543,6 +591,12 @@ server_cleanup:
          atomic_store(&config->common.servers[server].repository, false);
          locked = false;
       }
+
+      pgmoneta_deque_destroy(labels);
+      labels = NULL;
+
+      pgmoneta_art_destroy(s3_labels);
+      s3_labels = NULL;
    }
 
    pgmoneta_stop_logging();


### PR DESCRIPTION
For S3-backed backups, scheduled verification loads local metadata
and checks against the configured remote storage primary does two things:
1. Metadata integrity:  downloads backup.sha512, backup.info, and
   backup.manifest from S3,  verifies backup.info SHA512 against
   the recorded hash
2. Object presence: lists all S3 objects under the backup prefix and confirms every manifest-listed file exists remotely

the check is purely metadata and key existence. When the storage engine is S3 and a backup's label exists in the remote listing, local SHA512 verification is skipped and the S3 verification path is used instead.