### PR TITLE
[#1186]Fix memory leak in sha512 verification

### DIFF
--- a/src/libpgmoneta/verify.c
+++ b/src/libpgmoneta/verify.c
@@ -375,10 +375,6 @@ pgmoneta_sha512_verification(char** argv)
          err = 1;
          goto server_cleanup;
       }
-      if (pgmoneta_deque_create(true, &labels))
-      {
-         goto server_cleanup;
-      }
       if (pgmoneta_storage_list_backup_labels(server, &labels))
       {
          goto server_cleanup;


### PR DESCRIPTION
why this removal: 

 In `verify.c`, before calling `pgmoneta_storage_list_backup_labels`, we were manually creating a deque:
 
But then on tracing the call stack, we see the very first thing `pgmoneta_storage_list_backup_labels` does is reset `*labels = NULL`, silently orphaning the allocation we just made,.
 
(also `pgmoneta_storage_list_backup_labels` already handles the deque creation internally)

- fixes #1186 
