### PR TITLE
[#1198]  Expose wal_streaming in status details for CI readiness polling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
           chown -R runner:runner $GITHUB_WORKSPACE
 
       - name: Run Tests
+        timeout-minutes: 45
         run: |
           export TEST_PG_VERSION=${{ matrix.pg_version }}
           if [ "${{ matrix.compiler }}" = "clang" ] && [ "${{ matrix.build_type }}" = "Debug" ]; then

--- a/AUTHORS
+++ b/AUTHORS
@@ -56,3 +56,4 @@ Ameen Sakr <ameensakr623@gmail.com>
 Harshit Shaw <shawharshit116@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
+Mostafa Mahmoud <mm1471800@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -63,6 +63,7 @@ Ameen Sakr <ameensakr623@gmail.com>
 Harshit Shaw <shawharshit116@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
+Mostafa Mahmoud <mm1471800@gmail.com>
 ```
 
 ## Committers

--- a/src/include/management.h
+++ b/src/include/management.h
@@ -197,6 +197,7 @@ extern "C" {
 #define MANAGEMENT_ARGUMENT_USED_SPACE            "UsedSpace"
 #define MANAGEMENT_ARGUMENT_VALID                 "Valid"
 #define MANAGEMENT_ARGUMENT_WAL                   "WAL"
+#define MANAGEMENT_ARGUMENT_WAL_STREAMING         "WalStreaming"
 #define MANAGEMENT_ARGUMENT_WORKER_ERRORS         "WorkerErrors"
 #define MANAGEMENT_ARGUMENT_WORKERS               "Workers"
 #define MANAGEMENT_ARGUMENT_WORKFLOW              "Workflow"

--- a/src/libpgmoneta/status.c
+++ b/src/libpgmoneta/status.c
@@ -373,6 +373,8 @@ pgmoneta_status_details(SSL* ssl, int client_fd, uint8_t compression, uint8_t en
       pgmoneta_json_put(js, MANAGEMENT_ARGUMENT_ONLINE, (uintptr_t)config->common.servers[i].online, ValueBool);
       pgmoneta_json_put(js, MANAGEMENT_ARGUMENT_PRIMARY, (uintptr_t)config->common.servers[i].primary, ValueBool);
 
+      pgmoneta_json_put(js, MANAGEMENT_ARGUMENT_WAL_STREAMING, (uintptr_t)(config->common.servers[i].wal_streaming > 0), ValueBool);
+
       d = pgmoneta_get_server(i);
 
       server_size = pgmoneta_directory_size(d);

--- a/test/check.sh
+++ b/test/check.sh
@@ -522,6 +522,23 @@ execute_testcases() {
       sleep 2
    done
 
+   echo "Wait for WAL streaming to be ready"
+   for i in {1..5}; do
+      if $EXECUTABLE_DIRECTORY/pgmoneta-cli -c $CONFIGURATION_DIRECTORY/pgmoneta_cli.conf status details -F json 2>/dev/null | \
+         grep -q '"WalStreaming": true'; then
+         echo "WAL streaming ready ... ok"
+         break
+      fi
+      if [[ $i -eq 5 ]]; then
+         echo "WAL streaming not ready ... not ok"
+         echo "Checking logs:"
+         tail -20 $LOG_DIR/pgmoneta.log 2>/dev/null || echo "Log file not found"
+         exit 1
+      fi
+      echo "Waiting for WAL streaming to be ready"
+      sleep 2
+   done
+
    echo "Start running MCTF tests"
    if [[ -f "$TEST_DIRECTORY/pgmoneta-test" ]]; then
       TEST_FILTER_ARGS=()

--- a/test/include/mctf.h
+++ b/test/include/mctf.h
@@ -115,16 +115,17 @@ typedef struct mctf_result
  */
 typedef struct mctf_runner
 {
-   mctf_test_t* tests;                /**< Linked list of registered tests */
-   mctf_test_t* tests_tail;           /**< Tail pointer for O(1) append */
-   mctf_result_t* results;            /**< Array of test results */
-   mctf_test_hooks_t* test_hooks;     /**< Per-test hook registrations (by module) */
-   mctf_module_hooks_t* module_hooks; /**< Per-module hook registrations */
-   size_t test_count;                 /**< Total number of tests */
-   size_t result_count;               /**< Total number of results */
-   size_t passed_count;               /**< Number of passed tests */
-   size_t failed_count;               /**< Number of failed tests */
-   size_t skipped_count;              /**< Number of skipped tests */
+   mctf_test_t* tests;                 /**< Linked list of registered tests */
+   mctf_test_t* tests_tail;            /**< Tail pointer for O(1) append */
+   mctf_result_t* results;             /**< Array of test results */
+   mctf_test_hooks_t* test_hooks;      /**< Per-test hook registrations (by module) */
+   mctf_module_hooks_t* module_hooks;  /**< Per-module hook registrations */
+   mctf_hook_func_t global_test_setup; /**< Called before EVERY test, regardless of module */
+   size_t test_count;                  /**< Total number of tests */
+   size_t result_count;                /**< Total number of results */
+   size_t passed_count;                /**< Number of passed tests */
+   size_t failed_count;                /**< Number of failed tests */
+   size_t skipped_count;               /**< Number of skipped tests */
 } mctf_runner_t;
 
 /**
@@ -212,6 +213,14 @@ mctf_register_test_setup(const char* module, mctf_hook_func_t func);
  */
 void
 mctf_register_test_teardown(const char* module, mctf_hook_func_t func);
+
+/**
+ * Register a global per-test setup hook, called before EVERY test regardless of module.
+ * Runs before any per-module setup hook registered via mctf_register_test_setup.
+ * @param func The setup function
+ */
+void
+mctf_register_global_test_setup(mctf_hook_func_t func);
 
 /**
  * Register a per-module setup hook.

--- a/test/include/tsclient.h
+++ b/test/include/tsclient.h
@@ -207,6 +207,21 @@ int
 pgmoneta_tsclient_status_details(int expected_error);
 
 /**
+ * Query the server's status details and report whether any server has WAL streaming active.
+ * @param ready set to true if at least one server has an active WAL receiver, false otherwise
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_tsclient_wal_streaming_ready(bool* ready);
+
+/**
+ * MCTF global per test setup hook: polls pgmoneta_tsclient_wal_streaming_ready(), retrying
+ * for a few seconds if WAL streaming isn't ready yet, then returns so the test can run.
+ */
+void
+pgmoneta_test_wait_for_wal_streaming(void);
+
+/**
  * Execute reload command on the server
  * @param expected_error expected error code
  * @return 0 upon success, otherwise 1

--- a/test/libpgmonetatest/mctf.c
+++ b/test/libpgmonetatest/mctf.c
@@ -372,6 +372,15 @@ get_or_create_module_hooks(const char* module)
 }
 
 void
+mctf_register_global_test_setup(mctf_hook_func_t func)
+{
+   if (!g_initialized)
+      mctf_init();
+
+   g_runner.global_test_setup = func;
+}
+
+void
 mctf_register_test_setup(const char* module, mctf_hook_func_t func)
 {
    mctf_test_hooks_t* h;
@@ -628,6 +637,12 @@ mctf_run_tests(mctf_filter_type_t filter_type, const char* filter)
 
       mctf_errno = 0;
       if (mctf_errmsg) { free(mctf_errmsg); mctf_errmsg = NULL; }
+
+      // global per test setup
+      if (g_runner.global_test_setup)
+      {
+         g_runner.global_test_setup();
+      }
 
       /* Per-test setup */
       if (cur_test_hooks && cur_test_hooks->setup)

--- a/test/libpgmonetatest/tsclient.c
+++ b/test/libpgmonetatest/tsclient.c
@@ -52,6 +52,10 @@
 #include <sys/types.h>
 
 
+/* Retry parameters for pgmoneta_test_wait_for_wal_streaming() */
+#define WAL_STREAMING_TEST_RETRY_MAX          5
+#define WAL_STREAMING_TEST_RETRY_DELAY_MICRO  2000000 // 2 seconds
+
 static int check_output_outcome(int socket, int expected_error, struct json** output);
 static int get_connection();
 
@@ -549,6 +553,85 @@ pgmoneta_tsclient_status_details(int expected_error)
 error:
    pgmoneta_disconnect(socket);
    return 1;
+}
+
+int
+pgmoneta_tsclient_wal_streaming_ready(bool* ready)
+{
+   int socket = -1;
+   struct json* read = NULL;
+   struct json* response = NULL;
+   struct json* servers = NULL;
+   struct json_iterator* iter = NULL;
+
+   *ready = false;
+
+   socket = get_connection();
+   if (!pgmoneta_socket_isvalid(socket))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_management_request_status_details(NULL, socket, MANAGEMENT_COMPRESSION_NONE, MANAGEMENT_ENCRYPTION_NONE, MANAGEMENT_OUTPUT_FORMAT_JSON))
+   {
+      goto error;
+   }
+
+   if (check_output_outcome(socket, 0, &read))
+   {
+      goto error;
+   }
+
+   response = (struct json*)pgmoneta_json_get(read, MANAGEMENT_CATEGORY_RESPONSE);
+   servers = (struct json*)pgmoneta_json_get(response, MANAGEMENT_ARGUMENT_SERVERS);
+
+   if (servers != NULL && pgmoneta_json_iterator_create(servers, &iter) == 0)
+   {
+      while (pgmoneta_json_iterator_next(iter))
+      {
+         struct json* server = (struct json*)pgmoneta_value_data(iter->value);
+         if ((bool)pgmoneta_json_get(server, MANAGEMENT_ARGUMENT_WAL_STREAMING))
+         {
+            *ready = true;
+            break;
+         }
+      }
+      pgmoneta_json_iterator_destroy(iter);
+   }
+
+   pgmoneta_json_destroy(read);
+   pgmoneta_disconnect(socket);
+   return 0;
+error:
+   if (read != NULL)
+   {
+      pgmoneta_json_destroy(read);
+   }
+   pgmoneta_disconnect(socket);
+   return 1;
+}
+
+void
+pgmoneta_test_wait_for_wal_streaming(void)
+{
+   struct main_configuration* config = (struct main_configuration*)shmem;
+   bool ready = false;
+
+   if (config == NULL || strlen(config->common.configuration_path) == 0)
+   {
+      return;
+   }
+
+   for (int i = 0; i < WAL_STREAMING_TEST_RETRY_MAX; i++)
+   {
+      if (pgmoneta_tsclient_wal_streaming_ready(&ready) == 0 && ready)
+      {
+         return;
+      }
+      usleep(WAL_STREAMING_TEST_RETRY_DELAY_MICRO);
+   }
+
+   pgmoneta_log_warn("WAL streaming not ready before test; proceeding anyway");
 }
 
 int

--- a/test/postgresql/src/postgresql14/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql14/conf/postgresql.conf
@@ -330,7 +330,7 @@ min_wal_size = 80MB
 				# (change requires restart)
 #max_replication_slots = 10	# max number of replication slots
 				# (change requires restart)
-#wal_keep_size = 0		# in megabytes; 0 disables
+wal_keep_size = 512		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
 track_commit_timestamp = on	# collect timestamp of transaction commit

--- a/test/postgresql/src/postgresql15/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql15/conf/postgresql.conf
@@ -330,7 +330,7 @@ min_wal_size = 80MB
 				# (change requires restart)
 #max_replication_slots = 10	# max number of replication slots
 				# (change requires restart)
-#wal_keep_size = 0		# in megabytes; 0 disables
+wal_keep_size = 512		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
 track_commit_timestamp = on	# collect timestamp of transaction commit

--- a/test/postgresql/src/postgresql17/conf/postgresql.conf
+++ b/test/postgresql/src/postgresql17/conf/postgresql.conf
@@ -330,7 +330,7 @@ summarize_wal = on		# run WAL summarizer process?
 				# (change requires restart)
 #max_replication_slots = 10	# max number of replication slots
 				# (change requires restart)
-#wal_keep_size = 0		# in megabytes; 0 disables
+wal_keep_size = 512		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
 track_commit_timestamp = on	# collect timestamp of transaction commit

--- a/test/runner.c
+++ b/test/runner.c
@@ -28,6 +28,7 @@
  */
 #include <mctf.h>
 #include <html_report.h>
+#include <tsclient.h>
 #include <tscommon.h>
 #include <utils.h>
 #include <logging.h>
@@ -398,6 +399,8 @@ main(int argc, char* argv[])
    }
 
    setup_signal_handlers();
+
+   mctf_register_global_test_setup(pgmoneta_test_wait_for_wal_streaming);
 
    if (getenv("PGMONETA_TEST_CONF") != NULL)
    {


### PR DESCRIPTION
- Closes #1198 
### Changes
- Include `WalStreaming` (`true` or `false`) attribute in the output of the details command
- Update `check.sh` to only run tests when `WalStreaming = true` and added a retry loop for this check
- Add a retry loop before every test to check if wal server is ready or not
- Add timeout to the CI (45 minutes)