### PR TITLE
[#1206]feat(test): MCTF SSH storage engine integration tests

### DIFF
--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -474,6 +474,7 @@ struct main_configuration
    char ssh_ciphers[MISC_LENGTH];       /**< The SSH supported ciphers */
    char ssh_public_key_file[MAX_PATH];  /**< The SSH public key path */
    char ssh_private_key_file[MAX_PATH]; /**< The SSH private key path */
+   int ssh_port;                        /**< The SSH port (0 = default 22) */
 
    struct s3_configuration s3; /**< The S3 configuration */
 

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -1302,6 +1302,20 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
+               else if (pgmoneta_compare_string(key, "ssh_port"))
+               {
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
+                  {
+                     if (as_int(value, &config->ssh_port))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+               }
                else if (pgmoneta_compare_string(key, "s3_use_tls"))
                {
                   if (pgmoneta_compare_string(section, "pgmoneta"))

--- a/src/libpgmoneta/se_ssh.c
+++ b/src/libpgmoneta/se_ssh.c
@@ -135,13 +135,13 @@ ssh_storage_setup(char* name __attribute__((unused)), struct art* nodes)
    pgmoneta_dump_art(nodes);
 
    assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
-   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
 #endif
 
    server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
    label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
 
-   pgmoneta_log_debug("SSH storage engine (setup): %s/%s", config->common.servers[server].name, label);
+   pgmoneta_log_debug("SSH storage engine (setup): %s/%s", config->common.servers[server].name,
+                      label != NULL ? label : "(wal)");
 
    session = ssh_new();
 
@@ -152,6 +152,11 @@ ssh_storage_setup(char* name __attribute__((unused)), struct art* nodes)
 
    ssh_options_set(session, SSH_OPTIONS_USER, config->ssh_username);
    ssh_options_set(session, SSH_OPTIONS_HOST, config->ssh_hostname);
+   if (config->ssh_port > 0)
+   {
+      unsigned int port = (unsigned int)config->ssh_port;
+      ssh_options_set(session, SSH_OPTIONS_PORT, &port);
+   }
 
    if (strlen(config->ssh_ciphers) == 0)
    {
@@ -448,13 +453,13 @@ ssh_storage_wal_shipping_execute(char* name __attribute__((unused)), struct art*
    pgmoneta_dump_art(nodes);
 
    assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
-   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
 #endif
 
    server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
    label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
 
-   pgmoneta_log_debug("SSH storage engine (WAL shipping/execute): %s/%s", config->common.servers[server].name, label);
+   pgmoneta_log_debug("SSH storage engine (WAL shipping/execute): %s/%s", config->common.servers[server].name,
+                      label != NULL ? label : "(wal)");
 
    remote_root = get_remote_server_wal(server);
    local_root = pgmoneta_get_server_wal(server);
@@ -538,13 +543,13 @@ ssh_storage_wal_shipping_teardown(char* name __attribute__((unused)), struct art
    pgmoneta_dump_art(nodes);
 
    assert(pgmoneta_art_contains_key(nodes, NODE_SERVER_ID));
-   assert(pgmoneta_art_contains_key(nodes, NODE_LABEL));
 #endif
 
    server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
    label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
 
-   pgmoneta_log_debug("SSH storage engine (WAL shipping/teardown): %s/%s", config->common.servers[server].name, label);
+   pgmoneta_log_debug("SSH storage engine (WAL shipping/teardown): %s/%s", config->common.servers[server].name,
+                      label != NULL ? label : "(wal)");
 
    sftp_free(sftp);
 

--- a/test/include/mctf_container.h
+++ b/test/include/mctf_container.h
@@ -54,10 +54,9 @@ extern "C" {
 /**
  * Well-known container kinds the framework knows how to start.
  */
-enum mctf_container_kind {
-   MCTF_CONTAINER_GARAGE = 0, /**< Garage, an S3-compatible object store */
-   MCTF_CONTAINER_AZURITE = 1 /**< Azurite, a local Azure Blob Storage emulator */
-};
+#define MCTF_CONTAINER_GARAGE  0 /**< Garage, an S3-compatible object store */
+#define MCTF_CONTAINER_AZURITE 1 /**< Azurite, a local Azure Blob Storage emulator */
+#define MCTF_CONTAINER_SFTP    2 /**< atmoz/sftp, SSH/SFTP test server */
 
 /**
  * A running container handle.
@@ -115,7 +114,7 @@ mctf_container_engine(char* out, size_t size);
  * @return MCTF_OK, MCTF_SKIPPED, or MCTF_FAIL
  */
 int
-mctf_container_start(struct mctf_container* c, enum mctf_container_kind kind);
+mctf_container_start(struct mctf_container* c, int kind);
 
 /**
  * Pull a container image with retries (best-effort; a cached image is

--- a/test/include/mctf_se.h
+++ b/test/include/mctf_se.h
@@ -52,10 +52,9 @@ extern "C" {
 /**
  * Storage backends supported by the integration-test layer.
  */
-enum mctf_backend {
-   MCTF_BACKEND_GARAGE = 0, /**< S3, emulated by Garage */
-   MCTF_BACKEND_AZURITE = 1 /**< Azure Blob Storage, emulated by Azurite */
-};
+#define MCTF_BACKEND_GARAGE  0 /**< S3, emulated by Garage */
+#define MCTF_BACKEND_AZURITE 1 /**< Azure Blob Storage, emulated by Azurite */
+#define MCTF_BACKEND_SSH     2 /**< SSH, emulated by atmoz/sftp */
 
 /**
  * Shared context for one active backend, filled by the driver's start()
@@ -123,7 +122,7 @@ struct mctf_se_driver
  *         MCTF_FAIL on error
  */
 int
-mctf_se_up(enum mctf_backend backend);
+mctf_se_up(int backend);
 
 /**
  * Tear down the managed pgmoneta instance and the backend. Idempotent.

--- a/test/libpgmonetatest/backends/ssh.c
+++ b/test/libpgmonetatest/backends/ssh.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * SSH backend driver.
+ *
+ * Uses atmoz/sftp as the remote SSH/SFTP target. An Ed25519 key pair is
+ * generated at test startup and the public key is injected into the
+ * container via a volume mount (atmoz/sftp reads *.pub files from
+ * ~/.ssh/keys/).
+ */
+
+/* pgmoneta */
+#include <pgmoneta.h>
+#include <logging.h>
+#include <mctf_container.h>
+#include <mctf_se.h>
+#include <utils.h>
+
+/* system */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define SSH_HOST     "127.0.0.1"
+#define SSH_PORT     2222
+#define SSH_USER     "pgmoneta"
+/* atmoz/sftp chroots to the user's home dir, so /upload here is /home/pgmoneta/upload in the container. */
+#define SSH_BASE_DIR "/upload"
+
+/* Paths derived from getpid() — same convention as mctf_container.c:start_sftp(). */
+static char s_privkey_path[MAX_PATH];
+static char s_pubkey_path[MAX_PATH];
+
+/*
+ * The container gets a new host key every run, so a stale known_hosts entry
+ * would make se_ssh.c see SSH_KNOWN_HOSTS_CHANGED (hard error) instead of
+ * SSH_KNOWN_HOSTS_UNKNOWN (auto-accepted). Clear it first.
+ */
+static int
+provision(void)
+{
+   mctf_sh(NULL, "ssh-keygen -R \"[" SSH_HOST "]:%d\" 2>/dev/null", SSH_PORT);
+
+   fprintf(stderr, "    - known_hosts cleaned\n");
+   fflush(stderr);
+
+   return MCTF_OK;
+}
+
+static int
+ssh_start(struct mctf_se* s)
+{
+   int rc;
+
+   /* Must exist before MCTF_START_CONTAINER mounts the public key. */
+   pgmoneta_snprintf(s_privkey_path, sizeof(s_privkey_path), "/tmp/mctf-sftp-%d", (int)getpid());
+   pgmoneta_snprintf(s_pubkey_path,  sizeof(s_pubkey_path),  "/tmp/mctf-sftp-%d.pub", (int)getpid());
+
+   mctf_sh(NULL, "rm -f %s %s", s_privkey_path, s_pubkey_path);
+
+   if (mctf_sh(NULL, "ssh-keygen -t ed25519 -f %s -N '' -q", s_privkey_path) != 0)
+   {
+      pgmoneta_log_error("ssh backend: failed to generate key pair");
+      return MCTF_FAIL;
+   }
+   fprintf(stderr, "    - SSH key pair generated\n");
+   fflush(stderr);
+
+   rc = MCTF_START_CONTAINER(&s->container, MCTF_CONTAINER_SFTP);
+   if (rc != MCTF_OK)
+   {
+      return rc; /* MCTF_SKIPPED bubbles up to mctf_se_up */
+   }
+   fprintf(stderr, "    - container started\n");
+   fflush(stderr);
+
+   if (provision() != MCTF_OK)
+   {
+      return MCTF_FAIL;
+   }
+
+   pgmoneta_snprintf(s->endpoint,   sizeof(s->endpoint),   "%s", SSH_HOST);
+   s->port = SSH_PORT;
+   /* Repurpose access_key for SSH username and bucket for SSH base dir. */
+   pgmoneta_snprintf(s->access_key, sizeof(s->access_key), "%s", SSH_USER);
+   pgmoneta_snprintf(s->bucket,     sizeof(s->bucket),     "%s", SSH_BASE_DIR);
+
+   return MCTF_OK;
+}
+
+static void
+ssh_stop(struct mctf_se* s)
+{
+   MCTF_STOP_CONTAINER(&s->container);
+
+   if (s_privkey_path[0] != '\0')
+   {
+      mctf_sh(NULL, "rm -f %s %s", s_privkey_path, s_pubkey_path);
+   }
+}
+
+/* SSH config keys are global-only, so reopen [pgmoneta] after [primary]. */
+static int
+ssh_write_server_conf(struct mctf_se* s, FILE* f)
+{
+   fprintf(f, "\n[pgmoneta]\n");
+   fprintf(f, "ssh_hostname = %s\n", s->endpoint);
+   fprintf(f, "ssh_port = %d\n", s->port);
+   fprintf(f, "ssh_username = %s\n", s->access_key);
+   fprintf(f, "ssh_base_dir = %s\n", s->bucket);
+   fprintf(f, "ssh_public_key_file = %s\n", s_pubkey_path);
+   fprintf(f, "ssh_private_key_file = %s\n", s_privkey_path);
+   return MCTF_OK;
+}
+
+const struct mctf_se_driver mctf_ssh_driver = {
+   .name = "ssh",
+   .storage_engine = "ssh",
+   .start = ssh_start,
+   .stop = ssh_stop,
+   .write_server_conf = ssh_write_server_conf,
+};

--- a/test/libpgmonetatest/mctf_container.c
+++ b/test/libpgmonetatest/mctf_container.c
@@ -32,6 +32,7 @@
 #include <logging.h>
 #include <mctf_container.h>
 #include <tscommon.h>
+#include <utils.h>
 
 /* system */
 #include <stdarg.h>
@@ -51,12 +52,22 @@
 #define AZURITE_BLOB_PORT     10000
 #define AZURITE_READY_RETRIES 30
 
+/* atmoz/sftp container definition. SFTP_USER_CONF is the image's per-user
+ * spec: user:pass:uid:gid:homedir-subfolders. */
+#define SFTP_IMAGE           "atmoz/sftp:latest"
+#define SFTP_PORT            2222
+#define SFTP_USER            "pgmoneta"
+#define SFTP_BASEDIR         "/home/pgmoneta/upload"
+#define SFTP_USER_CONF       SFTP_USER "::::upload"
+#define SFTP_READY_RETRIES   30
+
 /* Image-pull retry policy (transient registry failures). */
 #define PULL_RETRIES         3
 #define PULL_BACKOFF_SECONDS 2
 
 static int start_garage(struct mctf_container* c);
 static int start_azurite(struct mctf_container* c);
+static int start_sftp(struct mctf_container* c);
 
 int
 mctf_sh(char** output, const char* fmt, ...)
@@ -99,13 +110,13 @@ mctf_container_engine(char* out, size_t size)
 {
    if (mctf_sh(NULL, "podman info >/dev/null") == 0)
    {
-      snprintf(out, size, "podman");
+      pgmoneta_snprintf(out, size, "podman");
       return MCTF_OK;
    }
 
    if (mctf_sh(NULL, "docker info >/dev/null") == 0)
    {
-      snprintf(out, size, "docker");
+      pgmoneta_snprintf(out, size, "docker");
       return MCTF_OK;
    }
 
@@ -137,7 +148,7 @@ mctf_project_root(char* out, size_t size)
       *slash = '\0';
    }
 
-   if (snprintf(out, size, "%s", self) <= 0)
+   if (pgmoneta_snprintf(out, size, "%s", self) <= 0)
    {
       return MCTF_FAIL;
    }
@@ -174,7 +185,7 @@ mctf_container_run(struct mctf_container* c, const char* name, const char* image
 {
    int i;
 
-   snprintf(c->name, sizeof(c->name), "%s", name);
+   pgmoneta_snprintf(c->name, sizeof(c->name), "%s", name);
 
    /* Pull up front (with retry) so the run below is a local, network-free
     * operation. Best-effort: run auto-pulls too, and a cached image may exist. */
@@ -236,7 +247,7 @@ mctf_container_sweep(const char* engine)
 }
 
 int
-mctf_container_start(struct mctf_container* c, enum mctf_container_kind kind)
+mctf_container_start(struct mctf_container* c, int kind)
 {
    int rc;
 
@@ -256,8 +267,10 @@ mctf_container_start(struct mctf_container* c, enum mctf_container_kind kind)
          return start_garage(c);
       case MCTF_CONTAINER_AZURITE:
          return start_azurite(c);
+      case MCTF_CONTAINER_SFTP:
+         return start_sftp(c);
       default:
-         pgmoneta_log_error("mctf_container: unknown kind %d", (int)kind);
+         pgmoneta_log_error("mctf_container: unknown kind %d", kind);
          return MCTF_FAIL;
    }
 }
@@ -268,8 +281,8 @@ start_azurite(struct mctf_container* c)
    char name[128];
    int i;
 
-   snprintf(name, sizeof(name), "pgmoneta-mctf-azurite-%d", (int)getpid());
-   snprintf(c->name, sizeof(c->name), "%s", name);
+   pgmoneta_snprintf(name, sizeof(name), "pgmoneta-mctf-azurite-%d", (int)getpid());
+   pgmoneta_snprintf(c->name, sizeof(c->name), "%s", name);
 
    mctf_container_pull(c->engine, AZURITE_IMAGE, PULL_RETRIES);
 
@@ -304,6 +317,56 @@ start_azurite(struct mctf_container* c)
 }
 
 static int
+start_sftp(struct mctf_container* c)
+{
+   char name[128];
+   char pubkey_path[256];
+   int i;
+
+   pgmoneta_snprintf(name, sizeof(name), "pgmoneta-mctf-sftp-%d", (int)getpid());
+   pgmoneta_snprintf(pubkey_path, sizeof(pubkey_path), "/tmp/mctf-sftp-%d.pub", (int)getpid());
+
+   /* The SSH backend driver generates the key pair and places the public
+    * key here before calling MCTF_START_CONTAINER. */
+   if (access(pubkey_path, R_OK) != 0)
+   {
+      pgmoneta_log_error("mctf_container: sftp public key not found: %s", pubkey_path);
+      return MCTF_FAIL;
+   }
+
+   mctf_container_pull(c->engine, SFTP_IMAGE, PULL_RETRIES);
+   mctf_sh(NULL, "%s rm -f %s", c->engine, name);
+
+   if (mctf_sh(NULL, "%s run -d --name %s --label %s "
+               "-p %d:22 "
+               "-v %s:/home/%s/.ssh/keys/id_ed25519.pub:ro "
+               "%s %s",
+               c->engine, name, MCTF_CONTAINER_LABEL,
+               SFTP_PORT,
+               pubkey_path, SFTP_USER,
+               SFTP_IMAGE, SFTP_USER_CONF) != 0)
+   {
+      pgmoneta_log_error("mctf_container: failed to start %s", name);
+      return MCTF_FAIL;
+   }
+
+   pgmoneta_snprintf(c->name, sizeof(c->name), "%s", name);
+   c->running = true;
+
+   for (i = 0; i < SFTP_READY_RETRIES; i++)
+   {
+      if (mctf_container_exec(c, "pgrep sshd", NULL) == 0)
+      {
+         return MCTF_OK;
+      }
+      sleep(1);
+   }
+
+   pgmoneta_log_error("mctf_container: sftp sshd not ready after %d s", SFTP_READY_RETRIES);
+   return MCTF_FAIL;
+}
+
+static int
 start_garage(struct mctf_container* c)
 {
    char root[MAX_PATH];
@@ -316,7 +379,7 @@ start_garage(struct mctf_container* c)
       pgmoneta_log_error("mctf_container: cannot resolve project root");
       return MCTF_FAIL;
    }
-   snprintf(toml, sizeof(toml), "%s/%s", root, GARAGE_TOML);
+   pgmoneta_snprintf(toml, sizeof(toml), "%s/%s", root, GARAGE_TOML);
 
    if (access(toml, R_OK) != 0)
    {
@@ -324,8 +387,8 @@ start_garage(struct mctf_container* c)
       return MCTF_FAIL;
    }
 
-   snprintf(name, sizeof(name), "pgmoneta-mctf-garage-%d", (int)getpid());
-   snprintf(run_args, sizeof(run_args), "--network host -v %s:/etc/garage.toml:ro", toml);
+   pgmoneta_snprintf(name, sizeof(name), "pgmoneta-mctf-garage-%d", (int)getpid());
+   pgmoneta_snprintf(run_args, sizeof(run_args), "--network host -v %s:/etc/garage.toml:ro", toml);
 
    /* The image's default command is already ["/garage","server"] and reads
     * /etc/garage.toml; do not append a command (that would override it). */

--- a/test/libpgmonetatest/mctf_se.c
+++ b/test/libpgmonetatest/mctf_se.c
@@ -50,6 +50,9 @@
 #include <unistd.h>
 
 #define MANAGED_DAEMON_RETRIES 15
+/* WAL streaming starts on a 60 s wall-clock periodic (wal_streaming_cb), so
+ * the receiver may connect up to a minute after the daemon reports ready. */
+#define WAL_STREAMING_RETRIES  90
 
 /*
  * The backend registry.
@@ -60,12 +63,12 @@
  */
 extern const struct mctf_se_driver mctf_garage_driver;
 extern const struct mctf_se_driver mctf_azurite_driver;
-/* extern const struct mctf_se_driver mctf_ssh_driver; */
+extern const struct mctf_se_driver mctf_ssh_driver;
 
 static const struct mctf_se_driver* registry[] = {
    [MCTF_BACKEND_GARAGE]  = &mctf_garage_driver,
    [MCTF_BACKEND_AZURITE] = &mctf_azurite_driver,
-   /* [MCTF_BACKEND_SSH] = &mctf_ssh_driver, */
+   [MCTF_BACKEND_SSH]     = &mctf_ssh_driver,
 };
 
 /* Managed-instance state (single active backend). */
@@ -179,12 +182,30 @@ daemon_up(void)
       {
          fprintf(stderr, "    - managed pgmoneta started\n");
          fflush(stderr);
+         break;
+      }
+      sleep(1);
+   }
+   if (i == MANAGED_DAEMON_RETRIES)
+   {
+      pgmoneta_log_error("mctf_se: managed pgmoneta did not become ready");
+      return MCTF_FAIL;
+   }
+
+   /* A backup issued before the WAL receiver connects fails with "not WAL
+    * streaming"; wait for the first (partial) WAL segment to appear. */
+   for (i = 0; i < WAL_STREAMING_RETRIES; i++)
+   {
+      if (mctf_sh(NULL, "ls %s/backup/primary/wal/ 2>/dev/null | grep -q .", run_dir) == 0)
+      {
+         fprintf(stderr, "    - WAL streaming active\n");
+         fflush(stderr);
          return MCTF_OK;
       }
       sleep(1);
    }
 
-   pgmoneta_log_error("mctf_se: managed pgmoneta did not become ready");
+   pgmoneta_log_error("mctf_se: WAL streaming did not start");
    return MCTF_FAIL;
 }
 
@@ -221,12 +242,14 @@ signal_cleanup(int sig)
 }
 
 int
-mctf_se_up(enum mctf_backend backend)
+mctf_se_up(int backend)
 {
    const struct mctf_se_driver* driver;
    const char* uc;
    time_t start;
    int rc;
+   char backup_dir[MAX_PATH];
+   char workspace_dir[MAX_PATH];
 
    if (storage_active)
    {
@@ -237,7 +260,7 @@ mctf_se_up(enum mctf_backend backend)
    if ((size_t)backend >= sizeof(registry) / sizeof(registry[0]) ||
        registry[backend] == NULL)
    {
-      pgmoneta_log_error("mctf_se: unknown backend %d", (int)backend);
+      pgmoneta_log_error("mctf_se: unknown backend %d", backend);
       return MCTF_FAIL;
    }
    driver = registry[backend];
@@ -252,7 +275,7 @@ mctf_se_up(enum mctf_backend backend)
       pgmoneta_log_info("mctf_se: test environment not initialised; skipping");
       return MCTF_SKIPPED;
    }
-   snprintf(user_conf, sizeof(user_conf), "%s", uc);
+   pgmoneta_snprintf(user_conf, sizeof(user_conf), "%s", uc);
 
    if (pgmoneta_test_resolve_binary_path("pgmoneta", daemon_bin) != 0 ||
        pgmoneta_test_resolve_binary_path("pgmoneta-cli", cli_bin) != 0)
@@ -261,14 +284,17 @@ mctf_se_up(enum mctf_backend backend)
       return MCTF_FAIL;
    }
 
-   snprintf(run_dir, sizeof(run_dir), "%s/se-%s", TEST_BASE_DIR, driver->name);
-   snprintf(sock_dir, sizeof(sock_dir), "%s/sock", run_dir);
-   snprintf(conf_path, sizeof(conf_path), "%s/pgmoneta.conf", run_dir);
-   snprintf(cli_conf_path, sizeof(cli_conf_path), "%s/pgmoneta_cli.conf", run_dir);
+   pgmoneta_snprintf(run_dir, sizeof(run_dir), "%s/se-%s", TEST_BASE_DIR, driver->name);
+   pgmoneta_snprintf(sock_dir, sizeof(sock_dir), "%s/sock", run_dir);
+   pgmoneta_snprintf(conf_path, sizeof(conf_path), "%s/pgmoneta.conf", run_dir);
+   pgmoneta_snprintf(cli_conf_path, sizeof(cli_conf_path), "%s/pgmoneta_cli.conf", run_dir);
 
-   mkdir(run_dir, 0700);
-   mkdir(sock_dir, 0700);
-   mctf_sh(NULL, "mkdir -p %s/backup %s/workspace", run_dir, run_dir);
+   pgmoneta_snprintf(backup_dir, sizeof(backup_dir), "%s/backup", run_dir);
+   pgmoneta_snprintf(workspace_dir, sizeof(workspace_dir), "%s/workspace", run_dir);
+
+   pgmoneta_mkdir(sock_dir);
+   pgmoneta_mkdir(backup_dir);
+   pgmoneta_mkdir(workspace_dir);
 
    if (!atexit_registered)
    {
@@ -347,7 +373,7 @@ mctf_se_backup(const char* server)
 {
    char args[256];
 
-   snprintf(args, sizeof(args), "backup %s", server != NULL ? server : "primary");
+   pgmoneta_snprintf(args, sizeof(args), "backup %s", server != NULL ? server : "primary");
    return mctf_se_cli(args, NULL);
 }
 
@@ -356,7 +382,7 @@ mctf_se_restore(const char* server, const char* backup_id, const char* directory
 {
    char args[2 * MAX_PATH];
 
-   snprintf(args, sizeof(args), "restore %s %s %s",
+   pgmoneta_snprintf(args, sizeof(args), "restore %s %s %s",
             server != NULL ? server : "primary",
             backup_id != NULL ? backup_id : "newest",
             directory != NULL ? directory : TEST_RESTORE_DIR);
@@ -368,7 +394,7 @@ mctf_se_list_backup(const char* server, char** output)
 {
    char args[256];
 
-   snprintf(args, sizeof(args), "-F json list-backup %s", server != NULL ? server : "primary");
+   pgmoneta_snprintf(args, sizeof(args), "-F json list-backup %s", server != NULL ? server : "primary");
    return mctf_se_cli(args, output);
 }
 
@@ -377,7 +403,7 @@ mctf_se_s3_ls(const char* server, const char* label, char** output)
 {
    char args[512];
 
-   snprintf(args, sizeof(args), "-F json s3 ls %s %s",
+   pgmoneta_snprintf(args, sizeof(args), "-F json s3 ls %s %s",
             server != NULL ? server : "primary",
             label != NULL ? label : "");
    return mctf_se_cli(args, output);
@@ -388,7 +414,7 @@ mctf_se_delete(const char* server, const char* label)
 {
    char args[512];
 
-   snprintf(args, sizeof(args), "delete %s %s",
+   pgmoneta_snprintf(args, sizeof(args), "delete %s %s",
             server != NULL ? server : "primary",
             label != NULL ? label : "newest");
    return mctf_se_cli(args, NULL);
@@ -406,7 +432,7 @@ mctf_se_has_local_metadata(const char* server)
       return false;
    }
 
-   snprintf(path, sizeof(path), "%s/backup/%s/backup", run_dir, server != NULL ? server : "primary");
+   pgmoneta_snprintf(path, sizeof(path), "%s/backup/%s/backup", run_dir, server != NULL ? server : "primary");
    pgmoneta_load_infos(path, &number_of_backups, &backups);
 
    for (int i = 0; i < number_of_backups; i++)

--- a/test/testcases/test_ssh.c
+++ b/test/testcases/test_ssh.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * Storage-engine integration tests: SSH via atmoz/sftp.
+ *
+ * The entire backend lifecycle (generate a key pair, start an sftp container,
+ * configure and start a dedicated pgmoneta, tear everything down) is handled
+ * by mctf_se. A test only states intent.
+ */
+
+#include <mctf.h>
+#include <mctf_container.h>
+#include <mctf_se.h>
+#include <tscommon.h>
+#include <utils.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+static int storage_status = MCTF_FAIL;
+
+/* Return the lexicographically largest (newest) backup label for primary. */
+static int
+newest_backup_label(char* out, size_t size)
+{
+   char backup_dir[MAX_PATH];
+   char** dirs = NULL;
+   int ndir = 0;
+   int best = -1;
+
+   pgmoneta_snprintf(backup_dir, sizeof(backup_dir), "%s/backup/primary/backup", mctf_se_run_dir());
+   pgmoneta_get_directories(backup_dir, &ndir, &dirs);
+   if (ndir <= 0 || dirs == NULL)
+   {
+      return MCTF_FAIL;
+   }
+
+   for (int i = 0; i < ndir; i++)
+   {
+      if (best < 0 || strcmp(dirs[i], dirs[best]) > 0)
+      {
+         best = i;
+      }
+   }
+   pgmoneta_snprintf(out, size, "%s", dirs[best]);
+
+   for (int i = 0; i < ndir; i++)
+   {
+      free(dirs[i]);
+   }
+   free(dirs);
+
+   return out[0] != '\0' ? MCTF_OK : MCTF_FAIL;
+}
+
+MCTF_MODULE_SETUP(ssh)
+{
+   char label[256];
+
+   memset(label, 0, sizeof(label));
+   storage_status = mctf_se_up(MCTF_BACKEND_SSH);
+   if (storage_status == MCTF_OK)
+   {
+      /* Catches silent SFTP failures where the CLI exits 0 but nothing was stored. */
+      if (mctf_se_backup("primary") != 0 ||
+          newest_backup_label(label, sizeof(label)) != MCTF_OK)
+      {
+         storage_status = MCTF_FAIL;
+      }
+   }
+}
+
+MCTF_MODULE_TEARDOWN(ssh)
+{
+   mctf_se_down();
+}
+
+/*
+ * Direct proof that backup data landed on the remote: exec into the sftp
+ * container and count files under the SSH base directory. At least one file
+ * must be present after a successful backup.
+ */
+MCTF_INTEGRATION_TEST(test_ssh_remote_files_exist)
+{
+   const struct mctf_se* ctx = NULL;
+   char* out = NULL;
+   int file_count = 0;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   ctx = mctf_se_context();
+   MCTF_ASSERT_PTR_NONNULL(ctx, cleanup, "no active backend context");
+
+   /* Count all regular files uploaded to the remote SSH base directory. */
+   MCTF_ASSERT(mctf_container_exec((struct mctf_container*)&ctx->container,
+                                   "find /home/pgmoneta/upload -type f",
+                                   &out) == 0,
+               cleanup, "find on sftp container failed");
+
+   MCTF_ASSERT_PTR_NONNULL(out, cleanup, "find returned no output");
+
+   /* Count newlines to get the number of files. */
+   for (const char* p = out; *p != '\0'; p++)
+   {
+      if (*p == '\n')
+      {
+         file_count++;
+      }
+   }
+   MCTF_ASSERT(file_count > 0, cleanup, "no files found in SSH base directory after backup");
+
+cleanup:
+   free(out);
+   MCTF_FINISH();
+}
+
+/*
+ * The local backup catalog must record the SSH backup as successful.
+ * STATUS=1 in backup.info is the authoritative signal that pgmoneta
+ * considers the backup complete.
+ */
+MCTF_INTEGRATION_TEST(test_ssh_backup_info_is_valid)
+{
+   char backup_dir[MAX_PATH];
+   char** dirs = NULL;
+   int ndir = 0;
+   char info_path[MAX_PATH];
+   char* out = NULL;
+   int best = -1;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   /* Locate the newest backup directory under the managed instance's local catalog. */
+   pgmoneta_snprintf(backup_dir, sizeof(backup_dir), "%s/backup/primary/backup", mctf_se_run_dir());
+   pgmoneta_get_directories(backup_dir, &ndir, &dirs);
+   MCTF_ASSERT(ndir > 0 && dirs != NULL, cleanup, "no backup directories in local catalog");
+
+   for (int i = 0; i < ndir; i++)
+   {
+      if (best < 0 || strcmp(dirs[i], dirs[best]) > 0)
+      {
+         best = i;
+      }
+   }
+
+   pgmoneta_snprintf(info_path, sizeof(info_path), "%s/%s/backup.info", backup_dir, dirs[best]);
+   mctf_sh(&out, "grep -c 'STATUS=1' %s", info_path);
+   MCTF_ASSERT_PTR_NONNULL(out, cleanup, "could not read backup.info");
+   MCTF_ASSERT(atoi(out) > 0, cleanup, "STATUS=1 not found in backup.info");
+
+cleanup:
+   free(out);
+   if (dirs != NULL)
+   {
+      for (int i = 0; i < ndir; i++)
+      {
+         free(dirs[i]);
+      }
+      free(dirs);
+   }
+   MCTF_FINISH();
+}
+
+/*
+ * Even though data is stored on the remote SSH server, the local backup
+ * catalog (backup.info, backup.sha512, backup.manifest) must remain on disk
+ * — it is the authoritative index of all backups and must survive a remote
+ * backup.
+ */
+MCTF_INTEGRATION_TEST(test_ssh_local_metadata_retained)
+{
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   MCTF_ASSERT(mctf_se_has_local_metadata("primary"), cleanup,
+               "local metadata missing after SSH backup");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/*
+ * A second backup to the same SSH server must succeed. This guards against
+ * connection/session bugs where the first backup leaves the SSH session in
+ * a broken state or corrupts the remote directory layout.
+ */
+MCTF_INTEGRATION_TEST(test_ssh_second_backup_succeeds)
+{
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   MCTF_ASSERT(mctf_se_backup("primary") == 0, cleanup, "second SSH backup failed");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
- closes #1206 

changes includes:
- Add `ssh_port` config option to support connecting to a non-default SSH port
- Fix `se_ssh.c` to not require a backup label during WAL shipping 
- Add `atmoz`/`sftp` container backend driver for test infrastructure
- Add WAL-streaming readiness wait to the `mctf_se` test harness
- Add 4 SSH storage engine integration tests