### PR TITLE
[#1204]feat(test): MCTF Azure storage engine integration tests

### DIFF
--- a/contrib/azurite/pgmoneta-azure.conf.in
+++ b/contrib/azurite/pgmoneta-azure.conf.in
@@ -1,0 +1,25 @@
+[pgmoneta]
+host = localhost
+base_dir = BASE_DIR/backup
+compression = zstd
+retention = 7
+log_type = file
+log_level = debug5
+log_path = LOG_DIR/pgmoneta.log
+unix_socket_dir = /tmp/
+storage_engine = azure
+
+azure_storage_account = devstoreaccount1
+azure_shared_key = Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+azure_container = AZURE_CONTAINER
+azure_base_dir = pgmoneta
+azure_endpoint = 127.0.0.1
+azure_port = 10000
+azure_use_tls = off
+
+[primary]
+host = localhost
+port = PG_PORT
+user = PG_REPL_USER_NAME
+wal_slot = repl
+create_slot = yes

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -481,6 +481,9 @@ struct main_configuration
    char azure_container[MISC_LENGTH];       /**< The Azure container name */
    char azure_shared_key[MISC_LENGTH];      /**< The Azure storage account key */
    char azure_base_dir[MAX_PATH];           /**< The Azure base directory */
+   char azure_endpoint[MISC_LENGTH];        /**< The Azure endpoint override (e.g. 127.0.0.1 for Azurite) */
+   int azure_port;                          /**< The Azure port (0 = default 443) */
+   bool azure_use_tls;                      /**< Use TLS for Azure endpoint */
 
    int retention_days;     /**< The retention days for the server */
    int retention_weeks;    /**< The retention weeks for the server */

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -1583,6 +1583,50 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
+               else if (pgmoneta_compare_string(key, "azure_endpoint"))
+               {
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(config->azure_endpoint, value, max);
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+               }
+               else if (pgmoneta_compare_string(key, "azure_port"))
+               {
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
+                  {
+                     if (as_int(value, &config->azure_port))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+               }
+               else if (pgmoneta_compare_string(key, "azure_use_tls"))
+               {
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
+                  {
+                     if (as_bool(value, &config->azure_use_tls))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+               }
                else if (pgmoneta_compare_string(key, "workspace"))
                {
                   if (pgmoneta_compare_string(section, "pgmoneta"))

--- a/src/libpgmoneta/se_azure.c
+++ b/src/libpgmoneta/se_azure.c
@@ -137,6 +137,12 @@ azure_storage_execute(char* name __attribute__((unused)), struct art* nodes)
    base_dir = pgmoneta_get_server_backup(server);
    azure_root = azure_get_basepath(server, label);
 
+   if (pgmoneta_load_info(base_dir, label, &temp_backup))
+   {
+      pgmoneta_log_error("Unable to get backup for directory %s", base_dir);
+      goto error;
+   }
+
    if (azure_upload_files(local_root, azure_root, ""))
    {
       goto error;
@@ -149,11 +155,6 @@ azure_storage_execute(char* name __attribute__((unused)), struct art* nodes)
 #endif
 
    remote_azure_elapsed_time = pgmoneta_compute_duration(start_t, end_t);
-   if (pgmoneta_load_info(base_dir, label, &temp_backup))
-   {
-      pgmoneta_log_error("Unable to get backup for directory %s", base_dir);
-      goto error;
-   }
    temp_backup->remote_azure_elapsed_time = remote_azure_elapsed_time;
    if (pgmoneta_save_info(base_dir, temp_backup))
    {
@@ -163,13 +164,16 @@ azure_storage_execute(char* name __attribute__((unused)), struct art* nodes)
 
    free(temp_backup);
    free(local_root);
+   free(base_dir);
    free(azure_root);
 
    return 0;
 
 error:
 
+   free(temp_backup);
    free(local_root);
+   free(base_dir);
    free(azure_root);
 
    return 1;
@@ -424,6 +428,13 @@ azure_send_upload_request(char* local_root, char* azure_root, char* relative_pat
    string_to_sign = pgmoneta_append(string_to_sign, "\nx-ms-version:2021-08-06\n/");
    string_to_sign = pgmoneta_append(string_to_sign, config->azure_storage_account);
    string_to_sign = pgmoneta_append(string_to_sign, "/");
+   /* For path-style endpoints (Azurite), the URI already contains /<account>/<container>/<blob>.
+    * The canonical resource is "/" + account_name + uri_path, so the account appears twice. */
+   if (strlen(config->azure_endpoint) > 0)
+   {
+      string_to_sign = pgmoneta_append(string_to_sign, config->azure_storage_account);
+      string_to_sign = pgmoneta_append(string_to_sign, "/");
+   }
    string_to_sign = pgmoneta_append(string_to_sign, config->azure_container);
    string_to_sign = pgmoneta_append(string_to_sign, "/");
    string_to_sign = pgmoneta_append(string_to_sign, azure_path);
@@ -450,13 +461,28 @@ azure_send_upload_request(char* local_root, char* azure_root, char* relative_pat
 
    azure_host = azure_get_host();
 
-   if (pgmoneta_http_create(azure_host, 443, true, &connection))
    {
-      pgmoneta_log_error("Failed to connect to Azure host: %s", azure_host);
-      goto error;
-   }
+      bool use_endpoint = (strlen(config->azure_endpoint) > 0);
+      int conn_port = use_endpoint ? (config->azure_port > 0 ? config->azure_port : 443) : 443;
+      bool conn_tls = use_endpoint ? config->azure_use_tls : true;
 
-   pgmoneta_snprintf(azure_put_path, sizeof(azure_put_path), "/%s/%s", config->azure_container, azure_path);
+      if (pgmoneta_http_create(azure_host, conn_port, conn_tls, &connection))
+      {
+         pgmoneta_log_error("Failed to connect to Azure host: %s:%d", azure_host, conn_port);
+         goto error;
+      }
+
+      if (use_endpoint)
+      {
+         pgmoneta_snprintf(azure_put_path, sizeof(azure_put_path), "/%s/%s/%s",
+                           config->azure_storage_account, config->azure_container, azure_path);
+      }
+      else
+      {
+         pgmoneta_snprintf(azure_put_path, sizeof(azure_put_path), "/%s/%s",
+                           config->azure_container, azure_path);
+      }
+   }
 
    if (pgmoneta_http_request_create(PGMONETA_HTTP_PUT, azure_put_path, &request))
    {
@@ -599,8 +625,15 @@ azure_get_host()
 
    config = (struct main_configuration*)shmem;
 
-   host = pgmoneta_append(host, config->azure_storage_account);
-   host = pgmoneta_append(host, ".blob.core.windows.net");
+   if (strlen(config->azure_endpoint) > 0)
+   {
+      host = pgmoneta_append(host, config->azure_endpoint);
+   }
+   else
+   {
+      host = pgmoneta_append(host, config->azure_storage_account);
+      host = pgmoneta_append(host, ".blob.core.windows.net");
+   }
 
    return host;
 }

--- a/test/check.sh
+++ b/test/check.sh
@@ -508,7 +508,9 @@ execute_testcases() {
    echo "Start running MCTF tests"
    if [[ -f "$TEST_DIRECTORY/pgmoneta-test" ]]; then
       TEST_FILTER_ARGS=()
-      if [[ -n "${TEST_FILTER:-}" ]]; then
+      if [[ "${INTEGRATION_MODE:-false}" == "true" ]]; then
+         TEST_FILTER_ARGS=(-i)
+      elif [[ -n "${TEST_FILTER:-}" ]]; then
          TEST_FILTER_ARGS=(-t "$TEST_FILTER")
       elif [[ -n "${MODULE_FILTER:-}" ]]; then
          TEST_FILTER_ARGS=(-m "$MODULE_FILTER")
@@ -535,11 +537,17 @@ usage() {
    echo "Options (run tests with optional filter; default is full suite):"
    echo " -t, --test NAME     Run only tests matching NAME"
    echo " -m, --module NAME   Run all tests in module NAME"
+   echo " -i, --integration   Run only the storage-engine integration tests (all backends)"
+   echo "Note: PGMONETA_TEST_PORT overrides the default container port (6432)"
    echo "Examples:"
-   echo "  $0                  Run full test suite"
-   echo "  $0 build            Set up environment only; then run e.g. $0 -t backup_full"
-   echo "  $0 -t backup_full   Run test matching 'backup_full' (runs build if needed)"
-   echo "  $0 -m restore       Run all tests in module 'restore'"
+   echo "  $0                           Run full test suite"
+   echo "  $0 build                     Set up environment only; then run e.g. $0 -t backup_full"
+   echo "  $0 -t backup_full            Run test matching 'backup_full' (runs build if needed)"
+   echo "  $0 -m restore                Run all tests in module 'restore'"
+   echo "  $0 -m azure                  Run Azure integration tests"
+   echo "  $0 -m s3                     Run S3/Garage integration tests"
+   echo "  $0 -i                        Run all storage-engine integration tests"
+   echo "  PGMONETA_TEST_PORT=6433 $0   Use port 6433 for the PostgreSQL container"
    exit 1
 }
 
@@ -561,21 +569,27 @@ run_tests() {
 
 TEST_FILTER=""
 MODULE_FILTER=""
+INTEGRATION_MODE=false
 SUBCOMMAND=""
 while [[ $# -gt 0 ]]; do
    case "$1" in
       -t|--test)
-         [[ -n "$MODULE_FILTER" ]] && { echo "Error: Cannot specify both -t and -m options"; usage; }
+         [[ -n "$MODULE_FILTER" || "$INTEGRATION_MODE" == "true" ]] && { echo "Error: Cannot combine -t with -m or -i"; usage; }
          shift
          [[ $# -eq 0 ]] && { echo "Error: -t/--test requires NAME"; usage; }
          TEST_FILTER="$1"
          shift
          ;;
       -m|--module)
-         [[ -n "$TEST_FILTER" ]] && { echo "Error: Cannot specify both -t and -m options"; usage; }
+         [[ -n "$TEST_FILTER" || "$INTEGRATION_MODE" == "true" ]] && { echo "Error: Cannot combine -m with -t or -i"; usage; }
          shift
          [[ $# -eq 0 ]] && { echo "Error: -m/--module requires NAME"; usage; }
          MODULE_FILTER="$1"
+         shift
+         ;;
+      -i|--integration)
+         [[ -n "$TEST_FILTER" || -n "$MODULE_FILTER" ]] && { echo "Error: Cannot combine -i with -t or -m"; usage; }
+         INTEGRATION_MODE=true
          shift
          ;;
       build)

--- a/test/include/mctf_container.h
+++ b/test/include/mctf_container.h
@@ -55,8 +55,8 @@ extern "C" {
  * Well-known container kinds the framework knows how to start.
  */
 enum mctf_container_kind {
-   MCTF_CONTAINER_GARAGE = 0 /**< Garage, an S3-compatible object store */
-   /* TODO: add more container kinds as backends land (e.g. Azurite, SSH, PostgreSQL) */
+   MCTF_CONTAINER_GARAGE = 0, /**< Garage, an S3-compatible object store */
+   MCTF_CONTAINER_AZURITE = 1 /**< Azurite, a local Azure Blob Storage emulator */
 };
 
 /**

--- a/test/include/mctf_se.h
+++ b/test/include/mctf_se.h
@@ -53,8 +53,8 @@ extern "C" {
  * Storage backends supported by the integration-test layer.
  */
 enum mctf_backend {
-   MCTF_BACKEND_GARAGE = 0 /**< S3, emulated by Garage */
-   /* future: MCTF_BACKEND_AZURITE, MCTF_BACKEND_SSH, MCTF_BACKEND_GCS, ... */
+   MCTF_BACKEND_GARAGE = 0, /**< S3, emulated by Garage */
+   MCTF_BACKEND_AZURITE = 1 /**< Azure Blob Storage, emulated by Azurite */
 };
 
 /**
@@ -98,8 +98,17 @@ struct mctf_se_driver
    void (*stop)(struct mctf_se* s);
 
    /**
-    * Emit the backend-specific server configuration lines (e.g. the s3_*
-    * keys) into the [primary] section of the managed pgmoneta.conf.
+    * Emit backend-specific global configuration lines (e.g. azure_* keys)
+    * into the [pgmoneta] section of the managed pgmoneta.conf.
+    * Optional: set to NULL when all config belongs in the server section.
+    * @return MCTF_OK on success, otherwise MCTF_FAIL
+    */
+   int (*write_global_conf)(struct mctf_se* s, FILE* f);
+
+   /**
+    * Emit backend-specific per-server configuration lines (e.g. s3_* keys)
+    * into the [primary] section of the managed pgmoneta.conf.
+    * Optional: set to NULL when all config belongs in the global section.
     * @return MCTF_OK on success, otherwise MCTF_FAIL
     */
    int (*write_server_conf)(struct mctf_se* s, FILE* f);
@@ -197,6 +206,16 @@ mctf_se_run_dir(void);
  */
 const struct mctf_se*
 mctf_se_context(void);
+
+/**
+ * Count the number of blobs in the active Azurite container by querying
+ * the Blob Storage REST API directly using SharedKey authentication.
+ * This is the Azure equivalent of `pgmoneta-cli s3 ls`.
+ *
+ * @return Number of blobs (>= 0), or -1 on error / no active backend
+ */
+int
+mctf_se_azure_blob_count(void);
 
 #ifdef __cplusplus
 }

--- a/test/libpgmonetatest/backends/azurite.c
+++ b/test/libpgmonetatest/backends/azurite.c
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * Azurite backend driver.
+ *
+ * Azurite is a local Azure Blob Storage emulator; it stands in for Azure so
+ * the real se_azure code path is exercised. The container lifecycle is handled
+ * by MCTF_START_CONTAINER; this driver adds the provisioning step (create the
+ * blob container) and the server configuration lines.
+ *
+ * Azurite well-known credentials (public, for local development only):
+ *   Account : devstoreaccount1
+ *   Key     : Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/
+ *             K1SZFPTOtr/KBHBeksoGMGw==
+ *
+ * Container creation uses the SharedKey REST API via a Python3 stdlib script
+ * (no external packages). Python runs as a subprocess so it is isolated from
+ * the test process's pgmoneta context, which is not yet initialized at
+ * provisioning time (pgmoneta daemon starts after provision completes).
+ */
+
+#include <pgmoneta.h>
+#include <logging.h>
+#include <mctf_container.h>
+#include <mctf_se.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define AZURITE_ACCOUNT   "devstoreaccount1"
+#define AZURITE_KEY       "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+#define AZURITE_CONTAINER "pgmoneta-test-container"
+#define AZURITE_BLOB_PORT 10000
+
+/*
+ * Create the blob container in Azurite via Python3 stdlib (no external packages).
+ *
+ * Python runs as a subprocess so it is fully isolated from the test process's
+ * pgmoneta context. provision() is called before the managed pgmoneta daemon
+ * starts, so pgmoneta's shmem and HTTP stack are not yet usable here.
+ *
+ * Azurite quirks vs. production Azure SharedKey:
+ *   1. Content-Length in the canonical string must be '' (empty), not '0',
+ *      even for a PUT with an empty body.
+ *   2. Canonical resource uses the account name twice for path-style URLs:
+ *      /{account}/{account}/{container}\nrestype:container
+ */
+static int
+provision(struct mctf_se* s)
+{
+   char script_path[256];
+   FILE* f;
+   int rc;
+
+   (void)s;
+
+   snprintf(script_path, sizeof(script_path), "/tmp/mctf-azurite-provision-%d.py", (int)getpid());
+   f = fopen(script_path, "w");
+   if (f == NULL)
+   {
+      pgmoneta_log_error("azurite: cannot write provisioning script");
+      return MCTF_FAIL;
+   }
+
+   fprintf(f,
+      "import base64, hashlib, hmac, datetime, http.client, sys\n"
+      "\n"
+      "ACCOUNT   = '%s'\n"
+      "KEY_B64   = '%s'\n"
+      "CONTAINER = '%s'\n"
+      "PORT      = %d\n"
+      "VERSION   = '2020-08-04'\n"
+      "\n"
+      "now = datetime.datetime.utcnow().strftime('%%a, %%d %%b %%Y %%H:%%M:%%S GMT')\n"
+      "\n"
+      "string_to_sign = (\n"
+      "    'PUT\\n'\n"
+      "    '\\n'   # Content-Encoding\n"
+      "    '\\n'   # Content-Language\n"
+      "    '\\n'   # Content-Length (empty, not '0' — Azurite quirk)\n"
+      "    '\\n'   # Content-MD5\n"
+      "    '\\n'   # Content-Type\n"
+      "    '\\n'   # Date (empty; using x-ms-date)\n"
+      "    '\\n'   # If-Modified-Since\n"
+      "    '\\n'   # If-Match\n"
+      "    '\\n'   # If-None-Match\n"
+      "    '\\n'   # If-Unmodified-Since\n"
+      "    '\\n'   # Range\n"
+      "    f'x-ms-date:{now}\\n'\n"
+      "    f'x-ms-version:{VERSION}\\n'\n"
+      "    f'/{ACCOUNT}/{ACCOUNT}/{CONTAINER}\\nrestype:container'\n"
+      ")\n"
+      "\n"
+      "key = base64.b64decode(KEY_B64)\n"
+      "sig = base64.b64encode(\n"
+      "    hmac.new(key, string_to_sign.encode('utf-8'), hashlib.sha256).digest()\n"
+      ").decode()\n"
+      "\n"
+      "conn = http.client.HTTPConnection('127.0.0.1', PORT)\n"
+      "conn.request('PUT', f'/{ACCOUNT}/{CONTAINER}?restype=container', body=b'', headers={\n"
+      "    'x-ms-date':     now,\n"
+      "    'x-ms-version':  VERSION,\n"
+      "    'Content-Length': '0',\n"
+      "    'Authorization': f'SharedKey {ACCOUNT}:{sig}',\n"
+      "})\n"
+      "resp = conn.getresponse()\n"
+      "body = resp.read().decode(errors='replace')\n"
+      "conn.close()\n"
+      "if resp.status == 201:\n"
+      "    print(f'container {CONTAINER!r} created')\n"
+      "elif resp.status == 409:\n"
+      "    print(f'container {CONTAINER!r} already exists')\n"
+      "else:\n"
+      "    print(f'HTTP {resp.status}: {body}', file=sys.stderr)\n"
+      "    sys.exit(1)\n",
+      AZURITE_ACCOUNT, AZURITE_KEY, AZURITE_CONTAINER, AZURITE_BLOB_PORT);
+
+   fclose(f);
+
+   rc = mctf_sh(NULL, "python3 %s", script_path);
+   unlink(script_path);
+
+   return (rc == 0) ? MCTF_OK : MCTF_FAIL;
+}
+
+static int
+azurite_start(struct mctf_se* s)
+{
+   int rc;
+
+   rc = MCTF_START_CONTAINER(&s->container, MCTF_CONTAINER_AZURITE);
+   if (rc != MCTF_OK)
+   {
+      return rc;
+   }
+   fprintf(stderr, "    - container started\n");
+   fflush(stderr);
+
+   if (provision(s) != MCTF_OK)
+   {
+      return MCTF_FAIL;
+   }
+   fprintf(stderr, "    - blob container provisioned\n");
+   fflush(stderr);
+
+   snprintf(s->endpoint,   sizeof(s->endpoint),   "127.0.0.1");
+   snprintf(s->access_key, sizeof(s->access_key),  "%s", AZURITE_ACCOUNT);
+   snprintf(s->secret_key, sizeof(s->secret_key),  "%s", AZURITE_KEY);
+   snprintf(s->bucket,     sizeof(s->bucket),      "%s", AZURITE_CONTAINER);
+   s->port    = AZURITE_BLOB_PORT;
+   s->use_tls = false;
+
+   return MCTF_OK;
+}
+
+static void
+azurite_stop(struct mctf_se* s)
+{
+   MCTF_STOP_CONTAINER(&s->container);
+}
+
+static int
+azurite_write_global_conf(struct mctf_se* s, FILE* f)
+{
+   /* Azure settings are global (main_configuration), not per-server. */
+   fprintf(f, "azure_storage_account = %s\n", s->access_key);
+   fprintf(f, "azure_shared_key = %s\n",      s->secret_key);
+   fprintf(f, "azure_container = %s\n",        s->bucket);
+   fprintf(f, "azure_base_dir = pgmoneta\n");
+   fprintf(f, "azure_endpoint = %s\n",         s->endpoint);
+   fprintf(f, "azure_port = %d\n",             s->port);
+   fprintf(f, "azure_use_tls = %s\n",          s->use_tls ? "on" : "off");
+   return MCTF_OK;
+}
+
+const struct mctf_se_driver mctf_azurite_driver = {
+   .name              = "azurite",
+   .storage_engine    = "azure",
+   .start             = azurite_start,
+   .stop              = azurite_stop,
+   .write_global_conf = azurite_write_global_conf,
+   .write_server_conf = NULL,
+};

--- a/test/libpgmonetatest/mctf_container.c
+++ b/test/libpgmonetatest/mctf_container.c
@@ -46,11 +46,17 @@
 #define GARAGE_READY_CMD     "/garage -c /etc/garage.toml status"
 #define GARAGE_READY_RETRIES 30
 
+/* Azurite (Azure Blob Storage emulator) container definition. */
+#define AZURITE_IMAGE         "mcr.microsoft.com/azure-storage/azurite"
+#define AZURITE_BLOB_PORT     10000
+#define AZURITE_READY_RETRIES 30
+
 /* Image-pull retry policy (transient registry failures). */
 #define PULL_RETRIES         3
 #define PULL_BACKOFF_SECONDS 2
 
 static int start_garage(struct mctf_container* c);
+static int start_azurite(struct mctf_container* c);
 
 int
 mctf_sh(char** output, const char* fmt, ...)
@@ -248,11 +254,53 @@ mctf_container_start(struct mctf_container* c, enum mctf_container_kind kind)
    {
       case MCTF_CONTAINER_GARAGE:
          return start_garage(c);
-      /* TODO: add cases for new container kinds as backends land */
+      case MCTF_CONTAINER_AZURITE:
+         return start_azurite(c);
       default:
          pgmoneta_log_error("mctf_container: unknown kind %d", (int)kind);
          return MCTF_FAIL;
    }
+}
+
+static int
+start_azurite(struct mctf_container* c)
+{
+   char name[128];
+   int i;
+
+   snprintf(name, sizeof(name), "pgmoneta-mctf-azurite-%d", (int)getpid());
+   snprintf(c->name, sizeof(c->name), "%s", name);
+
+   mctf_container_pull(c->engine, AZURITE_IMAGE, PULL_RETRIES);
+
+   /* Remove any stale container with the same name. */
+   mctf_sh(NULL, "%s rm -f %s 2>/dev/null", c->engine, name);
+
+   /* Start blob-only with --skipApiVersionCheck (modern SDK API versions). */
+   if (mctf_sh(NULL, "%s run -d --name %s --label %s --network host %s "
+               "azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck",
+               c->engine, name, MCTF_CONTAINER_LABEL, AZURITE_IMAGE) != 0)
+   {
+      pgmoneta_log_error("mctf_container: failed to start azurite");
+      return MCTF_FAIL;
+   }
+   c->running = true;
+
+   /* Wait until the blob port accepts TCP connections (checked from the host). */
+   for (i = 0; i < AZURITE_READY_RETRIES; i++)
+   {
+      if (mctf_sh(NULL, "python3 -c \""
+                  "import socket, sys; s=socket.socket(); s.settimeout(1); "
+                  "s.connect(('127.0.0.1', %d)); s.close()"
+                  "\" 2>/dev/null", AZURITE_BLOB_PORT) == 0)
+      {
+         return MCTF_OK;
+      }
+      sleep(1);
+   }
+
+   pgmoneta_log_error("mctf_container: azurite not ready after %d s", AZURITE_READY_RETRIES);
+   return MCTF_FAIL;
 }
 
 static int

--- a/test/libpgmonetatest/mctf_se.c
+++ b/test/libpgmonetatest/mctf_se.c
@@ -29,12 +29,15 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <http.h>
 #include <info.h>
 #include <logging.h>
 #include <mctf_container.h>
 #include <mctf_se.h>
+#include <security.h>
 #include <shmem.h>
 #include <tscommon.h>
+#include <utils.h>
 
 /* system */
 #include <signal.h>
@@ -56,13 +59,13 @@
  * driver below, and add one row to the table. Nothing else changes.
  */
 extern const struct mctf_se_driver mctf_garage_driver;
-/* extern const struct mctf_se_driver mctf_azurite_driver; */
-/* extern const struct mctf_se_driver mctf_ssh_driver;     */
+extern const struct mctf_se_driver mctf_azurite_driver;
+/* extern const struct mctf_se_driver mctf_ssh_driver; */
 
 static const struct mctf_se_driver* registry[] = {
-   [MCTF_BACKEND_GARAGE] = &mctf_garage_driver,
-   /* [MCTF_BACKEND_AZURITE] = &mctf_azurite_driver, */
-   /* [MCTF_BACKEND_SSH]     = &mctf_ssh_driver,     */
+   [MCTF_BACKEND_GARAGE]  = &mctf_garage_driver,
+   [MCTF_BACKEND_AZURITE] = &mctf_azurite_driver,
+   /* [MCTF_BACKEND_SSH] = &mctf_ssh_driver, */
 };
 
 /* Managed-instance state (single active backend). */
@@ -118,6 +121,14 @@ write_confs(void)
    fprintf(f, "unix_socket_dir = %s/\n", sock_dir);
    fprintf(f, "pidfile = %s/pgmoneta.pid\n", run_dir);
    fprintf(f, "workspace = %s/workspace\n", run_dir);
+   if (storage.driver->write_global_conf != NULL)
+   {
+      if (storage.driver->write_global_conf(&storage, f) != MCTF_OK)
+      {
+         fclose(f);
+         return MCTF_FAIL;
+      }
+   }
    fprintf(f, "\n");
    fprintf(f, "[primary]\n");
    fprintf(f, "host = %s\n", primary->host);
@@ -125,10 +136,13 @@ write_confs(void)
    fprintf(f, "user = %s\n", primary->username);
    fprintf(f, "wal_slot = mctf_se\n");
    fprintf(f, "create_slot = yes\n");
-   if (storage.driver->write_server_conf(&storage, f) != MCTF_OK)
+   if (storage.driver->write_server_conf != NULL)
    {
-      fclose(f);
-      return MCTF_FAIL;
+      if (storage.driver->write_server_conf(&storage, f) != MCTF_OK)
+      {
+         fclose(f);
+         return MCTF_FAIL;
+      }
    }
    fclose(f);
 
@@ -414,4 +428,134 @@ const struct mctf_se*
 mctf_se_context(void)
 {
    return storage_active ? &storage : NULL;
+}
+
+int
+mctf_se_azure_blob_count(void)
+{
+   const struct mctf_se* ctx = mctf_se_context();
+   char utc_date[UTC_TIME_LENGTH];
+   char* string_to_sign = NULL;
+   char* signing_key = NULL;
+   char* base64_signature = NULL;
+   size_t base64_signature_length = 0;
+   char* auth_value = NULL;
+   unsigned char* signature_hmac = NULL;
+   int hmac_length = 0;
+   size_t signing_key_length = 0;
+   struct http* connection = NULL;
+   struct http_request* request = NULL;
+   struct http_response* response = NULL;
+   char request_path[512];
+   char* body = NULL;
+   char* p = NULL;
+   int count = -1;
+
+   if (ctx == NULL || ctx->driver == NULL)
+   {
+      goto done;
+   }
+
+   memset(utc_date, 0, sizeof(utc_date));
+   if (pgmoneta_get_timestamp_UTC_format(utc_date))
+   {
+      goto done;
+   }
+
+   /*
+    * Canonical string for Azurite list-blobs (GET).
+    * Content-Length is empty (not "0") for GET requests.
+    * Canonical resource uses the account name twice for path-style URLs:
+    *   /{account}/{account}/{container}\ncomp:list\nrestype:container
+    */
+   string_to_sign = pgmoneta_append(string_to_sign, "GET\n\n\n\n\n\n\n\n\n\n\n\n");
+   string_to_sign = pgmoneta_append(string_to_sign, "x-ms-date:");
+   string_to_sign = pgmoneta_append(string_to_sign, utc_date);
+   string_to_sign = pgmoneta_append(string_to_sign, "\nx-ms-version:2020-08-04\n/");
+   string_to_sign = pgmoneta_append(string_to_sign, ctx->access_key);
+   string_to_sign = pgmoneta_append(string_to_sign, "/");
+   string_to_sign = pgmoneta_append(string_to_sign, ctx->access_key);
+   string_to_sign = pgmoneta_append(string_to_sign, "/");
+   string_to_sign = pgmoneta_append(string_to_sign, ctx->bucket);
+   string_to_sign = pgmoneta_append(string_to_sign, "\ncomp:list\nrestype:container");
+
+   if (pgmoneta_base64_decode((char*)ctx->secret_key, strlen(ctx->secret_key), (void**)&signing_key, &signing_key_length))
+   {
+      goto done;
+   }
+
+   if (pgmoneta_generate_string_hmac_sha256_hash(signing_key, (int)signing_key_length,
+                                                  string_to_sign, strlen(string_to_sign),
+                                                  &signature_hmac, &hmac_length))
+   {
+      goto done;
+   }
+
+   if (pgmoneta_base64_encode((char*)signature_hmac, hmac_length, &base64_signature, &base64_signature_length))
+   {
+      goto done;
+   }
+
+   auth_value = pgmoneta_append(auth_value, "SharedKey ");
+   auth_value = pgmoneta_append(auth_value, ctx->access_key);
+   auth_value = pgmoneta_append(auth_value, ":");
+   auth_value = pgmoneta_append(auth_value, base64_signature);
+
+   if (pgmoneta_http_create((char*)ctx->endpoint, ctx->port, ctx->use_tls, &connection))
+   {
+      goto done;
+   }
+
+   pgmoneta_snprintf(request_path, sizeof(request_path),
+                     "/%s/%s?restype=container&comp=list",
+                     ctx->access_key, ctx->bucket);
+
+   if (pgmoneta_http_request_create(PGMONETA_HTTP_GET, request_path, &request))
+   {
+      goto done;
+   }
+
+   pgmoneta_http_request_add_header(request, "x-ms-date", utc_date);
+   pgmoneta_http_request_add_header(request, "x-ms-version", "2020-08-04");
+   pgmoneta_http_request_add_header(request, "Authorization", auth_value);
+
+   if (pgmoneta_http_invoke(connection, request, &response))
+   {
+      goto done;
+   }
+
+   if (response == NULL || response->status_code != 200 || response->payload.data_size == 0)
+   {
+      goto done;
+   }
+
+   /* Count <Blob> tags in the XML response to determine how many blobs exist. */
+   body = malloc(response->payload.data_size + 1);
+   if (body == NULL)
+   {
+      goto done;
+   }
+   memcpy(body, response->payload.data, response->payload.data_size);
+   body[response->payload.data_size] = '\0';
+
+   count = 0;
+   p = body;
+   while ((p = strstr(p, "<Blob>")) != NULL)
+   {
+      count++;
+      p += 6;
+   }
+
+done:
+   free(body);
+   free(string_to_sign);
+   free(signing_key);
+   free(base64_signature);
+   free(auth_value);
+   free(signature_hmac);
+   pgmoneta_http_request_destroy(request);
+   pgmoneta_http_response_destroy(response);
+   pgmoneta_http_destroy(connection);
+
+   return count;
 }

--- a/test/testcases/test_azure.c
+++ b/test/testcases/test_azure.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * Storage-engine integration tests: Azure Blob Storage via Azurite.
+ *
+ * The entire backend lifecycle (start the Azurite container, provision the
+ * blob container, configure and start a dedicated pgmoneta, tear everything
+ * down) is handled by mctf_se. A test only states intent.
+ *
+ * Blob-side verification uses a direct Azurite REST query (python3 stdlib,
+ * SharedKey auth) to count blobs in the container — equivalent to what
+ * mctf_se_s3_ls does for S3. Indirect signals are also checked:
+ *   - STATUS=1 in backup.info confirms the upload completed successfully
+ *   - the local data/ subdirectory is removed by azure_storage_teardown when
+ *     STORAGE_ENGINE_LOCAL is not set — this proves the teardown ran
+ */
+
+#include <mctf.h>
+#include <mctf_container.h>
+#include <mctf_se.h>
+#include <tscommon.h>
+#include <utils.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int storage_status = MCTF_FAIL;
+static char shared_label[256];
+
+/* Return the lexicographically largest (newest) backup label for primary. */
+static int
+newest_backup_label(char* out, size_t size)
+{
+   char backup_dir[MAX_PATH];
+   char** dirs = NULL;
+   int ndir = 0;
+   int best = -1;
+
+   snprintf(backup_dir, sizeof(backup_dir), "%s/backup/primary/backup", mctf_se_run_dir());
+   pgmoneta_get_directories(backup_dir, &ndir, &dirs);
+   if (ndir <= 0 || dirs == NULL)
+      return MCTF_FAIL;
+
+   for (int i = 0; i < ndir; i++)
+   {
+      if (best < 0 || strcmp(dirs[i], dirs[best]) > 0)
+         best = i;
+   }
+   snprintf(out, size, "%s", dirs[best]);
+
+   for (int i = 0; i < ndir; i++)
+      free(dirs[i]);
+   free(dirs);
+
+   return out[0] != '\0' ? MCTF_OK : MCTF_FAIL;
+}
+
+MCTF_MODULE_SETUP(azure)
+{
+   memset(shared_label, 0, sizeof(shared_label));
+   storage_status = mctf_se_up(MCTF_BACKEND_AZURITE);
+   if (storage_status == MCTF_OK)
+   {
+      if (mctf_se_backup("primary") != 0 ||
+          newest_backup_label(shared_label, sizeof(shared_label)) != MCTF_OK)
+      {
+         storage_status = MCTF_FAIL;
+      }
+   }
+}
+
+MCTF_MODULE_TEARDOWN(azure)
+{
+   mctf_se_down();
+}
+
+/* Verify blobs physically exist in Azurite by querying its list-blobs REST API. */
+MCTF_INTEGRATION_TEST(test_azure_blobs_exist_in_container)
+{
+   int blob_count;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   blob_count = mctf_se_azure_blob_count();
+   MCTF_ASSERT(blob_count > 0, cleanup,
+               "Azurite container is empty after backup — se_azure.c did not upload any blobs");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Verify backup.info contains STATUS=1, confirming the upload completed without error. */
+MCTF_INTEGRATION_TEST(test_azure_backup_info_is_valid)
+{
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+   MCTF_ASSERT(shared_label[0] != '\0', cleanup, "no backup label available");
+
+   MCTF_ASSERT(
+      mctf_sh(NULL, "grep -q 'STATUS=1' %s/backup/primary/backup/%s/backup.info",
+              mctf_se_run_dir(), shared_label) == 0,
+      cleanup, "backup.info does not contain STATUS=1 (upload may have failed)");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Verify the local data/ directory is removed after upload, confirming teardown ran. */
+MCTF_INTEGRATION_TEST(test_azure_backup_removes_local_data)
+{
+   char data_path[MAX_PATH];
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+   MCTF_ASSERT(shared_label[0] != '\0', cleanup, "no backup label available");
+
+   snprintf(data_path, sizeof(data_path), "%s/backup/primary/backup/%s/data",
+            mctf_se_run_dir(), shared_label);
+
+   MCTF_ASSERT(access(data_path, F_OK) != 0, cleanup,
+               "local data/ directory still exists after azure-only backup (teardown failed)");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Verify a second consecutive backup also succeeds, guarding against WAL or connection regressions. */
+MCTF_INTEGRATION_TEST(test_azure_second_backup_succeeds)
+{
+   char label2[256] = {0};
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   MCTF_ASSERT(mctf_se_backup("primary") == 0, cleanup, "second backup to Azure failed");
+   MCTF_ASSERT(newest_backup_label(label2, sizeof(label2)) == MCTF_OK, cleanup,
+               "could not resolve second backup label");
+
+   /* The new label must be different from (and lexicographically after) the first. */
+   MCTF_ASSERT(strcmp(label2, shared_label) > 0, cleanup,
+               "second backup label is not newer than first");
+
+   MCTF_ASSERT(
+      mctf_sh(NULL, "grep -q 'STATUS=1' %s/backup/primary/backup/%s/backup.info",
+              mctf_se_run_dir(), label2) == 0,
+      cleanup, "second backup.info does not contain STATUS=1");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
- closes #1204 

changes includes: 
- Add `azure_endpoint`, `azure_port`, `azure_use_tls` config options to support custom endpoints
- Fix `se_azure.c` to work with path-style URLs and correct auth signing for Azurite
- Fix two memory leaks in `se_azure.c`
- Add Azurite container backend driver for test infrastructure
- Add 4 Azure Blob Storage integration tests