### PR TITLE
Harden SCRAM iteration count

### DIFF
--- a/src/include/security.h
+++ b/src/include/security.h
@@ -39,6 +39,10 @@ extern "C" {
 #include <stdlib.h>
 #include <openssl/ssl.h>
 
+/* Largest SCRAM-SHA-256 iteration count we accept; caps the PBKDF2 work a peer
+ * can force on us. Well above PostgreSQL's default of 4096. */
+#define SCRAM_MAX_ITERATIONS 100000
+
 /** @struct hasher
  * Defines a hasher
  */

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -41,6 +41,9 @@
 #include <nmmintrin.h>
 #include <wmmintrin.h>
 #endif
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -99,6 +102,7 @@ static char* get_admin_password(char* username);
 
 static int sasl_prep(char* password, char** password_prep);
 static int generate_nounce(char** nounce);
+static int scram_parse_iterations(char* str, int* iterations);
 static int get_scram_attribute(char attribute, char* input, size_t size, char** value);
 static int client_proof(char* password, char* salt, int salt_length, int iterations,
                         char* client_first_message_bare, size_t client_first_message_bare_length,
@@ -516,7 +520,10 @@ pgmoneta_remote_management_scram_sha256(char* username, char* password, int serv
       goto error;
    }
 
-   iteration = atoi(iteration_string);
+   if (scram_parse_iterations(iteration_string, &iteration))
+   {
+      goto error;
+   }
 
    memset(&wo_proof[0], 0, sizeof(wo_proof));
    pgmoneta_snprintf(&wo_proof[0], sizeof(wo_proof), "c=biws,r=%s", combined_nounce);
@@ -1399,7 +1406,10 @@ server_scram256(char* username, char* password, SSL* ssl, int server_fd)
       goto error;
    }
 
-   iteration = atoi(iteration_string);
+   if (scram_parse_iterations(iteration_string, &iteration))
+   {
+      goto error;
+   }
 
    memset(&wo_proof[0], 0, sizeof(wo_proof));
    pgmoneta_snprintf(&wo_proof[0], sizeof(wo_proof), "c=biws,r=%s", combined_nounce);
@@ -2021,6 +2031,66 @@ generate_nounce(char** nounce)
 error:
 
    return 1;
+}
+
+/* Parse a SCRAM-SHA-256 iteration count from an untrusted peer. Unlike atoi()
+ * this rejects garbage, signs and overflow, and caps the value at
+ * SCRAM_MAX_ITERATIONS so a peer cannot force unbounded PBKDF2 work. */
+static int
+scram_parse_iterations(char* str, int* iterations)
+{
+   char* end = NULL;
+   long value;
+
+   *iterations = 0;
+
+   if (str == NULL || str[0] == '\0')
+   {
+      pgmoneta_log_error("SCRAM-SHA-256: missing iteration count");
+      return 1;
+   }
+
+   /* decimal digits only - no sign, whitespace or 0x prefix */
+   for (char* p = str; *p != '\0'; p++)
+   {
+      if (!isdigit((unsigned char)*p))
+      {
+         pgmoneta_log_error("SCRAM-SHA-256: invalid iteration count '%s'", str);
+         return 1;
+      }
+   }
+
+   errno = 0;
+   value = strtol(str, &end, 10);
+
+   if (errno != 0 || end == str || *end != '\0')
+   {
+      pgmoneta_log_error("SCRAM-SHA-256: invalid iteration count '%s'", str);
+      return 1;
+   }
+
+   if (value <= 0)
+   {
+      pgmoneta_log_error("SCRAM-SHA-256: non-positive iteration count '%s'", str);
+      return 1;
+   }
+
+   if (value > INT_MAX)
+   {
+      pgmoneta_log_error("SCRAM-SHA-256: iteration count '%s' is out of range", str);
+      return 1;
+   }
+
+   if (value > SCRAM_MAX_ITERATIONS)
+   {
+      pgmoneta_log_error("SCRAM-SHA-256: iteration count %ld exceeds the maximum of %d",
+                         value, SCRAM_MAX_ITERATIONS);
+      return 1;
+   }
+
+   *iterations = (int)value;
+
+   return 0;
 }
 
 static int


### PR DESCRIPTION
The SCRAM-SHA-256 iteration count from the server-first-message and the stored verifier was parsed with atoi() and used directly as the PBKDF2 loop count. atoi() ignores trailing garbage, accepts signs, and is undefined on overflow, and a large value lets a peer force unbounded PBKDF2 work.

Add scram_parse_iterations(), which accepts only a positive decimal value that fits in an int and is at most SCRAM_MAX_ITERATIONS (100000, well above PostgreSQL's default of 4096), and use it at every call site that previously parsed the count with atoi().