### PR TITLE
[#1173] support-timestamp for wal records

### DIFF
--- a/doc/manual/en/78-wal.md
+++ b/doc/manual/en/78-wal.md
@@ -21,6 +21,7 @@ _Fields:_
 - **long_phd**: A pointer to the extended header (long header) found on the first page of the WAL file. This header contains additional metadata.
 - **page_headers**: A deque of headers representing each page in the WAL file, excluding the first page.
 - **records**: A deque of decoded WAL records. Each record represents a change made to the database and contains both metadata and the actual data to be applied during recovery or replication.
+- **xid_ts_map**: A mapping from transaction IDs to their commit/abort timestamps. This enables timestamp display for all records, not just transaction records.
 
 **Function Overview**
 
@@ -110,6 +111,159 @@ if (result == 0) {
 }
 pgmoneta_destroy_walfile(wf);
 ```
+
+### XID Timestamp Mapping
+
+The WAL reader maintains a mapping from transaction IDs (XIDs) to their commit/abort timestamps. This allows timestamp display for all WAL records, not just transaction commit/abort records.
+
+**`struct xid_timestamp_map`**
+
+```c
+struct xid_timestamp_map
+{
+   struct deque* entries; /**< Deque of XID timestamp entries. */
+   bool sorted;          /**< Whether deque entries are sorted and ready for sequential lookup. */
+};
+
+struct xid_timestamp_entry
+{
+   transaction_id xid;        /**< The transaction ID. */
+   timestamp_tz timestamp;    /**< The commit/abort timestamp. */
+};
+```
+
+_Fields:_
+
+- **entries**: Deque storing XID → timestamp mappings.
+- **sorted**: Whether deque entries have been sorted by XID for efficient sequential lookup.
+
+> NOTE: This subsystem requires PostgreSQL `track_commit_timestamp` to be enabled. If it is disabled, WAL transaction timestamp processing is unsupported and pgmoneta will fail startup.
+
+**XID Timestamp Map Functions**
+
+**`pgmoneta_xid_timestamp_map_create`**
+
+```c
+int pgmoneta_xid_timestamp_map_create(struct xid_timestamp_map** map);
+```
+
+_Description:_
+
+Creates a new XID timestamp map using a deque-backed container. The map removes manual capacity management and grows dynamically as needed.
+
+_Parameters:_
+
+- **initial_capacity**: Initial size hint for the map (preserved for API compatibility).
+- **map**: Output parameter for the created map.
+
+_Return:_
+
+- Returns `0` on success or `1` on failure.
+
+**`pgmoneta_xid_timestamp_map_destroy`**
+
+```c
+void pgmoneta_xid_timestamp_map_destroy(struct xid_timestamp_map* map);
+```
+
+_Description:_
+
+Frees all memory associated with an XID timestamp map, including its deque-backed entries.
+
+**`pgmoneta_xid_timestamp_map_put`**
+
+```c
+int pgmoneta_xid_timestamp_map_put(struct xid_timestamp_map* map, transaction_id xid, timestamp_tz timestamp);
+```
+
+_Description:_
+
+Adds an XID → timestamp mapping to the deque-backed map. Inserted entries are kept unsorted until lookup time and are sorted before search to preserve correct ordering.
+
+_Parameters:_
+
+- **map**: The XID timestamp map.
+- **xid**: The transaction ID.
+- **timestamp**: The commit/abort timestamp.
+
+_Return:_
+
+- Returns `0` on success or `1` on failure.
+
+**`pgmoneta_xid_timestamp_map_get`**
+
+```c
+int pgmoneta_xid_timestamp_map_get(struct xid_timestamp_map* map, transaction_id xid, timestamp_tz* timestamp);
+```
+
+_Description:_
+
+Retrieves the timestamp for a given XID from the sorted deque. Since the deque is ordered by XID before lookup, the search terminates early when the target is exceeded.
+
+_Parameters:_
+
+- **map**: The XID timestamp map.
+- **xid**: The transaction ID to look up.
+- **timestamp**: Output parameter for the timestamp.
+
+_Return:_
+
+- Returns `0` if the XID is found, or `1` if not found.
+
+**`pgmoneta_process_xid_timestamp`**
+
+```c
+int pgmoneta_process_xid_timestamp(struct decoded_xlog_record* record, struct xid_timestamp_map* map);
+```
+
+_Description:_
+
+Processes a WAL record and extracts its XID → timestamp mapping. This function is called during WAL file parsing to build the complete timestamp map for all transactions in the file.
+
+_Parameters:_
+
+- **record**: The decoded WAL record to process.
+- **map**: The XID timestamp map to populate.
+
+_Return:_
+
+- Returns `0` on success or `1` on error.
+
+**Performance Characteristics:**
+
+- **Insertion**: O(n) due to deque sorting before lookup
+- **Lookup**: O(n) in the worst case with early termination after sort
+- **Memory**: O(n) where n is the number of unique transactions
+
+**Usage Example:**
+
+```c
+struct xid_timestamp_map* ts_map = NULL;
+pgmoneta_xid_timestamp_map_create(100, &ts_map);
+
+// During WAL parsing
+for each WAL record:
+    if (record->has_xact_timestamp)
+    {
+        pgmoneta_xid_timestamp_map_put(ts_map, record->header.xl_xid, record->xact_timestamp);
+    }
+
+// During display
+for each WAL record:
+    timestamp_tz ts;
+    if (record->has_xact_timestamp)
+    {
+        timestamp_str = pgmoneta_wal_timestamptz_to_str(record->xact_timestamp);
+    }
+    else if (pgmoneta_xid_timestamp_map_get(ts_map, record->header.xl_xid, &ts) == 0)
+    {
+        timestamp_str = pgmoneta_wal_timestamptz_to_str(ts);
+    }
+
+pgmoneta_xid_timestamp_map_destroy(ts_map);
+```
+
+### WAL Description Functions
 
 **`pgmoneta_describe_walfile`**
 

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -331,6 +331,7 @@ struct server
    bool checksums;                                                /**< Are checksums enabled */
    int fips_enabled;                                              /**< FIPS mode status */
    bool summarize_wal;                                            /**< Is summarize_wal enabled */
+   bool track_commit_timestamp;                                   /**< Is commit timestamp tracking enabled */
    bool valid;                                                    /**< Is the server valid */
    int version;                                                   /**< The major version of the server*/
    int minor_version;                                             /**< The minor version of the server*/

--- a/src/include/walfile.h
+++ b/src/include/walfile.h
@@ -87,6 +87,8 @@ struct xlog_long_page_header_data
  *                   Each page contains metadata about the organization of that page.
  *   - records: A deque that holds the WAL records stored in the WAL file.
  *              Each element has a `struct decoded_xlog_record` data type.
+ *   - xid_timestamp_map: A mapping from transaction IDs to their commit/abort timestamps.
+ *                        This allows efficient lookup of when each transaction committed.
  */
 struct walfile
 {
@@ -94,6 +96,7 @@ struct walfile
    struct xlog_long_page_header_data* long_phd; /**< Extended XLOG page header. */
    struct deque* page_headers;                  /**< Deque of page headers in the WAL file. */
    struct deque* records;                       /**< Deque of records in the WAL file. */
+   struct xid_timestamp_map* xid_ts_map;        /**< XID to timestamp mapping. */
 };
 
 /**

--- a/src/include/walfile/wal_reader.h
+++ b/src/include/walfile/wal_reader.h
@@ -340,6 +340,8 @@ struct decoded_xlog_record
    struct xlog_record header;                             /**< Header of the record. */
    rep_origin_id record_origin;                           /**< Origin ID of the record. */
    transaction_id toplevel_xid;                           /**< Top-level transaction ID. */
+   timestamp_tz xact_timestamp;                           /**< Commit or abort timestamp, when available. */
+   bool has_xact_timestamp;                               /**< Indicates if xact_timestamp is available. */
    char* main_data;                                       /**< Main data portion of the record. */
    uint32_t main_data_len;                                /**< Length of the main data portion. */
    uint32_t block_size;                                   /**< Block size. */
@@ -387,6 +389,44 @@ struct column_widths
    int rec_width; /**< Width of the record type column. */
    int tot_width; /**< Width of the total length column. */
    int xid_width; /**< Width of the transaction ID column. */
+   int ts_width;  /**< Width of the timestamp column. */
+};
+
+/**
+ * @struct xid_timestamp_entry
+ * @brief Represents a single XID to timestamp mapping entry.
+ *
+ * This structure maps a transaction ID to its commit timestamp.
+ *
+ * Fields:
+ * - xid: The transaction ID.
+ * - timestamp: The commit/abort timestamp for the transaction.
+ */
+struct xid_timestamp_entry
+{
+   transaction_id xid;     /**< The transaction ID. */
+   timestamp_tz timestamp; /**< The commit/abort timestamp. */
+};
+
+/**
+ * @struct xid_timestamp_map
+ * @brief A mapping from transaction IDs to their timestamps.
+ *
+ * This structure maintains a collection of XID -> timestamp mappings,
+ * allowing efficient lookup of transaction commit times.
+ *
+ * This subsystem requires PostgreSQL track_commit_timestamp to be enabled.
+ * If track_commit_timestamp is disabled, WAL transaction timestamp handling is
+ * unsupported and startup will fail.
+ *
+ * Fields:
+ * - entries: Deque of XID timestamp entries.
+ * - sorted: Whether deque entries are sorted and ready for sequential lookup.
+ */
+struct xid_timestamp_map
+{
+   struct deque* entries; /**< Deque of XID timestamp entries. */
+   bool sorted;           /**< Whether deque entries are sorted and ready for sequential lookup. */
 };
 
 /* External variables */
@@ -498,11 +538,13 @@ pgmoneta_wal_array_desc(char* buf, void* array, size_t elem_size, int count);
  * @param limit The limit
  * @param included_objects Objects that will include wal records that reference them
  * @param widths The column widths for consistent formatting
+ * @param xid_ts_map The XID to timestamp mapping for looking up timestamps
  */
 void
 pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_value, enum value_type type, FILE* out,
                             bool quiet, bool color, struct deque* rms, uint64_t start_lsn, uint64_t end_lsn,
-                            struct deque* xids, uint32_t limit, char** included_objects, struct column_widths* widths);
+                            struct deque* xids, uint32_t limit, char** included_objects, struct column_widths* widths,
+                            struct xid_timestamp_map* xid_ts_map);
 
 /**
  * Display the ocuurance of resource manager in WAL records
@@ -576,6 +618,68 @@ void
 pgmoneta_calculate_column_widths(struct walfile* wf, uint64_t start_lsn, uint64_t end_lsn,
                                  struct deque* rms, struct deque* xids, char** included_objects,
                                  struct column_widths* widths);
+
+/**
+ * Create a new deque-backed XID timestamp map
+ *
+ * @param initial_capacity Initial capacity hint for the map
+ * @param map Output parameter for the created map
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_xid_timestamp_map_create(struct xid_timestamp_map** map);
+
+/**
+ * Destroy an XID timestamp map
+ *
+ * @param map The map to destroy
+ */
+void
+pgmoneta_xid_timestamp_map_destroy(struct xid_timestamp_map* map);
+
+/**
+ * Add or update an XID -> timestamp mapping
+ *
+ * @param map The XID timestamp map
+ * @param xid The transaction ID
+ * @param timestamp The commit/abort timestamp
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_xid_timestamp_map_put(struct xid_timestamp_map* map, transaction_id xid, timestamp_tz timestamp);
+
+/**
+ * Get the timestamp for a given XID
+ *
+ * @param map The XID timestamp map
+ * @param xid The transaction ID to look up
+ * @param timestamp Output parameter for the timestamp
+ * @return 0 if found, 1 if not found
+ */
+int
+pgmoneta_xid_timestamp_map_get(struct xid_timestamp_map* map, transaction_id xid, timestamp_tz* timestamp);
+
+/**
+ * Get the size of the XID timestamp map
+ *
+ * @param map The XID timestamp map
+ * @return The number of entries in the map
+ */
+size_t
+pgmoneta_xid_timestamp_map_size(struct xid_timestamp_map* map);
+
+/**
+ * Process a WAL record and extract XID -> timestamp mapping
+ *
+ * This function examines a decoded WAL record and extracts transaction
+ * commit/abort timestamps, adding them to the XID timestamp map.
+ *
+ * @param record The decoded WAL record to process
+ * @param map The XID timestamp map to populate
+ * @return 0 on success, 1 on error
+ */
+int
+pgmoneta_process_xid_timestamp(struct decoded_xlog_record* record, struct xid_timestamp_map* map);
 
 #ifdef __cplusplus
 }

--- a/src/libpgmoneta/server.c
+++ b/src/libpgmoneta/server.c
@@ -49,6 +49,7 @@
 
 static int get_primary(SSL* ssl, int socket, bool* primary);
 static int get_wal_level(SSL* ssl, int socket, bool* replica);
+static int get_track_commit_timestamp(SSL* ssl, int socket, bool* enabled);
 static int get_wal_size(SSL* ssl, int socket, int* ws);
 static int get_checksums(SSL* ssl, int socket, bool* checksums);
 static int get_segment_size(SSL* ssl, int socket, size_t* segsz);
@@ -88,6 +89,7 @@ pgmoneta_server_info(int srv, SSL* ssl, int socket)
    pgmoneta_server_set_online(srv, true);
    config->common.servers[srv].valid = false;
    config->common.servers[srv].checksums = false;
+   config->common.servers[srv].track_commit_timestamp = false;
 
    if (pgmoneta_extract_server_parameters(&server_parameters))
    {
@@ -127,6 +129,20 @@ pgmoneta_server_info(int srv, SSL* ssl, int socket)
    }
 
    pgmoneta_log_debug("%s/wal_level %s", config->common.servers[srv].name, config->common.servers[srv].valid ? "Yes" : "No");
+
+   if (get_track_commit_timestamp(ssl, socket, &config->common.servers[srv].track_commit_timestamp))
+   {
+      pgmoneta_log_error("Unable to determine track_commit_timestamp for %s", config->common.servers[srv].name);
+      config->common.servers[srv].valid = false;
+      goto done;
+   }
+
+   if (!config->common.servers[srv].track_commit_timestamp)
+   {
+      pgmoneta_log_error("Server %s has track_commit_timestamp disabled; commit timestamps are required for WAL transaction timestamp handling", config->common.servers[srv].name);
+      config->common.servers[srv].valid = false;
+      goto done;
+   }
 
    if (get_checksums(ssl, socket, &checksums))
    {
@@ -1013,6 +1029,82 @@ error:
    pgmoneta_free_query_response(response);
    pgmoneta_free_message(query_msg);
    return 1;
+}
+
+/**
+ * Checks if track_commit_timestamp is enabled on the server.
+ * Retries up to 5 times with 500ms intervals if initial query fails.
+ *
+ * @param ssl SSL connection context
+ * @param socket Socket file descriptor
+ * @param enabled Output: true if track_commit_timestamp is 'on', false otherwise
+ * @return 0 on success, 1 on failure
+ */
+static int
+get_track_commit_timestamp(SSL* ssl, int socket, bool* enabled)
+{
+   int ret;
+   int retry_count = 0;
+   const int max_retries = 5;
+   char timestamp_value[MISC_LENGTH];
+   struct message* query_msg = NULL;
+   struct query_response* response = NULL;
+
+   *enabled = false;
+
+   ret = pgmoneta_create_query_message("SHOW track_commit_timestamp;", &query_msg);
+   if (ret != MESSAGE_STATUS_OK || query_msg == NULL)
+   {
+      pgmoneta_log_error("Failed to create query message for track_commit_timestamp");
+      pgmoneta_free_message(query_msg);
+      return 1;
+   }
+
+   while (retry_count < max_retries)
+   {
+      pgmoneta_query_execute(ssl, socket, query_msg, &response);
+      if (is_valid_response(response))
+      {
+         break;
+      }
+      pgmoneta_free_query_response(response);
+      response = NULL;
+      retry_count++;
+      if (retry_count < max_retries)
+      {
+         SLEEP(500000L);
+      }
+   }
+
+   if (!is_valid_response(response))
+   {
+      pgmoneta_log_error("Failed to get track_commit_timestamp after %d attempts", max_retries);
+      pgmoneta_query_response_debug(response);
+      pgmoneta_free_query_response(response);
+      pgmoneta_free_message(query_msg);
+      return 1;
+   }
+
+   if (response->tuples == NULL || response->tuples->data == NULL || response->tuples->data[0] == NULL)
+   {
+      pgmoneta_log_error("Invalid tuple data for track_commit_timestamp query");
+      pgmoneta_free_query_response(response);
+      pgmoneta_free_message(query_msg);
+      return 1;
+   }
+
+   memset(timestamp_value, 0, sizeof(timestamp_value));
+   pgmoneta_snprintf(timestamp_value, sizeof(timestamp_value), "%s", response->tuples->data[0]);
+
+   if (pgmoneta_compare_string("on", timestamp_value))
+   {
+      *enabled = true;
+   }
+
+   pgmoneta_free_query_response(response);
+   pgmoneta_free_message(query_msg);
+
+   return 0;
 }
 
 static int

--- a/src/libpgmoneta/walfile.c
+++ b/src/libpgmoneta/walfile.c
@@ -108,12 +108,38 @@ pgmoneta_read_walfile(int server, char* path, struct walfile** wf)
       goto error;
    }
 
+   if (pgmoneta_xid_timestamp_map_create(&new_wf->xid_ts_map))
+   {
+      pgmoneta_log_error("Failed to create XID timestamp map");
+      error_code = PGMONETA_WAL_ERR_MEMORY;
+      goto error;
+   }
+
    if (pgmoneta_wal_parse_wal_file(path, server, new_wf))
    {
       pgmoneta_log_error("Failed to parse WAL file: %s", path);
       error_code = PGMONETA_WAL_ERR_FORMAT;
       goto error;
    }
+
+   struct deque_iterator* record_iterator = NULL;
+   if (pgmoneta_deque_iterator_create(new_wf->records, &record_iterator) == 0)
+   {
+      while (pgmoneta_deque_iterator_next(record_iterator))
+      {
+         struct decoded_xlog_record* record = (struct decoded_xlog_record*)record_iterator->value->data;
+         if (!record->partial)
+         {
+            if (pgmoneta_process_xid_timestamp(record, new_wf->xid_ts_map))
+            {
+               pgmoneta_log_warn("Failed to process XID timestamp for record");
+            }
+         }
+      }
+      pgmoneta_deque_iterator_destroy(record_iterator);
+   }
+
+   pgmoneta_log_debug("Created XID timestamp map with %zu entries", pgmoneta_xid_timestamp_map_size(new_wf->xid_ts_map));
 
    *wf = new_wf;
 
@@ -375,6 +401,11 @@ pgmoneta_destroy_walfile(struct walfile* wf)
    if (wf->long_phd != NULL)
    {
       free(wf->long_phd);
+   }
+
+   if (wf->xid_ts_map != NULL)
+   {
+      pgmoneta_xid_timestamp_map_destroy(wf->xid_ts_map);
    }
 
    free(wf);

--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -54,9 +54,15 @@
 struct server* server_config;
 
 static int decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlog_record* record, uint32_t block_size, uint16_t magic_value, xlog_rec_ptr lsn);
-static void record_json(struct decoded_xlog_record* record, uint8_t magic_value, struct value** value);
+static void record_json(struct decoded_xlog_record* record, uint8_t magic_value, struct xid_timestamp_map* xid_ts_map, struct value** value);
 static bool get_record_block_tag_extended(struct decoded_xlog_record* pRecord, int id, struct rel_file_locator* pLocator, enum fork_number* pNumber, block_number* pInt, buffer* pVoid);
 static int magic_value_to_postgres_version(uint16_t magic_value);
+static int compare_xid_timestamp_entries(struct value* a, struct value* b);
+static void xid_timestamp_entry_destroy(uintptr_t data);
+static void pgmoneta_xid_timestamp_map_sort(struct xid_timestamp_map* map);
+static int add_xid_and_subxacts_to_map(transaction_id main_xid, transaction_id* subxacts, int nsubxacts, timestamp_tz timestamp, struct xid_timestamp_map* map);
+static int process_commit_record(struct xl_xact_commit* xlrec, uint8_t xl_info, transaction_id xid, bool use_v15_parser, struct xid_timestamp_map* map);
+static int process_abort_record(struct xl_xact_abort* xlrec, uint8_t xl_info, transaction_id xid, bool use_v15_parser, struct xid_timestamp_map* map);
 
 static bool is_included(char* rm, struct deque* rms, uint64_t s_lsn, uint64_t start_lsn, uint64_t e_lsn, uint64_t end_lsn,
                         uint32_t xid, struct deque* xids, char** included_objects, char* rm_desc, uint32_t xl_info, rmgr_id rm_id);
@@ -693,6 +699,8 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
    decoded->next = NULL;
    decoded->record_origin = INVALID_REP_ORIGIN_ID;
    decoded->toplevel_xid = INVALID_TRANSACTION_ID;
+   decoded->xact_timestamp = 0;
+   decoded->has_xact_timestamp = false;
    decoded->main_data = NULL;
    decoded->main_data_len = 0;
    decoded->block_size = block_size;
@@ -912,6 +920,35 @@ decode_xlog_record(char* buffer, struct decoded_xlog_record* decoded, struct xlo
       }
       memcpy(decoded->main_data, ptr, decoded->main_data_len);
       ptr += decoded->main_data_len;
+   }
+
+   if (record->xl_rmid == RM_XACT_ID && decoded->main_data != NULL)
+   {
+      if (server_config != NULL && server_config->valid && !server_config->track_commit_timestamp)
+      {
+         decoded->has_xact_timestamp = false;
+      }
+      else
+      {
+         uint8_t op = record->xl_info & XLOG_XACT_OPMASK;
+
+         if (op == XLOG_XACT_COMMIT || op == XLOG_XACT_ABORT)
+         {
+            if (decoded->main_data_len >= sizeof(timestamp_tz))
+            {
+               memcpy(&decoded->xact_timestamp, decoded->main_data, sizeof(timestamp_tz));
+               decoded->has_xact_timestamp = true;
+            }
+         }
+         else if (op == XLOG_XACT_COMMIT_PREPARED || op == XLOG_XACT_ABORT_PREPARED)
+         {
+            if (decoded->main_data_len >= sizeof(timestamp_tz))
+            {
+               memcpy(&decoded->xact_timestamp, decoded->main_data, sizeof(timestamp_tz));
+               decoded->has_xact_timestamp = true;
+            }
+         }
+      }
    }
    decoded->partial = false;
 
@@ -1456,6 +1493,29 @@ pgmoneta_calculate_column_widths(struct walfile* wf, uint64_t start_lsn, uint64_
          widths->xid_width = temp_width;
       }
 
+      if (record->has_xact_timestamp)
+      {
+         char* ts = pgmoneta_wal_timestamptz_to_str(record->xact_timestamp);
+         temp_width = strlen(ts);
+         if (temp_width > widths->ts_width)
+         {
+            widths->ts_width = temp_width;
+         }
+      }
+      else if (wf->xid_ts_map != NULL && record->header.xl_xid != INVALID_TRANSACTION_ID)
+      {
+         timestamp_tz ts;
+         if (pgmoneta_xid_timestamp_map_get(wf->xid_ts_map, record->header.xl_xid, &ts) == 0)
+         {
+            char* ts_str = pgmoneta_wal_timestamptz_to_str(ts);
+            temp_width = strlen(ts_str);
+            if (temp_width > widths->ts_width)
+            {
+               widths->ts_width = temp_width;
+            }
+         }
+      }
+
       free(start_lsn_string);
       free(end_lsn_string);
       start_lsn_string = NULL;
@@ -1468,7 +1528,8 @@ pgmoneta_calculate_column_widths(struct walfile* wf, uint64_t start_lsn, uint64_
 void
 pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_value, enum value_type type, FILE* out,
                             bool quiet, bool color, struct deque* rms, uint64_t start_lsn, uint64_t end_lsn,
-                            struct deque* xids, uint32_t limit, char** included_objects, struct column_widths* widths)
+                            struct deque* xids, uint32_t limit, char** included_objects, struct column_widths* widths,
+                            struct xid_timestamp_map* xid_ts_map)
 {
    static uint32_t current_limit = 0;
    char* header_str = NULL;
@@ -1477,6 +1538,7 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
    char* start_lsn_string = NULL;
    char* end_lsn_string = NULL;
    char* enhanced_desc = NULL;
+   char* timestamp_str = NULL;
    struct value* record_serialized = NULL;
    char* value_str = NULL;
    uint32_t rec_len = 0;
@@ -1537,7 +1599,7 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
          {
             fprintf(out, ",\n{\"Record\": ");
          }
-         record_json(record, magic_value, &record_serialized);
+         record_json(record, magic_value, xid_ts_map, &record_serialized);
          value_str = pgmoneta_value_to_string(record_serialized, FORMAT_JSON_COMPACT, NULL, 0);
          fprintf(out, "%s}", value_str);
          pgmoneta_value_destroy(record_serialized);
@@ -1569,32 +1631,47 @@ pgmoneta_wal_record_display(struct decoded_xlog_record* record, uint16_t magic_v
          start_lsn_string = pgmoneta_lsn_to_string(record->header.xl_prev);
          end_lsn_string = pgmoneta_lsn_to_string(record->lsn);
 
+         if (record->has_xact_timestamp)
+         {
+            timestamp_str = pgmoneta_wal_timestamptz_to_str(record->xact_timestamp);
+         }
+         else if (xid_ts_map != NULL && record->header.xl_xid != INVALID_TRANSACTION_ID)
+         {
+            timestamp_tz ts;
+            if (pgmoneta_xid_timestamp_map_get(xid_ts_map, record->header.xl_xid, &ts) == 0)
+            {
+               timestamp_str = pgmoneta_wal_timestamptz_to_str(ts);
+            }
+         }
+
          bool has_desc = enhanced_desc && strlen(enhanced_desc) > 0;
          bool has_backup = backup_str && strlen(backup_str) > 0;
          bool both_empty = !has_desc && !has_backup;
 
          if (color)
          {
-            fprintf(out, "%s%-*s%s | %s%-*s%s | %s%-*s%s | %s%-*d%s | %s%-*d%s | %s%-*u%s | %s%s%s%s%s\n",
+            fprintf(out, "%s%-*s%s | %s%-*s%s | %s%-*s%s | %s%-*d%s | %s%-*d%s | %s%-*u%s | %s%-*s%s | %s%s%s%s%s\n",
                     COLOR_RED, widths->rm_width, rmgr_table[record->header.xl_rmid].name, COLOR_RESET,
                     COLOR_MAGENTA, widths->lsn_width, start_lsn_string, COLOR_RESET,
                     COLOR_MAGENTA, widths->lsn_width, end_lsn_string, COLOR_RESET,
                     COLOR_BLUE, widths->rec_width, rec_len, COLOR_RESET,
                     COLOR_YELLOW, widths->tot_width, record->header.xl_tot_len, COLOR_RESET,
                     COLOR_CYAN, widths->xid_width, record->header.xl_xid, COLOR_RESET,
+                    COLOR_MAGENTA, widths->ts_width, timestamp_str ? timestamp_str : "", COLOR_RESET,
                     COLOR_GREEN, both_empty ? "<empty>" : (has_desc ? enhanced_desc : ""),
                     has_backup ? " " : "",
                     has_backup ? backup_str : "", COLOR_RESET);
          }
          else
          {
-            fprintf(out, "%-*s | %-*s | %-*s | %-*d | %-*d | %-*u | %s%s%s\n",
+            fprintf(out, "%-*s | %-*s | %-*s | %-*d | %-*d | %-*u | %-*s | %s%s%s\n",
                     widths->rm_width, rmgr_table[record->header.xl_rmid].name,
                     widths->lsn_width, start_lsn_string,
                     widths->lsn_width, end_lsn_string,
                     widths->rec_width, rec_len,
                     widths->tot_width, record->header.xl_tot_len,
                     widths->xid_width, record->header.xl_xid,
+                    widths->ts_width, timestamp_str ? timestamp_str : "",
                     both_empty ? "<empty>" : (has_desc ? enhanced_desc : ""),
                     has_backup ? " " : "",
                     has_backup ? backup_str : "");
@@ -1903,7 +1980,7 @@ no:
 }
 
 static void
-record_json(struct decoded_xlog_record* record, uint8_t magic_value, struct value** value)
+record_json(struct decoded_xlog_record* record, uint8_t magic_value, struct xid_timestamp_map* xid_ts_map, struct value** value)
 {
    char* rm_desc = NULL;
    char* backup_str = NULL;
@@ -1930,6 +2007,20 @@ record_json(struct decoded_xlog_record* record, uint8_t magic_value, struct valu
    pgmoneta_json_put(record_json, "TotalLength", record->header.xl_tot_len, ValueUInt32);
    pgmoneta_json_put(record_json, "Xid", record->header.xl_xid, ValueUInt32);
    pgmoneta_json_put(record_json, "Info", record->header.xl_info, ValueUInt8);
+   if (record->has_xact_timestamp)
+   {
+      char* ts_str = pgmoneta_wal_timestamptz_to_str(record->xact_timestamp);
+      pgmoneta_json_put(record_json, "Timestamp", (uintptr_t)ts_str, ValueString);
+   }
+   else if (xid_ts_map != NULL && record->header.xl_xid != INVALID_TRANSACTION_ID)
+   {
+      timestamp_tz ts;
+      if (pgmoneta_xid_timestamp_map_get(xid_ts_map, record->header.xl_xid, &ts) == 0)
+      {
+         char* ts_str = pgmoneta_wal_timestamptz_to_str(ts);
+         pgmoneta_json_put(record_json, "Timestamp", (uintptr_t)ts_str, ValueString);
+      }
+   }
    pgmoneta_json_put(record_json, "StartLSN", record->header.xl_prev, ValueUInt64);
    pgmoneta_json_put(record_json, "EndLSN", record->lsn, ValueUInt64);
    pgmoneta_json_put(record_json, "ResourceManagerId", record->header.xl_rmid, ValueUInt8);
@@ -2468,4 +2559,312 @@ pgmoneta_wal_encode_xlog_record(struct decoded_xlog_record* decoded, uint16_t ma
    assert(ptr - buffer == total_length);
 
    return buffer;
+}
+
+int
+pgmoneta_xid_timestamp_map_create(struct xid_timestamp_map** map)
+{
+   if (map == NULL)
+   {
+      pgmoneta_log_error("Invalid parameter: map is NULL");
+      return 1;
+   }
+
+   struct xid_timestamp_map* m = malloc(sizeof(struct xid_timestamp_map));
+   if (m == NULL)
+   {
+      pgmoneta_log_error("Failed to allocate memory for XID timestamp map");
+      return 1;
+   }
+
+   if (pgmoneta_deque_create(false, &m->entries))
+   {
+      pgmoneta_log_error("Failed to create deque for XID timestamp map");
+      free(m);
+      return 1;
+   }
+
+   m->sorted = false;
+   *map = m;
+   return 0;
+}
+
+void
+pgmoneta_xid_timestamp_map_destroy(struct xid_timestamp_map* map)
+{
+   if (map == NULL)
+   {
+      return;
+   }
+
+   if (map->entries != NULL)
+   {
+      pgmoneta_deque_destroy(map->entries);
+   }
+   free(map);
+}
+
+int
+pgmoneta_xid_timestamp_map_put(struct xid_timestamp_map* map, transaction_id xid, timestamp_tz timestamp)
+{
+   if (map == NULL)
+   {
+      pgmoneta_log_error("Invalid parameter: map is NULL");
+      return 1;
+   }
+
+   map->sorted = false;
+
+   struct xid_timestamp_entry* entry = malloc(sizeof(struct xid_timestamp_entry));
+   if (entry == NULL)
+   {
+      pgmoneta_log_error("Failed to allocate memory for XID timestamp entry");
+      return 1;
+   }
+
+   entry->xid = xid;
+   entry->timestamp = timestamp;
+
+   struct value_config config;
+   memset(&config, 0, sizeof(struct value_config));
+   config.destroy_data = xid_timestamp_entry_destroy;
+
+   pgmoneta_deque_add_with_config(map->entries, NULL, (uintptr_t)entry, &config);
+
+   return 0;
+}
+
+int
+pgmoneta_xid_timestamp_map_get(struct xid_timestamp_map* map, transaction_id xid, timestamp_tz* timestamp)
+{
+   if (map == NULL || timestamp == NULL)
+   {
+      pgmoneta_log_error("Invalid parameter: map or timestamp is NULL");
+      return 1;
+   }
+
+   if (!map->sorted)
+   {
+      pgmoneta_xid_timestamp_map_sort(map);
+   }
+
+   struct deque_iterator* iter = NULL;
+   if (pgmoneta_deque_iterator_create(map->entries, &iter))
+   {
+      pgmoneta_log_error("Failed to create iterator for XID timestamp map");
+      return 1;
+   }
+
+   int result = 1;
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      struct xid_timestamp_entry* entry = (struct xid_timestamp_entry*)pgmoneta_value_data(iter->value);
+      if (entry == NULL)
+      {
+         continue;
+      }
+
+      if (entry->xid == xid)
+      {
+         *timestamp = entry->timestamp;
+         result = 0;
+         break;
+      }
+      else if (entry->xid > xid)
+      {
+         break;
+      }
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   return result;
+}
+
+size_t
+pgmoneta_xid_timestamp_map_size(struct xid_timestamp_map* map)
+{
+   if (map == NULL)
+   {
+      return 0;
+   }
+
+   return pgmoneta_deque_size(map->entries);
+}
+
+static void
+pgmoneta_xid_timestamp_map_sort(struct xid_timestamp_map* map)
+{
+   if (map == NULL || map->entries == NULL)
+   {
+      return;
+   }
+
+   if (pgmoneta_deque_size(map->entries) <= 1)
+   {
+      map->sorted = true;
+      return;
+   }
+
+   pgmoneta_deque_sort(map->entries, compare_xid_timestamp_entries);
+   map->sorted = true;
+}
+
+static int
+compare_xid_timestamp_entries(struct value* a, struct value* b)
+{
+   if (a == NULL || b == NULL)
+   {
+      return 0;
+   }
+
+   const struct xid_timestamp_entry* entry_a = (const struct xid_timestamp_entry*)pgmoneta_value_data(a);
+   const struct xid_timestamp_entry* entry_b = (const struct xid_timestamp_entry*)pgmoneta_value_data(b);
+
+   if (entry_a == NULL || entry_b == NULL)
+   {
+      return 0;
+   }
+
+   if (entry_a->xid < entry_b->xid)
+   {
+      return -1;
+   }
+   if (entry_a->xid > entry_b->xid)
+   {
+      return 1;
+   }
+   return 0;
+}
+
+static void
+xid_timestamp_entry_destroy(uintptr_t data)
+{
+   free((void*)data);
+}
+
+static int
+process_commit_record(struct xl_xact_commit* xlrec, uint8_t xl_info, transaction_id xid,
+                      bool use_v15_parser, struct xid_timestamp_map* map)
+{
+   if (use_v15_parser)
+   {
+      struct xl_xact_parsed_commit_v15 parsed;
+      pgmoneta_wal_parse_commit_record_ge15(xl_info, xlrec, &parsed);
+      return add_xid_and_subxacts_to_map(xid, parsed.subxacts, parsed.nsubxacts, parsed.xact_time, map);
+   }
+   else
+   {
+      struct xl_xact_parsed_commit_v14 parsed;
+      pgmoneta_wal_parse_commit_record_l15(xl_info, xlrec, &parsed);
+      return add_xid_and_subxacts_to_map(xid, parsed.subxacts, parsed.nsubxacts, parsed.xact_time, map);
+   }
+}
+
+static int
+process_abort_record(struct xl_xact_abort* xlrec, uint8_t xl_info, transaction_id xid,
+                     bool use_v15_parser, struct xid_timestamp_map* map)
+{
+   if (use_v15_parser)
+   {
+      struct xl_xact_parsed_abort_v15 parsed;
+      pgmoneta_wal_parse_abort_record_ge15(xl_info, xlrec, &parsed);
+      return add_xid_and_subxacts_to_map(xid, parsed.subxacts, parsed.nsubxacts, parsed.xact_time, map);
+   }
+   else
+   {
+      struct xl_xact_parsed_abort_v14 parsed;
+      pgmoneta_wal_parse_abort_record_l15(xl_info, xlrec, &parsed);
+      return add_xid_and_subxacts_to_map(xid, parsed.subxacts, parsed.nsubxacts, parsed.xact_time, map);
+   }
+}
+
+static int
+add_xid_and_subxacts_to_map(transaction_id main_xid, transaction_id* subxacts, int nsubxacts,
+                            timestamp_tz timestamp, struct xid_timestamp_map* map)
+{
+   if (pgmoneta_xid_timestamp_map_put(map, main_xid, timestamp))
+   {
+      pgmoneta_log_error("Failed to add XID %u to timestamp map", main_xid);
+      return 1;
+   }
+
+   for (int i = 0; i < nsubxacts; i++)
+   {
+      if (pgmoneta_xid_timestamp_map_put(map, subxacts[i], timestamp))
+      {
+         pgmoneta_log_warn("Failed to add subXID %u to timestamp map", subxacts[i]);
+      }
+      else
+      {
+         pgmoneta_log_trace("Added subXID %u -> timestamp %ld to map", subxacts[i], timestamp);
+      }
+   }
+
+   pgmoneta_log_trace("Added XID %u -> timestamp %ld to map with %d subxacts", main_xid, timestamp, nsubxacts);
+   return 0;
+}
+
+int
+pgmoneta_process_xid_timestamp(struct decoded_xlog_record* record, struct xid_timestamp_map* map)
+{
+   if (record == NULL || map == NULL)
+   {
+      pgmoneta_log_error("Invalid parameter: record or map is NULL");
+      return 1;
+   }
+
+   /* Server startup enforces track_commit_timestamp. If server_config exists and is valid,
+    * this code path is only reached when commit timestamp tracking is enabled.
+    */
+   if (server_config != NULL && server_config->valid && !server_config->track_commit_timestamp)
+   {
+      return 0;
+   }
+
+   if (record->header.xl_rmid != RM_XACT_ID || !record->has_xact_timestamp)
+   {
+      return 0;
+   }
+
+   transaction_id xid = record->header.xl_xid;
+   if (xid == INVALID_TRANSACTION_ID)
+   {
+      return 0;
+   }
+
+   uint8_t op = record->header.xl_info & XLOG_XACT_OPMASK;
+
+   if (op == XLOG_XACT_COMMIT || op == XLOG_XACT_ABORT)
+   {
+      bool use_v15_parser = (server_config == NULL || server_config->version == 0 || server_config->version >= 15);
+
+      if (op == XLOG_XACT_COMMIT)
+      {
+         struct xl_xact_commit* xlrec = (struct xl_xact_commit*)record->main_data;
+         if (process_commit_record(xlrec, record->header.xl_info, xid, use_v15_parser, map))
+         {
+            return 1;
+         }
+      }
+      else /* XLOG_XACT_ABORT */
+      {
+         struct xl_xact_abort* xlrec = (struct xl_xact_abort*)record->main_data;
+         if (process_abort_record(xlrec, record->header.xl_info, xid, use_v15_parser, map))
+         {
+            return 1;
+         }
+      }
+   }
+   else if (op == XLOG_XACT_COMMIT_PREPARED || op == XLOG_XACT_ABORT_PREPARED)
+   {
+      if (pgmoneta_xid_timestamp_map_put(map, xid, record->xact_timestamp))
+      {
+         pgmoneta_log_error("Failed to add XID %u to timestamp map", xid);
+         return 1;
+      }
+      pgmoneta_log_trace("Added XID %u -> timestamp %ld to map (prepared transaction)", xid, record->xact_timestamp);
+   }
+
+   return 0;
 }

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -113,6 +113,7 @@ struct wal_record_ui
    uint32_t rec_len;
    uint32_t tot_len;
    uint32_t xid;
+   char timestamp[64];
    char description[512];
    char hex_data[512];
    bool verified;
@@ -1146,6 +1147,31 @@ wal_interactive_load_records(struct ui_state* state, char* wal_filename)
 
       /* Transaction ID */
       rec_ui->xid = record->header.xl_xid;
+
+      /* get timestamp - either from record or lookup in XID timestamp map */
+      char* timestamp_str = NULL;
+      if (record->has_xact_timestamp)
+      {
+         timestamp_str = pgmoneta_wal_timestamptz_to_str(record->xact_timestamp);
+      }
+      else if (wf->xid_ts_map != NULL && rec_ui->xid != INVALID_TRANSACTION_ID)
+      {
+         timestamp_tz ts = 0;
+         if (pgmoneta_xid_timestamp_map_get(wf->xid_ts_map, rec_ui->xid, &ts) == 0)
+         {
+            timestamp_str = pgmoneta_wal_timestamptz_to_str(ts);
+         }
+      }
+
+      if (timestamp_str != NULL)
+      {
+         pgmoneta_snprintf(rec_ui->timestamp, sizeof(rec_ui->timestamp), "%s", timestamp_str);
+         /* No free needed - pgmoneta_wal_timestamptz_to_str returns static buffer */
+      }
+      else
+      {
+         rec_ui->timestamp[0] = '\0';
+      }
 
       /* Get human-readable description */
       char* desc = get_simple_record_description(record, wf->magic_number);
@@ -2547,6 +2573,7 @@ draw_main_content(struct ui_state* state)
    const int rec_width = 7;
    const int tot_width = 7;
    const int xid_width = 7;
+   const int ts_width = 22;
 
    /* Draw column headers with exact formatting */
    wattron(state->main_win, A_BOLD | A_UNDERLINE);
@@ -2588,6 +2615,12 @@ draw_main_content(struct ui_state* state)
    mvwprintw(state->main_win, 1, col, "%-*s", xid_width, "XID");
    wattroff(state->main_win, COLOR_PAIR(10));
    col += xid_width + 3;
+
+   /* timestamp header in MAGENTA */
+   wattron(state->main_win, COLOR_PAIR(7));
+   mvwprintw(state->main_win, 1, col, "%-*s", ts_width, "Timestamp");
+   wattroff(state->main_win, COLOR_PAIR(7));
+   col += ts_width + 3;
 
    /* description header in GREEN */
    wattron(state->main_win, COLOR_PAIR(11));
@@ -2714,6 +2747,22 @@ draw_main_content(struct ui_state* state)
          mvwprintw(state->main_win, i + 2, col, "%-*u", xid_width, rec_ui->xid);
          wattroff(state->main_win, COLOR_PAIR(15) | COLOR_PAIR(10) | A_BOLD);
          col += xid_width;
+         mvwprintw(state->main_win, i + 2, col, " | ");
+         col += 3;
+
+         /* timestamp in MAGENTA or HIGHLIGHT */
+         if (is_highlighted_row && state->highlight_count > 0 &&
+             state->current_search_field == WAL_SEARCH_FIELD_DESCRIPTION)
+         {
+            wattron(state->main_win, COLOR_PAIR(15) | A_BOLD);
+         }
+         else
+         {
+            wattron(state->main_win, COLOR_PAIR(7));
+         }
+         mvwprintw(state->main_win, i + 2, col, "%-*s", ts_width, rec_ui->timestamp);
+         wattroff(state->main_win, COLOR_PAIR(15) | COLOR_PAIR(7) | A_BOLD);
+         col += ts_width;
          mvwprintw(state->main_win, i + 2, col, " | ");
          col += 3;
 
@@ -2855,6 +2904,13 @@ show_detail_view(struct ui_state* state)
    wattron(detail_win, COLOR_PAIR(10));
    mvwprintw(detail_win, row, 17, "%u", rec_ui->xid);
    wattroff(detail_win, COLOR_PAIR(10));
+   row++;
+
+   /* timestamp in MAGENTA */
+   mvwprintw(detail_win, row, 2, "Timestamp:     ");
+   wattron(detail_win, COLOR_PAIR(7));
+   mvwprintw(detail_win, row, 17, "%s", rec_ui->timestamp);
+   wattroff(detail_win, COLOR_PAIR(7));
    row++;
 
    /* Valid status */
@@ -6046,7 +6102,7 @@ describe_walfile_internal(char* path, enum value_type type, FILE* out, bool quie
          else
          {
             pgmoneta_wal_record_display(record, wf->long_phd->std.xlp_magic, type, out, quiet, color,
-                                        rms, start_lsn, end_lsn, xids, limit, included_objects, widths);
+                                        rms, start_lsn, end_lsn, xids, limit, included_objects, widths, wf->xid_ts_map);
          }
       }
 
@@ -6067,7 +6123,7 @@ describe_walfile_internal(char* path, enum value_type type, FILE* out, bool quie
          else
          {
             pgmoneta_wal_record_display(record, wf->long_phd->std.xlp_magic, type, out, quiet, color,
-                                        rms, start_lsn, end_lsn, xids, limit, included_objects, widths);
+                                        rms, start_lsn, end_lsn, xids, limit, included_objects, widths, wf->xid_ts_map);
          }
       }
    }

--- a/test/libpgmonetatest/tswalinfo.c
+++ b/test/libpgmonetatest/tswalinfo.c
@@ -81,7 +81,7 @@ pgmoneta_tswalinfo_describe(char* path, char** output)
    {
       record = (struct decoded_xlog_record*)record_iterator->value->data;
       pgmoneta_wal_record_display(record, wf->long_phd->std.xlp_magic, ValueString, out, false, false,
-                                  NULL, 0, 0, NULL, 0, NULL, &widths);
+                                  NULL, 0, 0, NULL, 0, NULL, &widths, wf->xid_ts_map);
    }
 
    pgmoneta_deque_iterator_destroy(record_iterator);

--- a/test/postgresql/src/postgresql14/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql14/conf/postgresql.conf
@@ -333,7 +333,7 @@ min_wal_size = 80MB
 #wal_keep_size = 0		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
-#track_commit_timestamp = off	# collect timestamp of transaction commit
+track_commit_timestamp = on	# collect timestamp of transaction commit
 				# (change requires restart)
 
 # - Primary Server -

--- a/test/postgresql/src/postgresql15/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql15/conf/postgresql.conf
@@ -333,7 +333,7 @@ min_wal_size = 80MB
 #wal_keep_size = 0		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
-#track_commit_timestamp = off	# collect timestamp of transaction commit
+track_commit_timestamp = on	# collect timestamp of transaction commit
 				# (change requires restart)
 
 # - Primary Server -

--- a/test/postgresql/src/postgresql17/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql17/conf/postgresql.conf
@@ -333,7 +333,7 @@ summarize_wal = on		# run WAL summarizer process?
 #wal_keep_size = 0		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
-#track_commit_timestamp = off	# collect timestamp of transaction commit
+track_commit_timestamp = on	# collect timestamp of transaction commit
 				# (change requires restart)
 
 # - Primary Server -

--- a/test/testcases/test_server_api.c
+++ b/test/testcases/test_server_api.c
@@ -144,6 +144,26 @@ cleanup:
    MCTF_FINISH();
 }
 
+MCTF_TEST(test_server_api_track_commit_timestamp)
+{
+   struct main_configuration* config = NULL;
+   struct server srv;
+
+   MCTF_ASSERT(setup_server_connection() == 0, cleanup, "failed to setup server connection - check authentication and server configuration");
+
+   pgmoneta_server_info(PRIMARY_SERVER, srv_ssl, srv_socket);
+
+   config = (struct main_configuration*)shmem;
+   srv = config->common.servers[PRIMARY_SERVER];
+
+   MCTF_ASSERT(srv.track_commit_timestamp, cleanup, "track_commit_timestamp should be enabled");
+   MCTF_ASSERT(srv.valid, cleanup, "server should be valid when track_commit_timestamp is enabled");
+
+cleanup:
+   teardown_server_connection();
+   MCTF_FINISH();
+}
+
 static int
 setup_server_connection(void)
 {

--- a/test/testcases/test_wal_utils.c
+++ b/test/testcases/test_wal_utils.c
@@ -449,5 +449,11 @@ destroy_walfile(struct walfile* wf)
       wf->records = NULL;
    }
 
+   if (wf->xid_ts_map != NULL)
+   {
+      pgmoneta_xid_timestamp_map_destroy(wf->xid_ts_map);
+      wf->xid_ts_map = NULL;
+   }
+
    free(wf);
 }


### PR DESCRIPTION
fixes [#1173]

support timestamp for wal records

You should enable track_commit_timestamp so you can get this feature

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/77f669f8-274c-4497-ae9a-683987bf9b85" />

---

```
./src/pgmoneta-walinfo /home/sara-nabih/Downloads/wal-tests/0000000100000002000000C0
XLOG        | 2/BF000150 | 2/C0000028 | 114 | 114  | 0      |                                 | CHECKPOINT_SHUTDOWN redo 2/C0000028; tli 1; prev tli 1; fpw true; wal_level replica; xid 0:297177; oid 25183; multi 1; offset 0; oldest xid 744 in DB 1; oldest multi 1 in DB 1; oldest/newest commit timestamp xid: 297175/297176; oldest running xid 0 shutdown 
Standby     | 2/C0000028 | 2/C00000A0 | 50  | 50   | 0      |                                 | RUNNING_XACTS next_xid 297177 latest_completed_xid 297176 oldest_running_xid 297177 
XLOG        | 2/C00000A0 | 2/C00000D8 | 30  | 30   | 0      |                                 | <empty>
Standby     | 2/C00000D8 | 2/C00000F8 | 50  | 50   | 0      |                                 | RUNNING_XACTS next_xid 297177 latest_completed_xid 297176 oldest_running_xid 297177 
XLOG        | 2/C00000F8 | 2/C0000130 | 114 | 114  | 0      |                                 | CHECKPOINT_ONLINE redo 2/C00000D8; tli 1; prev tli 1; fpw true; wal_level replica; xid 0:297177; oid 25183; multi 1; offset 0; oldest xid 744 in DB 1; oldest multi 1 in DB 1; oldest/newest commit timestamp xid: 297175/297176; oldest running xid 297177 online 
Standby     | 2/C0000130 | 2/C00001A8 | 50  | 50   | 0      |                                 | RUNNING_XACTS next_xid 297177 latest_completed_xid 297176 oldest_running_xid 297177 
XLOG        | 2/C00001A8 | 2/C00001E0 | 49  | 145  | 0      |                                 | FPI_FOR_HINT blkref #0: rel 1663/16486/25180 forknum 0 blk 0 (FPW); hole: offset: 32, length: 8096, compression saved: 0, method: unknown blkref #0: rel 1663/16486/25180 forknum 0 blk 0 (FPW); hole: offset: 32, length: 8096, compression saved: 0, method: unknown
Heap        | 2/C00001E0 | 2/C0000278 | 54  | 54   | 297177 | 2026-06-08 21:07:13.425730 EEST | DELETE off 2 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/25180 forknum 0 blk 0 blkref #0: rel 1663/16486/25180 forknum 0 blk 0
Transaction | 2/C0000278 | 2/C00002B0 | 34  | 34   | 297177 | 2026-06-08 21:07:13.425730 EEST | COMMIT 2026-06-08 21:07:13.425730 EEST 
Standby     | 2/C00002B0 | 2/C00002D8 | 50  | 50   | 0      |                                 | RUNNING_XACTS next_xid 297178 latest_completed_xid 297177 oldest_running_xid 297178 
Standby     | 2/C00002D8 | 2/C0000310 | 42  | 42   | 297178 | 2026-06-08 21:08:25.506866 EEST | LOCK xid 297178 db 16486 rel 2639336944  
XLOG        | 2/C0000310 | 2/C0000340 | 49  | 6913 | 297178 | 2026-06-08 21:08:25.506866 EEST | FPI_FOR_HINT blkref #0: rel 1663/16486/2608 forknum 0 blk 14 (FPW); hole: offset: 480, length: 1328, compression saved: 0, method: unknown blkref #0: rel 1663/16486/2608 forknum 0 blk 14 (FPW); hole: offset: 480, length: 1328, compression saved: 0, method: unknown
XLOG        | 2/C0000340 | 2/C0001E48 | 49  | 6973 | 297178 | 2026-06-08 21:08:25.506866 EEST | FPI_FOR_HINT blkref #0: rel 1663/16486/1247 forknum 0 blk 14 (FPW); hole: offset: 484, length: 1268, compression saved: 0, method: unknown blkref #0: rel 1663/16486/1247 forknum 0 blk 14 (FPW); hole: offset: 484, length: 1268, compression saved: 0, method: unknown
Heap        | 2/C0001E48 | 2/C00039A0 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 115 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/1247 forknum 0 blk 14 blkref #0: rel 1663/16486/1247 forknum 0 blk 14
Heap        | 2/C00039A0 | 2/C00039D8 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 113 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/2608 forknum 0 blk 14 blkref #0: rel 1663/16486/2608 forknum 0 blk 14
Heap        | 2/C00039D8 | 2/C0003A10 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 114 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/1247 forknum 0 blk 14 blkref #0: rel 1663/16486/1247 forknum 0 blk 14
Heap        | 2/C0003A10 | 2/C0003A48 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 112 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/2608 forknum 0 blk 14 blkref #0: rel 1663/16486/2608 forknum 0 blk 14
XLOG        | 2/C0003A48 | 2/C0003A80 | 49  | 7349 | 297178 | 2026-06-08 21:08:25.506866 EEST | FPI_FOR_HINT blkref #0: rel 1663/16486/1249 forknum 0 blk 59 (FPW); hole: offset: 364, length: 892, compression saved: 0, method: unknown blkref #0: rel 1663/16486/1249 forknum 0 blk 59 (FPW); hole: offset: 364, length: 892, compression saved: 0, method: unknown
Heap        | 2/C0003A80 | 2/C0005750 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 85 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/1249 forknum 0 blk 59 blkref #0: rel 1663/16486/1249 forknum 0 blk 59
Heap        | 2/C0005750 | 2/C0005788 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 84 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/1249 forknum 0 blk 59 blkref #0: rel 1663/16486/1249 forknum 0 blk 59
Heap        | 2/C0005788 | 2/C00057C0 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 83 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/1249 forknum 0 blk 59 blkref #0: rel 1663/16486/1249 forknum 0 blk 59
Heap        | 2/C00057C0 | 2/C00057F8 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 82 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/1249 forknum 0 blk 59 blkref #0: rel 1663/16486/1249 forknum 0 blk 59
Heap        | 2/C00057F8 | 2/C0005830 | 54  | 54   | 297178 | 2026-06-08 21:08:25.506866 EEST | DELETE off 81 flags 0x00 KEYS_UPDATED  blkref #0: rel 1663/16486/1249 forknum 0 blk 59 blkref #0: rel 1663/16486/1249 forknum 0 blk 59
...
```
---
