### PR TITLE
[#1211]feat: unify remote storage engines into one parallel upload path

### DIFF
--- a/src/include/storage.h
+++ b/src/include/storage.h
@@ -43,6 +43,15 @@ extern "C" {
 #include <libssh/sftp.h>
 
 /**
+ * Storage engine capabilities
+ */
+#define STORAGE_CAP_ATOMIC_RENAME (1 << 0) /**< Atomic rename (SSH) */
+#define STORAGE_CAP_RANGE_GET     (1 << 1) /**< Range reads (S3, Azure) */
+#define STORAGE_CAP_BATCH_DELETE  (1 << 2) /**< Batch delete (S3) */
+#define STORAGE_CAP_MULTIPART     (1 << 3) /**< Multipart upload (S3) */
+#define STORAGE_CAP_PARALLEL_SAFE (1 << 4) /**< Parallel-safe upload (S3, Azure) */
+
+/**
  * Create a workflow for the local storage engine
  * @return The workflow
  */
@@ -95,6 +104,13 @@ pgmoneta_storage_verify_backup(int server, struct backup* backup_info);
  */
 struct workflow*
 pgmoneta_storage_create_azure(void);
+
+/**
+ * Create a workflow for the remote storage engines
+ * @return The workflow
+ */
+struct workflow*
+pgmoneta_storage_create_remote(void);
 
 /**
  * Open WAL shipping file in remote ssh server

--- a/src/include/workers.h
+++ b/src/include/workers.h
@@ -79,6 +79,7 @@ struct workers
    struct worker** worker;         /**< The list of workers */
    volatile int number_of_alive;   /**< The number of alive workers */
    volatile int number_of_working; /**< The number of workers */
+   volatile int keepalive;         /**< The keep-alive flag */
    pthread_mutex_t worker_lock;    /**< The worker lock */
    pthread_cond_t worker_all_idle; /**< Are workers idle */
    struct deque* outcome;          /**< Aggregated failures */

--- a/src/libpgmoneta/se_azure.c
+++ b/src/libpgmoneta/se_azure.c
@@ -184,7 +184,6 @@ azure_storage_teardown(char* name __attribute__((unused)), struct art* nodes)
 {
    int server = -1;
    char* label = NULL;
-   char* root = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -198,17 +197,6 @@ azure_storage_teardown(char* name __attribute__((unused)), struct art* nodes)
 
    server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
    label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
-
-   if (!pgmoneta_is_storage_engine_enabled(STORAGE_ENGINE_LOCAL))
-   {
-      root = pgmoneta_get_server_backup_identifier_data(server, label);
-
-      if (root != NULL)
-      {
-         pgmoneta_delete_directory(root);
-         free(root);
-      }
-   }
 
    pgmoneta_log_debug("Azure storage engine (teardown): %s/%s", config->common.servers[server].name, label);
 
@@ -682,4 +670,21 @@ azure_add_request_headers(struct http_request* request, char* auth_value, char* 
    }
 
    return 0;
+}
+
+int
+azure_upload(int server, char* label, int compression __attribute__((unused)), int encryption __attribute__((unused)))
+{
+   char* local_root = NULL;
+   char* azure_root = NULL;
+   int rc;
+
+   local_root = pgmoneta_get_server_backup_identifier(server, label);
+   azure_root = azure_get_basepath(server, label);
+
+   rc = azure_upload_files(local_root, azure_root, "");
+
+   free(local_root);
+   free(azure_root);
+   return rc;
 }

--- a/src/libpgmoneta/se_remote.c
+++ b/src/libpgmoneta/se_remote.c
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * se_remote: fans a backup out to all configured remote storage backends,
+ * driven by the engines[] capability table.
+ */
+
+/* pgmoneta */
+#include <pgmoneta.h>
+#include <info.h>
+#include <logging.h>
+#include <shmem.h>
+#include <storage.h>
+#include <utils.h>
+#include <workers.h>
+#include <workflow.h>
+
+/* system */
+#include <stdbool.h>
+#include <stdlib.h>
+#include <time.h>
+
+/* Per-backend upload/cleanup entry points defined in their respective se_*.c */
+extern int ssh_upload(int server, char* label, int compression, int encryption);
+extern int s3_upload(int server, char* label, int compression, int encryption);
+extern int s3_cleanup(int server, char* label);
+extern int azure_upload(int server, char* label, int compression, int encryption);
+
+/* The contract each remote backend must implement */
+struct storage_engine
+{
+   const char* name;
+   int engine_flag;
+   int capabilities;
+   int (*upload)(int server, char* label, int compression, int encryption);
+   int (*cleanup)(int server, char* label);
+};
+
+static const struct storage_engine engines[] = {
+   {"SSH", STORAGE_ENGINE_SSH,
+    STORAGE_CAP_ATOMIC_RENAME,
+    ssh_upload, NULL},
+   {"S3", STORAGE_ENGINE_S3,
+    STORAGE_CAP_RANGE_GET | STORAGE_CAP_BATCH_DELETE | STORAGE_CAP_MULTIPART | STORAGE_CAP_PARALLEL_SAFE,
+    s3_upload, s3_cleanup},
+   {"Azure", STORAGE_ENGINE_AZURE,
+    STORAGE_CAP_RANGE_GET | STORAGE_CAP_PARALLEL_SAFE,
+    azure_upload, NULL},
+};
+
+#define N_ENGINES ((int)(sizeof(engines) / sizeof(engines[0])))
+
+struct remote_task
+{
+   struct worker_common common;
+   const struct storage_engine* engine;
+   int server;
+   char* label;
+   int compression;
+   int encryption;
+   int result;
+   double elapsed;
+};
+
+static char* remote_upload_name(void);
+static int remote_upload_setup(char*, struct art*);
+static int remote_upload_execute(char*, struct art*);
+static int remote_upload_teardown(char*, struct art*);
+static void maybe_delete_local_data(int server, char* label);
+
+static void
+backend_task(struct worker_common* wc)
+{
+   struct remote_task* t = (struct remote_task*)wc;
+   struct timespec start;
+   struct timespec end;
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &start);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+#endif
+
+   pgmoneta_log_debug("remote_upload: %s started", t->engine->name);
+
+   t->result = t->engine->upload(t->server, t->label, t->compression, t->encryption);
+
+#ifdef HAVE_FREEBSD
+   clock_gettime(CLOCK_MONOTONIC_FAST, &end);
+#else
+   clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+#endif
+
+   t->elapsed = pgmoneta_compute_duration(start, end);
+
+   pgmoneta_log_debug("remote_upload: %s finished (%.2fs)", t->engine->name, t->elapsed);
+}
+
+struct workflow*
+pgmoneta_storage_create_remote(void)
+{
+   struct workflow* wf = malloc(sizeof(struct workflow));
+
+   if (wf == NULL)
+   {
+      return NULL;
+   }
+
+   wf->name = &remote_upload_name;
+   wf->setup = &remote_upload_setup;
+   wf->execute = &remote_upload_execute;
+   wf->teardown = &remote_upload_teardown;
+   wf->next = NULL;
+
+   return wf;
+}
+
+static char*
+remote_upload_name(void)
+{
+   return "Remote";
+}
+
+static int
+remote_upload_setup(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server;
+   char* label;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+
+   pgmoneta_log_debug("Remote storage engine (setup): %s/%s",
+                      config->common.servers[server].name, label);
+   return 0;
+}
+
+static int
+remote_upload_execute(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server;
+   char* label;
+   int n = 0;
+   int n_parallel = 0;
+   bool any_failed = false;
+   struct remote_task tasks[N_ENGINES];
+   struct workers* workers = NULL;
+   struct backup* bck = NULL;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+   bck = (struct backup*)pgmoneta_art_search(nodes, NODE_BACKUP);
+
+   pgmoneta_log_debug("Remote storage engine (execute): %s/%s",
+                      config->common.servers[server].name, label);
+
+   if (bck == NULL)
+   {
+      pgmoneta_log_error("remote_upload: no backup struct in nodes for %s/%s",
+                         config->common.servers[server].name, label);
+      return 1;
+   }
+
+   for (int i = 0; i < N_ENGINES; i++)
+   {
+      if (config->storage_engine & engines[i].engine_flag)
+      {
+         n++;
+         if (engines[i].capabilities & STORAGE_CAP_PARALLEL_SAFE)
+         {
+            n_parallel++;
+         }
+      }
+   }
+
+   if (n == 0)
+   {
+      return 0;
+   }
+
+   if (n_parallel > 0)
+   {
+      if (pgmoneta_workers_initialize(n_parallel, &workers))
+      {
+         pgmoneta_log_warn("remote_upload: could not create worker pool; running all backends serially");
+         workers = NULL;
+      }
+   }
+
+   n = 0;
+
+   /* Dispatch parallel-safe engines to the pool */
+   for (int i = 0; i < N_ENGINES; i++)
+   {
+      if (!(config->storage_engine & engines[i].engine_flag) ||
+          !(engines[i].capabilities & STORAGE_CAP_PARALLEL_SAFE) ||
+          workers == NULL)
+      {
+         continue;
+      }
+
+      tasks[n].common.workers = workers;
+      tasks[n].engine = &engines[i];
+      tasks[n].server = server;
+      tasks[n].label = label;
+      tasks[n].compression = bck->compression;
+      tasks[n].encryption = bck->encryption;
+      tasks[n].result = 1;
+      tasks[n].elapsed = 0.0;
+
+      if (pgmoneta_workers_add(workers, backend_task, (struct worker_common*)&tasks[n]))
+      {
+         pgmoneta_log_error("remote_upload: failed to queue task for %s backend", engines[i].name);
+      }
+      n++;
+   }
+
+   /* Run the rest in-thread while the pool works */
+   for (int i = 0; i < N_ENGINES; i++)
+   {
+      if (!(config->storage_engine & engines[i].engine_flag) ||
+          ((engines[i].capabilities & STORAGE_CAP_PARALLEL_SAFE) && workers != NULL))
+      {
+         continue;
+      }
+
+      tasks[n].common.workers = NULL;
+      tasks[n].engine = &engines[i];
+      tasks[n].server = server;
+      tasks[n].label = label;
+      tasks[n].compression = bck->compression;
+      tasks[n].encryption = bck->encryption;
+      tasks[n].result = 1;
+      tasks[n].elapsed = 0.0;
+
+      backend_task((struct worker_common*)&tasks[n]);
+      n++;
+   }
+
+   /* Wait for tasks to finish */
+   pgmoneta_workers_wait(workers);
+   pgmoneta_workers_destroy(workers);
+
+   /* Collect results */
+   for (int i = 0; i < n; i++)
+   {
+      if (tasks[i].result != 0)
+      {
+         pgmoneta_log_error("remote_upload: %s upload failed for %s/%s",
+                            tasks[i].engine->name,
+                            config->common.servers[server].name,
+                            label);
+         any_failed = true;
+      }
+   }
+
+   if (any_failed)
+   {
+      /* Atomic policy: sweep every backend on any failure. TODO: partial-success policy. */
+      for (int i = 0; i < n; i++)
+      {
+         if (tasks[i].engine->cleanup != NULL)
+         {
+            if (tasks[i].engine->cleanup(server, label) != 0)
+            {
+               pgmoneta_log_warn("remote_upload: cleanup of %s failed; orphaned objects may remain",
+                                 tasks[i].engine->name);
+            }
+         }
+         else
+         {
+            pgmoneta_log_warn("remote_upload: %s has no cleanup implementation; "
+                              "orphaned objects may remain after upload failure",
+                              tasks[i].engine->name);
+         }
+      }
+      return 1;
+   }
+
+   /* Record per-backend timing on the live NODE_BACKUP struct */
+   for (int i = 0; i < n; i++)
+   {
+      if (tasks[i].engine->engine_flag == STORAGE_ENGINE_SSH)
+      {
+         bck->remote_ssh_elapsed_time = tasks[i].elapsed;
+      }
+      else if (tasks[i].engine->engine_flag == STORAGE_ENGINE_S3)
+      {
+         bck->remote_s3_elapsed_time = tasks[i].elapsed;
+      }
+      else if (tasks[i].engine->engine_flag == STORAGE_ENGINE_AZURE)
+      {
+         bck->remote_azure_elapsed_time = tasks[i].elapsed;
+      }
+   }
+
+   return 0;
+}
+
+static int
+remote_upload_teardown(char* name __attribute__((unused)), struct art* nodes)
+{
+   int server;
+   char* label;
+   struct main_configuration* config = (struct main_configuration*)shmem;
+
+   server = (int)pgmoneta_art_search(nodes, NODE_SERVER_ID);
+   label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
+
+   pgmoneta_log_debug("Remote storage engine (teardown): %s/%s",
+                      config->common.servers[server].name, label);
+
+   maybe_delete_local_data(server, label);
+   return 0;
+}
+
+/* Remove the local data/ dir unless local is a configured destination */
+static void
+maybe_delete_local_data(int server, char* label)
+{
+   char* root = NULL;
+
+   if (pgmoneta_is_storage_engine_enabled(STORAGE_ENGINE_LOCAL))
+   {
+      return;
+   }
+
+   root = pgmoneta_get_server_backup_identifier_data(server, label);
+   if (root != NULL)
+   {
+      pgmoneta_delete_directory(root);
+      free(root);
+   }
+}

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -70,7 +70,7 @@ static int s3_bootstrap(char* s3_root, int server, char* local_root);
 static int s3_download_files(char* s3_root, char* local_root, int server, int compression, int encryption);
 static int s3_send_upload_request(char* local_root, char* s3_root, char* relative_path, char* file_sha512, int server);
 static int s3_list_objects(char* relative_path, char* s3_list, int server, bool common_prefixes, struct deque** objects);
-static int s3_delete_all_objects(char* relative_path, char* s3_list, int server, struct art*) __attribute__((unused));
+static int s3_delete_all_objects(char* relative_path, char* s3_list, int server, struct art*);
 static int s3_send_list_request(char* relative_path, char* s3_list, int server, char* continuationToken, bool common_prefixes, struct http_response** response);
 static int s3_list_backup_prefixes(int server, struct deque** labels);
 static int s3_verify_backup(int server, struct backup* backup_info);
@@ -533,7 +533,6 @@ s3_storage_teardown(char* name __attribute__((unused)), struct art* nodes)
 {
    int server = -1;
    char* label = NULL;
-   char* root = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -549,17 +548,6 @@ s3_storage_teardown(char* name __attribute__((unused)), struct art* nodes)
    label = (char*)pgmoneta_art_search(nodes, NODE_LABEL);
 
    pgmoneta_log_debug("S3 storage engine (teardown): %s/%s", config->common.servers[server].name, label);
-
-   if (!pgmoneta_is_storage_engine_enabled(STORAGE_ENGINE_LOCAL))
-   {
-      root = pgmoneta_get_server_backup_identifier_data(server, label);
-
-      if (root != NULL)
-      {
-         pgmoneta_delete_directory(root);
-         free(root);
-      }
-   }
 
    return 0;
 }
@@ -3233,4 +3221,33 @@ s3_label_from_common_prefix(char* prefix)
    }
 
    return copy;
