### PR TITLE
[#1117] Add progress tracking to Verify workflow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,3 +55,4 @@ Som Shegokar <akashshegokar2186@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
 Harshit Shaw <shawharshit116@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
+Rohan Mishra <kmrrohan29@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -62,6 +62,7 @@ Som Shegokar <akashshegokar2186@gmail.com>
 Ameen Sakr <ameensakr623@gmail.com>
 Harshit Shaw <shawharshit116@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
+Rohan Mishra <kmrrohan29@gmail.com>
 ```
 
 ## Committers

--- a/src/libpgmoneta/progress.c
+++ b/src/libpgmoneta/progress.c
@@ -202,7 +202,7 @@ calculate_fallback_weights(int workflow_type, int* phases, int n_phases, int* we
          /* TODO: Implement fallback weights for archive */
          break;
       case WORKFLOW_TYPE_VERIFY:
-         /* TODO: Implement fallback weights for verify */
+         weights[0] = 100;
          break;
       case WORKFLOW_TYPE_S3_LIST:
          weights[0] = 100;
@@ -310,7 +310,7 @@ pgmoneta_progress_setup(int server, struct workflow* workflow, struct art* nodes
          /* TODO: Implement adaptive/fallback weights for archive */
          break;
       case WORKFLOW_TYPE_VERIFY:
-         /* TODO: Implement adaptive/fallback weights for verify */
+         calculate_fallback_weights(workflow_type, phases, n_phases, weights);
          break;
       case WORKFLOW_TYPE_S3_LIST:
       case WORKFLOW_TYPE_S3_RESTORE:

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -31,6 +31,8 @@
 #include <csv.h>
 #include <logging.h>
 #include <management.h>
+#include <manifest.h>
+#include <progress.h>
 #include <security.h>
 #include <utils.h>
 #include <value.h>
@@ -116,6 +118,18 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
    manifest_file = pgmoneta_append(manifest_file, "/");
    manifest_file = pgmoneta_append(manifest_file, "backup.manifest");
 
+   if (pgmoneta_is_progress_enabled(server))
+   {
+      struct deque* manifest_paths = NULL;
+
+      if (pgmoneta_manifest_get_paths(manifest_file, &manifest_paths))
+      {
+         pgmoneta_log_error("Verify: Unable to get manifest paths for progress tracking: %s", manifest_file);
+         goto error;
+      }
+      pgmoneta_progress_set_total(server, pgmoneta_deque_size(manifest_paths));
+      pgmoneta_deque_destroy(manifest_paths);
+   }
    if (pgmoneta_deque_create(true, &failed_deque))
    {
       goto error;
@@ -171,7 +185,7 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
          goto error;
       }
 
-      if (pgmoneta_create_worker_input(NULL, NULL, NULL, -1, workers, &payload))
+      if (pgmoneta_create_worker_input(NULL, NULL, NULL, server, workers, &payload))
       {
          goto error;
       }
@@ -307,6 +321,11 @@ do_verify(struct worker_common* wc)
       pgmoneta_json_destroy(j);
    }
 
+   if (pgmoneta_is_progress_enabled(wi->level))
+   {
+      pgmoneta_progress_increment(wi->level, 1);
+   }
+
    wi->data = NULL;
    wi->failed = NULL;
    wi->all = NULL;
@@ -321,6 +340,11 @@ error:
    pgmoneta_log_error("Unable to calculate hash for %s", f);
 
    pgmoneta_json_destroy(wi->data);
+
+   if (pgmoneta_is_progress_enabled(wi->level))
+   {
+      pgmoneta_progress_increment(wi->level, 1);
+   }
 
    wi->data = NULL;
    wi->failed = NULL;


### PR DESCRIPTION
Closes #1117

This PR adds progress tracking to the Verify workflow, following the same framework introduced for backups in #1008.

Changes made:
- verify_execute() now sets the progress total using pgmoneta_manifest_get_paths() to count manifest entries before processing
- pgmoneta_create_worker_input() in wf_verify.c now passes server instead of -1, so worker callbacks know which server's progress to update
- do_verify() now increments progress after each file is processed, in both the success and error paths
- Added WORKFLOW_TYPE_VERIFY case to calculate_fallback_weights() in progress.c, setting weights[0] = 100 since verify has a single phase (hashing)
- Wired WORKFLOW_TYPE_VERIFY into the adaptive/fallback weight dispatcher to call calculate_fallback_weights()

Tested by building the project successfully with no errors.