### PR TITLE
[#1176] Use bounded pgmoneta_snprintf for port formatting in pgmoneta_connect

### DIFF
--- a/src/libpgmoneta/network.c
+++ b/src/libpgmoneta/network.c
@@ -241,7 +241,7 @@ pgmoneta_connect(char* hostname, int port, int* fd)
    config = (struct main_configuration*)shmem;
 
    memset(&sport, 0, sizeof(sport));
-   sprintf(&sport[0], "%d", port);
+   pgmoneta_snprintf(&sport[0], sizeof(sport), "%d", port);
 
    /* Connect to server */
    memset(&hints, 0, sizeof hints);


### PR DESCRIPTION
In `pgmoneta_connect` the backend port was formatted into the stack buffer `sport` with an unbounded `sprintf`. The buffer is already correctly sized (six bytes holds 65535 plus its NUL), so this is a consistency/hardening change, not an overflow fix: every other formatted write in `src/libpgmoneta/network.c` already uses the bounded `pgmoneta_snprintf` (lines 171, 185, 220), and the sister project pgexporter already uses the bounded form here.

No behavioural change for valid ports.

close #1176