+}
+
+int
+s3_upload(int server, char* label, int compression, int encryption)
+{
+   char* local_root = NULL;
+   char* s3_root = NULL;
+   int rc;
+
+   local_root = pgmoneta_get_server_backup_identifier(server, label);
+   s3_root = s3_get_basepath(server, label);
+
+   rc = s3_upload_files(local_root, s3_root, server, compression, encryption);
+
+   free(local_root);
+   free(s3_root);
+   return rc;
+}
+
+int
+s3_cleanup(int server, char* label)
+{
+   char* s3_root = NULL;
+   int rc;
+
+   s3_root = s3_get_basepath(server, label);
+   rc = s3_delete_all_objects("", s3_root, server, NULL);
+   free(s3_root);
+   return rc;
 }

--- a/src/libpgmoneta/se_ssh.c
+++ b/src/libpgmoneta/se_ssh.c
@@ -33,6 +33,7 @@
 #include <backup.h>
 #include <logging.h>
 #include <security.h>
+#include <storage.h>
 #include <utils.h>
 #include <workflow.h>
 
@@ -284,9 +285,6 @@ ssh_storage_backup_execute(char* name __attribute__((unused)), struct art* nodes
 {
    int server = -1;
    char* label = NULL;
-   struct timespec start_t;
-   struct timespec end_t;
-   double remote_ssh_elapsed_time;
    char* server_path = NULL;
    char* local_root = NULL;
    char* remote_root = NULL;
@@ -295,13 +293,6 @@ ssh_storage_backup_execute(char* name __attribute__((unused)), struct art* nodes
    int number_of_backups = 0;
    struct backup** backups = NULL;
    struct main_configuration* config;
-   struct backup* temp_backup = NULL;
-
-#ifdef HAVE_FREEBSD
-   clock_gettime(CLOCK_MONOTONIC_FAST, &start_t);
-#else
-   clock_gettime(CLOCK_MONOTONIC_RAW, &start_t);
-#endif
 
    config = (struct main_configuration*)shmem;
 
@@ -388,27 +379,6 @@ ssh_storage_backup_execute(char* name __attribute__((unused)), struct art* nodes
       free(latest_backup_sha256);
    }
 
-#ifdef HAVE_FREEBSD
-   clock_gettime(CLOCK_MONOTONIC_FAST, &end_t);
-#else
-   clock_gettime(CLOCK_MONOTONIC_RAW, &end_t);
-#endif
-
-   remote_ssh_elapsed_time = pgmoneta_compute_duration(start_t, end_t);
-
-   if (pgmoneta_load_info(server_path, label, &temp_backup))
-   {
-      pgmoneta_log_error("Unable to get backup for directory %s", server_path);
-      goto error;
-   }
-   temp_backup->remote_ssh_elapsed_time = remote_ssh_elapsed_time;
-   if (pgmoneta_save_info(server_path, temp_backup))
-   {
-      pgmoneta_log_error("Unable to save backup info for directory %s", server_path);
-      goto error;
-   }
-
-   free(temp_backup);
    free(server_path);
    free(remote_root);
    free(local_root);
@@ -430,7 +400,6 @@ error:
       free(latest_backup_sha256);
    }
 
-   free(temp_backup);
    free(server_path);
    free(remote_root);
    free(local_root);
@@ -489,7 +458,6 @@ ssh_storage_backup_teardown(char* name __attribute__((unused)), struct art* node
 {
    int server = -1;
    char* label = NULL;
-   char* root = NULL;
    struct main_configuration* config;
 
    config = (struct main_configuration*)shmem;
@@ -506,26 +474,17 @@ ssh_storage_backup_teardown(char* name __attribute__((unused)), struct art* node
 
    pgmoneta_log_debug("SSH storage engine (teardown): %s/%s", config->common.servers[server].name, label);
 
-   if (!is_error)
-   {
-      root = pgmoneta_get_server_backup_identifier_data(server, label);
-   }
-   else
-   {
-      root = pgmoneta_get_server_backup_identifier(server, label);
-   }
-
-   pgmoneta_delete_directory(root);
-
    pgmoneta_art_destroy(tree_map);
-
-   free(root);
+   tree_map = NULL;
 
    free(latest_remote_root);
+   latest_remote_root = NULL;
 
    sftp_free(sftp);
+   sftp = NULL;
 
    ssh_free(session);
+   session = NULL;
 
    return 0;
 }
@@ -1118,4 +1077,50 @@ sftp_permission(char* path, int user, int group, int all)
    }
 
    return 0;
+}
+
+int
+ssh_upload(int server, char* label, int compression __attribute__((unused)), int encryption __attribute__((unused)))
+{
+   struct art* nodes = NULL;
+   int rc = 1;
+
+   if (pgmoneta_art_create(&nodes))
+   {
+      goto done;
+   }
+
+   if (pgmoneta_art_insert(nodes, NODE_SERVER_ID, (uintptr_t)server, ValueInt32))
+   {
+      goto done;
+   }
+
+   if (pgmoneta_art_insert(nodes, NODE_LABEL, (uintptr_t)label, ValueString))
+   {
+      goto done;
+   }
+
+   if (ssh_storage_setup("SSH", nodes))
+   {
+      goto cleanup;
+   }
+
+   rc = ssh_storage_backup_execute("SSH", nodes);
+
+cleanup:
+   if (tree_map != NULL)
+   {
+      pgmoneta_art_destroy(tree_map);
+      tree_map = NULL;
+   }
+   free(latest_remote_root);
+   latest_remote_root = NULL;
+   sftp_free(sftp);
+   sftp = NULL;
+   ssh_free(session);
+   session = NULL;
+
+done:
+   pgmoneta_art_destroy(nodes);
+   return rc;
 }

--- a/src/libpgmoneta/workers.c
+++ b/src/libpgmoneta/workers.c
@@ -44,8 +44,6 @@
 #include <sys/sysinfo.h>
 #endif
 
-static volatile int worker_keepalive;
-
 static int worker_init(struct workers* workers, struct worker** worker);
 static void* worker_do(struct worker* worker);
 static void worker_destroy(struct worker* worker);
@@ -63,8 +61,6 @@ pgmoneta_workers_initialize(int num, struct workers** workers)
 
    *workers = NULL;
 
-   worker_keepalive = 1;
-
    if (num < 1)
    {
       goto error;
@@ -79,6 +75,7 @@ pgmoneta_workers_initialize(int num, struct workers** workers)
 
    w->number_of_alive = 0;
    w->number_of_working = 0;
+   w->keepalive = 1;
    w->outcome = NULL;
 
    if (pgmoneta_deque_create(true, &w->outcome))
@@ -313,7 +310,7 @@ pgmoneta_workers_destroy(struct workers* workers)
    if (workers != NULL)
    {
       worker_total = workers->number_of_alive;
-      worker_keepalive = 0;
+      workers->keepalive = 0;
 
       time(&start);
       while (tpassed < timeout && workers->number_of_alive)
@@ -471,11 +468,11 @@ worker_do(struct worker* worker)
    workers->number_of_alive += 1;
    pthread_mutex_unlock(&workers->worker_lock);
 
-   while (worker_keepalive)
+   while (workers->keepalive)
    {
       semaphore_wait(workers->has_tasks);
 
-      if (worker_keepalive)
+      if (workers->keepalive)
       {
          pthread_mutex_lock(&workers->worker_lock);
          workers->number_of_working++;

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -584,20 +584,13 @@ wf_backup(void)
    {
       current->next = pgmoneta_create_sha256();
       current = current->next;
-
-      current->next = pgmoneta_storage_create_ssh(WORKFLOW_TYPE_BACKUP);
-      current = current->next;
    }
 
-   if (config->storage_engine & STORAGE_ENGINE_S3)
+   if ((config->storage_engine & STORAGE_ENGINE_SSH) ||
+       (config->storage_engine & STORAGE_ENGINE_S3) ||
+       (config->storage_engine & STORAGE_ENGINE_AZURE))
    {
-      current->next = pgmoneta_storage_create_s3(WORKFLOW_TYPE_BACKUP);
-      current = current->next;
-   }
-
-   if (config->storage_engine & STORAGE_ENGINE_AZURE)
-   {
-      current->next = pgmoneta_storage_create_azure();
+      current->next = pgmoneta_storage_create_remote();
       current = current->next;
    }
 
@@ -785,20 +778,13 @@ wf_post_rollup(struct backup* backup)
    {
       current->next = pgmoneta_create_sha256();
       current = current->next;
-
-      current->next = pgmoneta_storage_create_ssh(WORKFLOW_TYPE_BACKUP);
-      current = current->next;
    }
 
-   if (config->storage_engine & STORAGE_ENGINE_S3)
+   if ((config->storage_engine & STORAGE_ENGINE_SSH) ||
+       (config->storage_engine & STORAGE_ENGINE_S3) ||
+       (config->storage_engine & STORAGE_ENGINE_AZURE))
    {
-      current->next = pgmoneta_storage_create_s3(WORKFLOW_TYPE_BACKUP);
-      current = current->next;
-   }
-
-   if (config->storage_engine & STORAGE_ENGINE_AZURE)
-   {
-      current->next = pgmoneta_storage_create_azure();
+      current->next = pgmoneta_storage_create_remote();
       current = current->next;
    }
 
@@ -879,20 +865,13 @@ wf_incremental_backup(void)
    {
       current->next = pgmoneta_create_sha256();
       current = current->next;
-
-      current->next = pgmoneta_storage_create_ssh(WORKFLOW_TYPE_BACKUP);
-      current = current->next;
    }
 
-   if (config->storage_engine & STORAGE_ENGINE_S3)
+   if ((config->storage_engine & STORAGE_ENGINE_SSH) ||
+       (config->storage_engine & STORAGE_ENGINE_S3) ||
+       (config->storage_engine & STORAGE_ENGINE_AZURE))
    {
-      current->next = pgmoneta_storage_create_s3(WORKFLOW_TYPE_BACKUP);
-      current = current->next;
-   }
-
-   if (config->storage_engine & STORAGE_ENGINE_AZURE)
-   {
-      current->next = pgmoneta_storage_create_azure();
+      current->next = pgmoneta_storage_create_remote();
       current = current->next;
    }
 

--- a/test/include/mctf_se.h
+++ b/test/include/mctf_se.h
@@ -125,7 +125,14 @@ int
 mctf_se_up(int backend);
 
 /**
- * Tear down the managed pgmoneta instance and the backend. Idempotent.
+ * Bring up all backends and one pgmoneta instance with every storage engine.
+ * @return MCTF_OK, MCTF_SKIPPED, or MCTF_FAIL (as mctf_se_up)
+ */
+int
+mctf_se_up_all(void);
+
+/**
+ * Tear down the managed pgmoneta instance and all active backends. Idempotent.
  */
 void
 mctf_se_down(void);
@@ -205,6 +212,14 @@ mctf_se_run_dir(void);
  */
 const struct mctf_se*
 mctf_se_context(void);
+
+/**
+ * The context of one specific backend (multi-backend runs). In single-backend
+ * runs this returns the active context when @p backend matches it.
+ * NULL if that backend is not active.
+ */
+const struct mctf_se*
+mctf_se_context_for(int backend);
 
 /**
  * Count the number of blobs in the active Azurite container by querying

--- a/test/libpgmonetatest/backends/ssh.c
+++ b/test/libpgmonetatest/backends/ssh.c
@@ -127,11 +127,9 @@ ssh_stop(struct mctf_se* s)
    }
 }
 
-/* SSH config keys are global-only, so reopen [pgmoneta] after [primary]. */
 static int
-ssh_write_server_conf(struct mctf_se* s, FILE* f)
+ssh_write_global_conf(struct mctf_se* s, FILE* f)
 {
-   fprintf(f, "\n[pgmoneta]\n");
    fprintf(f, "ssh_hostname = %s\n", s->endpoint);
    fprintf(f, "ssh_port = %d\n", s->port);
    fprintf(f, "ssh_username = %s\n", s->access_key);
@@ -146,5 +144,6 @@ const struct mctf_se_driver mctf_ssh_driver = {
    .storage_engine = "ssh",
    .start = ssh_start,
    .stop = ssh_stop,
-   .write_server_conf = ssh_write_server_conf,
+   .write_global_conf = ssh_write_global_conf,
+   .write_server_conf = NULL,
 };

--- a/test/libpgmonetatest/mctf_container.c
+++ b/test/libpgmonetatest/mctf_container.c
@@ -251,6 +251,8 @@ mctf_container_start(struct mctf_container* c, int kind)
 {
    int rc;
 
+   static bool swept = false;
+
    memset(c, 0, sizeof(*c));
 
    rc = mctf_container_engine(c->engine, sizeof(c->engine));
@@ -259,7 +261,11 @@ mctf_container_start(struct mctf_container* c, int kind)
       return rc; /* MCTF_SKIPPED */
    }
 
-   mctf_container_sweep(c->engine);
+   if (!swept)
+   {
+      mctf_container_sweep(c->engine);
+      swept = true;
+   }
 
    switch (kind)
    {

--- a/test/libpgmonetatest/mctf_se.c
+++ b/test/libpgmonetatest/mctf_se.c
@@ -71,8 +71,10 @@ static const struct mctf_se_driver* registry[] = {
    [MCTF_BACKEND_SSH]     = &mctf_ssh_driver,
 };
 
-/* Managed-instance state (single active backend). */
-static struct mctf_se storage;
+#define MAX_BACKENDS ((int)(sizeof(registry) / sizeof(registry[0])))
+
+static struct mctf_se storage[MAX_BACKENDS];
+static int n_active = 0;
 static bool storage_active = false;
 static bool atexit_registered = false;
 
@@ -117,19 +119,28 @@ write_confs(void)
    fprintf(f, "base_dir = %s/backup\n", run_dir);
    fprintf(f, "compression = zstd\n");
    fprintf(f, "encryption = none\n");
-   fprintf(f, "storage_engine = %s\n", storage.driver->storage_engine);
+   fprintf(f, "workers = 4\n");
+   fprintf(f, "storage_engine = ");
+   for (int i = 0; i < n_active; i++)
+   {
+      fprintf(f, "%s%s", i > 0 ? ", " : "", storage[i].driver->storage_engine);
+   }
+   fprintf(f, "\n");
    fprintf(f, "log_type = file\n");
    fprintf(f, "log_level = debug5\n");
    fprintf(f, "log_path = %s/pgmoneta.log\n", run_dir);
    fprintf(f, "unix_socket_dir = %s/\n", sock_dir);
    fprintf(f, "pidfile = %s/pgmoneta.pid\n", run_dir);
    fprintf(f, "workspace = %s/workspace\n", run_dir);
-   if (storage.driver->write_global_conf != NULL)
+   for (int i = 0; i < n_active; i++)
    {
-      if (storage.driver->write_global_conf(&storage, f) != MCTF_OK)
+      if (storage[i].driver->write_global_conf != NULL)
       {
-         fclose(f);
-         return MCTF_FAIL;
+         if (storage[i].driver->write_global_conf(&storage[i], f) != MCTF_OK)
+         {
+            fclose(f);
+            return MCTF_FAIL;
+         }
       }
    }
    fprintf(f, "\n");
@@ -139,12 +150,15 @@ write_confs(void)
    fprintf(f, "user = %s\n", primary->username);
    fprintf(f, "wal_slot = mctf_se\n");
    fprintf(f, "create_slot = yes\n");
-   if (storage.driver->write_server_conf != NULL)
+   for (int i = 0; i < n_active; i++)
    {
-      if (storage.driver->write_server_conf(&storage, f) != MCTF_OK)
+      if (storage[i].driver->write_server_conf != NULL)
       {
-         fclose(f);
-         return MCTF_FAIL;
+         if (storage[i].driver->write_server_conf(&storage[i], f) != MCTF_OK)
+         {
+            fclose(f);
+            return MCTF_FAIL;
+         }
       }
    }
    fclose(f);
@@ -241,10 +255,10 @@ signal_cleanup(int sig)
    raise(sig);
 }
 
-int
-mctf_se_up(int backend)
+/* Start n backends, write config, and start the managed daemon. */
+static int
+se_up_common(const int* backends, int n, const char* name)
 {
-   const struct mctf_se_driver* driver;
    const char* uc;
    time_t start;
    int rc;
@@ -257,16 +271,22 @@ mctf_se_up(int backend)
       return MCTF_FAIL;
    }
 
-   if ((size_t)backend >= sizeof(registry) / sizeof(registry[0]) ||
-       registry[backend] == NULL)
+   for (int i = 0; i < n; i++)
    {
-      pgmoneta_log_error("mctf_se: unknown backend %d", backend);
-      return MCTF_FAIL;
+      if ((size_t)backends[i] >= sizeof(registry) / sizeof(registry[0]) ||
+          registry[backends[i]] == NULL)
+      {
+         pgmoneta_log_error("mctf_se: unknown backend %d", backends[i]);
+         return MCTF_FAIL;
+      }
    }
-   driver = registry[backend];
 
-   memset(&storage, 0, sizeof(storage));
-   storage.driver = driver;
+   memset(storage, 0, sizeof(storage));
+   n_active = n;
+   for (int i = 0; i < n; i++)
+   {
+      storage[i].driver = registry[backends[i]];
+   }
 
    /* Requires the full test environment (check.sh); skip otherwise. */
    uc = getenv("PGMONETA_TEST_USER_CONF");
@@ -284,7 +304,7 @@ mctf_se_up(int backend)
       return MCTF_FAIL;
    }
 
-   pgmoneta_snprintf(run_dir, sizeof(run_dir), "%s/se-%s", TEST_BASE_DIR, driver->name);
+   pgmoneta_snprintf(run_dir, sizeof(run_dir), "%s/se-%s", TEST_BASE_DIR, name);
    pgmoneta_snprintf(sock_dir, sizeof(sock_dir), "%s/sock", run_dir);
    pgmoneta_snprintf(conf_path, sizeof(conf_path), "%s/pgmoneta.conf", run_dir);
    pgmoneta_snprintf(cli_conf_path, sizeof(cli_conf_path), "%s/pgmoneta_cli.conf", run_dir);
@@ -307,37 +327,75 @@ mctf_se_up(int backend)
    storage_active = true; /* set early so teardown runs if a later step fails */
 
    start = time(NULL);
-   fprintf(stderr, "  ~ starting %s backend\n", driver->name);
-   fflush(stderr);
 
-   rc = driver->start(&storage);
-   if (rc == MCTF_SKIPPED)
+   for (int i = 0; i < n; i++)
    {
-      fprintf(stderr, "  ~ skipped (no container engine)\n");
+      fprintf(stderr, "  ~ starting %s backend\n", storage[i].driver->name);
       fflush(stderr);
-      storage_active = false;
-      return MCTF_SKIPPED;
+
+      rc = storage[i].driver->start(&storage[i]);
+      if (rc == MCTF_SKIPPED)
+      {
+         fprintf(stderr, "  ~ skipped (no container engine)\n");
+         fflush(stderr);
+         mctf_se_down();
+         return MCTF_SKIPPED;
+      }
+      if (rc != MCTF_OK || !storage[i].container.running)
+      {
+         fprintf(stderr, "  ~ %s backend FAILED\n", storage[i].driver->name);
+         fflush(stderr);
+         mctf_se_down();
+         return MCTF_FAIL;
+      }
    }
-   if (rc != MCTF_OK || !storage.container.running || write_confs() != MCTF_OK)
+
+   if (write_confs() != MCTF_OK)
    {
-      fprintf(stderr, "  ~ %s backend FAILED\n", driver->name);
+      fprintf(stderr, "  ~ %s FAILED\n", name);
       fflush(stderr);
       mctf_se_down();
       return MCTF_FAIL;
    }
    if (daemon_up() != MCTF_OK)
    {
-      fprintf(stderr, "  ~ %s backend FAILED\n", driver->name);
+      fprintf(stderr, "  ~ %s FAILED\n", name);
       fflush(stderr);
       dump_managed_log();
       mctf_se_down();
       return MCTF_FAIL;
    }
 
-   fprintf(stderr, "  ~ %s backend ready (%ds)\n", driver->name, (int)(time(NULL) - start));
+   fprintf(stderr, "  ~ %s ready (%ds)\n", name, (int)(time(NULL) - start));
    fflush(stderr);
 
    return MCTF_OK;
+}
+
+int
+mctf_se_up(int backend)
+{
+   if ((size_t)backend >= sizeof(registry) / sizeof(registry[0]) ||
+       registry[backend] == NULL)
+   {
+      pgmoneta_log_error("mctf_se: unknown backend %d", backend);
+      return MCTF_FAIL;
+   }
+
+   return se_up_common(&backend, 1, registry[backend]->name);
+}
+
+int
+mctf_se_up_all(void)
+{
+   int all[MAX_BACKENDS];
+
+   for (int i = 0; i < MAX_BACKENDS; i++)
+   {
+      all[i] = i;
+   }
+
+   return se_up_common(all, MAX_BACKENDS, "remote");
 }
 
 void
@@ -351,10 +409,15 @@ mctf_se_down(void)
 
    daemon_down();
 
-   if (storage.driver != NULL && storage.driver->stop != NULL)
+   /* Stop in reverse start order */
+   for (int i = n_active - 1; i >= 0; i--)
    {
-      storage.driver->stop(&storage);
+      if (storage[i].driver != NULL && storage[i].driver->stop != NULL)
+      {
+         storage[i].driver->stop(&storage[i]);
+      }
    }
+   n_active = 0;
 }
 
 int
@@ -453,13 +516,33 @@ mctf_se_run_dir(void)
 const struct mctf_se*
 mctf_se_context(void)
 {
-   return storage_active ? &storage : NULL;
+   return storage_active ? &storage[0] : NULL;
+}
+
+const struct mctf_se*
+mctf_se_context_for(int backend)
+{
+   if (!storage_active ||
+       (size_t)backend >= sizeof(registry) / sizeof(registry[0]))
+   {
+      return NULL;
+   }
+
+   for (int i = 0; i < n_active; i++)
+   {
+      if (storage[i].driver == registry[backend])
+      {
+         return &storage[i];
+      }
+   }
+
+   return NULL;
 }
 
 int
 mctf_se_azure_blob_count(void)
 {
-   const struct mctf_se* ctx = mctf_se_context();
+   const struct mctf_se* ctx = mctf_se_context_for(MCTF_BACKEND_AZURITE);
    char utc_date[UTC_TIME_LENGTH];
    char* string_to_sign = NULL;
    char* signing_key = NULL;

--- a/test/testcases/test_remote.c
+++ b/test/testcases/test_remote.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* Integration tests for the unified remote fan-out (SSH + S3 + Azure). */
+
+#include <mctf.h>
+#include <mctf_container.h>
+#include <mctf_se.h>
+#include <tscommon.h>
+#include <utils.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int storage_status = MCTF_FAIL;
+static char shared_label[256];
+
+/* Return the lexicographically largest (newest) backup label for primary. */
+static int
+newest_backup_label(char* out, size_t size)
+{
+   char backup_dir[MAX_PATH];
+   char** dirs = NULL;
+   int ndir = 0;
+   int best = -1;
+
+   pgmoneta_snprintf(backup_dir, sizeof(backup_dir), "%s/backup/primary/backup", mctf_se_run_dir());
+   pgmoneta_get_directories(backup_dir, &ndir, &dirs);
+   if (ndir <= 0 || dirs == NULL)
+   {
+      return MCTF_FAIL;
+   }
+
+   for (int i = 0; i < ndir; i++)
+   {
+      if (best < 0 || strcmp(dirs[i], dirs[best]) > 0)
+      {
+         best = i;
+      }
+   }
+   pgmoneta_snprintf(out, size, "%s", dirs[best]);
+
+   for (int i = 0; i < ndir; i++)
+   {
+      free(dirs[i]);
+   }
+   free(dirs);
+
+   return out[0] != '\0' ? MCTF_OK : MCTF_FAIL;
+}
+
+/* Read one REMOTE_*_ELAPSED value from the newest backup.info; -1 on error. */
+static double
+elapsed_from_backup_info(const char* key)
+{
+   char* out = NULL;
+   double v = -1.0;
+
+   mctf_sh(&out, "grep '^%s=' %s/backup/primary/backup/%s/backup.info | cut -d= -f2 | tr -d '\\n'",
+           key, mctf_se_run_dir(), shared_label);
+   if (out != NULL && out[0] != '\0')
+   {
+      v = atof(out);
+   }
+   free(out);
+
+   return v;
+}
+
+MCTF_MODULE_SETUP(remote)
+{
+   memset(shared_label, 0, sizeof(shared_label));
+   storage_status = mctf_se_up_all();
+   if (storage_status == MCTF_OK)
+   {
+      if (mctf_se_backup("primary") != 0 ||
+          newest_backup_label(shared_label, sizeof(shared_label)) != MCTF_OK)
+      {
+         storage_status = MCTF_FAIL;
+      }
+   }
+}
+
+MCTF_MODULE_TEARDOWN(remote)
+{
+   mctf_se_down();
+}
+
+/* One backup must land on every configured backend. */
+MCTF_INTEGRATION_TEST(test_remote_backup_lands_on_all_backends)
+{
+   const struct mctf_se* ssh_ctx = NULL;
+   char* s3_listing = NULL;
+   char* ssh_out = NULL;
+   int blob_count = 0;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   /* S3 (Garage) */
+   MCTF_ASSERT(mctf_se_s3_ls("primary", shared_label, &s3_listing) == 0, cleanup, "s3 ls failed");
+   MCTF_ASSERT_PTR_NONNULL(s3_listing, cleanup, "empty s3 ls response");
+   MCTF_ASSERT(strstr(s3_listing, "backup.info") != NULL, cleanup,
+               "backup.info not found in S3 objects");
+
+   /* Azure (Azurite) */
+   blob_count = mctf_se_azure_blob_count();
+   MCTF_ASSERT(blob_count > 0, cleanup, "no blobs found in Azurite after backup");
+
+   /* SSH (sftp) */
+   ssh_ctx = mctf_se_context_for(MCTF_BACKEND_SSH);
+   MCTF_ASSERT_PTR_NONNULL(ssh_ctx, cleanup, "no SSH backend context");
+   MCTF_ASSERT(mctf_container_exec((struct mctf_container*)&ssh_ctx->container,
+                                   "find /home/pgmoneta/upload -type f",
+                                   &ssh_out) == 0,
+               cleanup, "find on sftp container failed");
+   MCTF_ASSERT(ssh_out != NULL && strchr(ssh_out, '\n') != NULL, cleanup,
+               "no files found on sftp container after backup");
+
+cleanup:
+   free(s3_listing);
+   free(ssh_out);
+   MCTF_FINISH();
+}
+
+/* At least two uploads must be in flight before the first one finishes. */
+MCTF_INTEGRATION_TEST(test_remote_uploads_run_in_parallel)
+{
+   char* out = NULL;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   mctf_sh(&out,
+           "awk '/remote_upload: .* started/{s++} /remote_upload: .* finished/{print s; exit}' %s/pgmoneta.log",
+           mctf_se_run_dir());
+   MCTF_ASSERT(out != NULL && out[0] != '\0', cleanup, "no remote_upload markers in managed log");
+   MCTF_ASSERT(atoi(out) >= 2, cleanup,
+               "fewer than 2 uploads in flight before the first finished (serial upload?)");
+
+cleanup:
+   free(out);
+   MCTF_FINISH();
+}
+
+/* All three REMOTE_*_ELAPSED keys must appear in backup.info. */
+MCTF_INTEGRATION_TEST(test_remote_all_timings_recorded)
+{
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   MCTF_ASSERT(elapsed_from_backup_info("REMOTE_SSH_ELAPSED") > 0.0, cleanup,
+               "REMOTE_SSH_ELAPSED not recorded in backup.info");
+   MCTF_ASSERT(elapsed_from_backup_info("REMOTE_S3_ELAPSED") > 0.0, cleanup,
+               "REMOTE_S3_ELAPSED not recorded in backup.info");
+   MCTF_ASSERT(elapsed_from_backup_info("REMOTE_AZURE_ELAPSED") > 0.0, cleanup,
+               "REMOTE_AZURE_ELAPSED not recorded in backup.info");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* Local data/ is removed after remote-only backup; catalog stays. */
+MCTF_INTEGRATION_TEST(test_remote_local_data_removed_metadata_kept)
+{
+   char data_dir[MAX_PATH];
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   pgmoneta_snprintf(data_dir, sizeof(data_dir), "%s/backup/primary/backup/%s/data",
+                     mctf_se_run_dir(), shared_label);
+   MCTF_ASSERT(access(data_dir, F_OK) != 0, cleanup,
+               "local data directory still present after remote-only backup");
+
+   MCTF_ASSERT(mctf_se_has_local_metadata("primary"), cleanup,
+               "local metadata missing after remote backup");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/* A second backup must succeed to guard against per-backend state corruption. */
+MCTF_INTEGRATION_TEST(test_remote_second_backup_succeeds)
+{
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+
+   MCTF_ASSERT(mctf_se_backup("primary") == 0, cleanup, "second remote backup failed");
+
+cleanup:
+   MCTF_FINISH();
+}


### PR DESCRIPTION
- closes #1211 
- also fixes #1183 

changes includes:
- Unify the separate `ssh`/`s3`/`azure` upload paths into one shared node (`se_remote.c`) that runs all three in parallel threads 
- Uses plain `pthread`s (one per engine) for the fan-out, keeping it simple and independent of the worker pool
- Add `mctf_se_up_all()` plus 5 integration tests proving the fan-out lands on every backend and genuinely runs in parallel

