### PR TITLE
[#1221] Support backend passwords/tokens longer than 256 characters (cloud IAM DB-auth)

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -602,9 +602,9 @@ is_valid_key(char* key)
       return false;
    }
 
-   if (char_count > MAX_PASSWORD_CHARS)
+   if (strlen(key) >= MAX_PASSWORD_LENGTH)
    {
-      warnx("Master key too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+      warnx("Master key too long (%zu bytes). Maximum allowed: %d bytes.", strlen(key), MAX_PASSWORD_LENGTH - 1);
       return false;
    }
 
@@ -780,9 +780,9 @@ password:
       password = NULL;
       goto password;
    }
-   if (char_count > MAX_PASSWORD_CHARS)
+   if (strlen(password) >= MAX_PASSWORD_LENGTH)
    {
-      warnx("Password too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+      warnx("Password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(password), MAX_PASSWORD_LENGTH - 1);
       if (do_free)
       {
          free(password);
@@ -831,9 +831,9 @@ password:
          password = NULL;
          goto password;
       }
-      if (verify_char_count > MAX_PASSWORD_CHARS)
+      if (strlen(verify) >= MAX_PASSWORD_LENGTH)
       {
-         warnx("Verification password too long (%zu characters). Maximum allowed: %d characters.", verify_char_count, MAX_PASSWORD_CHARS);
+         warnx("Verification password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(verify), MAX_PASSWORD_LENGTH - 1);
          free(verify);
          verify = NULL;
          if (do_free)
@@ -1122,9 +1122,9 @@ password:
             password = NULL;
             goto password;
          }
-         if (char_count > MAX_PASSWORD_CHARS)
+         if (strlen(password) >= MAX_PASSWORD_LENGTH)
          {
-            warnx("Password too long (%zu characters). Maximum allowed: %d characters.", char_count, MAX_PASSWORD_CHARS);
+            warnx("Password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(password), MAX_PASSWORD_LENGTH - 1);
             if (do_free)
             {
                free(password);
@@ -1173,9 +1173,9 @@ password:
                password = NULL;
                goto password;
             }
-            if (verify_char_count > MAX_PASSWORD_CHARS)
+            if (strlen(verify) >= MAX_PASSWORD_LENGTH)
             {
-               warnx("Verification password too long (%zu characters). Maximum allowed: %d characters.", verify_char_count, MAX_PASSWORD_CHARS);
+               warnx("Verification password too long (%zu bytes). Maximum allowed: %d bytes.", strlen(verify), MAX_PASSWORD_LENGTH - 1);
                free(verify);
                verify = NULL;
                if (do_free)

--- a/src/cli.c
+++ b/src/cli.c
@@ -879,11 +879,10 @@ password:
          goto password;
       }
 
-      // Check character length
-      size_t char_count = pgmoneta_utf8_char_length((unsigned char*)password, strlen(password));
-      if (char_count == (size_t)-1 || char_count > MAX_PASSWORD_CHARS)
+      // Enforce the password byte-length limit
+      if (strlen(password) >= MAX_PASSWORD_LENGTH)
       {
-         printf("pgmoneta-cli: Invalid password: too many characters (max %d)\n", MAX_PASSWORD_CHARS);
+         printf("pgmoneta-cli: Invalid password: too long (max %d bytes)\n", MAX_PASSWORD_LENGTH - 1);
          goto password;
       }
 

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -68,8 +68,7 @@ extern "C" {
 #define DEFAULT_EVERY                1
 
 #define MAX_USERNAME_LENGTH          128
-#define MAX_PASSWORD_LENGTH          1024
-#define MAX_PASSWORD_CHARS           256
+#define MAX_PASSWORD_LENGTH          8192 /* Bytes; the single password-length limit, sized for cloud IAM DB-auth tokens (AWS RDS/Aurora, Azure AD, GCP) */
 #define MIN_MASTER_KEY_CHARS         8
 
 #define MAX_PATH                     1024

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -63,6 +63,14 @@
 #define NAME        "configuration"
 #define LINE_LENGTH 512
 
+/*
+ * Credential files (users/admins) store each entry as
+ * "username:base64(AES-256-GCM(password))". A password near MAX_PASSWORD_LENGTH
+ * (cloud IAM DB-auth tokens) expands under encryption + base64 well beyond
+ * LINE_LENGTH, so these files are read with a dedicated, larger line buffer.
+ */
+#define MAX_USER_LINE_LENGTH 16384
+
 static int extract_syskey_value(char* str, char** key, char** value);
 static void extract_key_value(char* str, char** key, char** value);
 static int as_int(char* str, int* i);
@@ -2909,7 +2917,7 @@ int
 pgmoneta_read_users_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    char* trimmed_line = NULL;
    int index;
    char* master_key = NULL;
@@ -3001,20 +3009,17 @@ pgmoneta_read_users_configuration(void* shm, char* filename)
             continue;
          }
 
-         // Check character length
-         size_t char_count = pgmoneta_utf8_char_length((unsigned char*)password, strlen(password));
          if (strlen(username) < MAX_USERNAME_LENGTH &&
-             strlen(password) < MAX_PASSWORD_LENGTH &&
-             char_count != (size_t)-1 && char_count <= MAX_PASSWORD_CHARS)
+             strlen(password) < MAX_PASSWORD_LENGTH)
          {
             memcpy(&config->common.users[index].username, username, strlen(username));
             memcpy(&config->common.users[index].password, password, strlen(password));
          }
          else
          {
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgmoneta_log_warn("Password too long for user '%s' (%zu characters)", username, char_count);
+               pgmoneta_log_warn("Password too long for user '%s' (%zu bytes, max %d)", username, strlen(password), MAX_PASSWORD_LENGTH - 1);
             }
             printf("pgmoneta: Invalid USER entry\n");
             printf("%s\n", line);
@@ -3132,7 +3137,7 @@ int
 pgmoneta_read_admins_configuration(void* shm, char* filename)
 {
    FILE* file;
-   char line[LINE_LENGTH];
+   char line[MAX_USER_LINE_LENGTH];
    char* trimmed_line = NULL;
    int index;
    char* master_key = NULL;
@@ -3226,20 +3231,17 @@ pgmoneta_read_admins_configuration(void* shm, char* filename)
             continue;
          }
 
-         // Check character length
-         size_t char_count = pgmoneta_utf8_char_length((unsigned char*)password, strlen(password));
          if (strlen(username) < MAX_USERNAME_LENGTH &&
-             strlen(password) < MAX_PASSWORD_LENGTH &&
-             char_count != (size_t)-1 && char_count <= MAX_PASSWORD_CHARS)
+             strlen(password) < MAX_PASSWORD_LENGTH)
          {
             memcpy(&config->common.admins[index].username, username, strlen(username));
             memcpy(&config->common.admins[index].password, password, strlen(password));
          }
          else
          {
-            if (char_count > MAX_PASSWORD_CHARS)
+            if (strlen(password) >= MAX_PASSWORD_LENGTH)
             {
-               pgmoneta_log_warn("Password too long for user '%s' (%zu characters)", username, char_count);
+               pgmoneta_log_warn("Password too long for user '%s' (%zu bytes, max %d)", username, strlen(password), MAX_PASSWORD_LENGTH - 1);
             }
             printf("pgmoneta: Invalid ADMIN entry\n");
             printf("%s\n", line);

--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -78,7 +78,7 @@
 #define SECURITY_ALL                99
 
 #define NUMBER_OF_SECURITY_MESSAGES 5
-#define SECURITY_BUFFER_SIZE        1024
+#define SECURITY_BUFFER_SIZE        16384 /* Must hold a PasswordMessage carrying a MAX_PASSWORD_LENGTH credential (cloud IAM tokens) */
 
 static signed char has_security;
 static ssize_t security_lengths[NUMBER_OF_SECURITY_MESSAGES];
@@ -1302,6 +1302,12 @@ server_password(char* username, char* password, SSL* ssl, int server_fd)
       goto error;
    }
 
+   if (password_msg->length > SECURITY_BUFFER_SIZE)
+   {
+      pgmoneta_log_error("Password message too large: %ld", password_msg->length);
+      goto error;
+   }
+
    security_lengths[auth_index] = password_msg->length;
    memcpy(&security_messages[auth_index], password_msg->data, password_msg->length);
    auth_index++;
@@ -2026,7 +2032,6 @@ error:
 static int
 sasl_prep(char* password, char** password_prep)
 {
-   size_t char_count;
    size_t password_len;
 
    if (!password || !password_prep)
@@ -2053,9 +2058,8 @@ sasl_prep(char* password, char** password_prep)
       goto error;
    }
 
-   // Validate the character count in the password
-   char_count = pgmoneta_utf8_char_length((const unsigned char*)password, password_len);
-   if (char_count == (size_t)-1 || char_count > MAX_PASSWORD_CHARS)
+   // Enforce the password byte-length limit
+   if (password_len >= MAX_PASSWORD_LENGTH)
    {
       goto error;
    }


### PR DESCRIPTION
Port of pgagroal/pgagroal#942 + pgagroal/pgagroal#944 to pgmoneta, per #1221.

Cloud IAM DB-auth tokens (AWS RDS/Aurora, Azure AD, GCP) routinely exceed 256 UTF-8 characters and can exceed 1024 bytes, so pgmoneta could not authenticate to an IAM-auth PostgreSQL backend — the token was rejected/truncated before the connection succeeded.

### Changes
- `MAX_PASSWORD_LENGTH` 1024 → **8192 bytes**, and **remove the duplicated `MAX_PASSWORD_CHARS`** (256-char) limit so byte length is the single source of truth.
- `SECURITY_BUFFER_SIZE` 1024 → 16384 so a `PasswordMessage` carrying such a credential fits, plus a size guard on the per-connection copy in `server_password`.
- Read the users/admins credential files with a dedicated 16384-byte line buffer (`MAX_USER_LINE_LENGTH`) — an encrypted + base64 long token expands well beyond `LINE_LENGTH`.
- Validate by byte length (`strlen >= MAX_PASSWORD_LENGTH`) instead of UTF-8 character count across `sasl_prep`, configuration loading, `cli`, and `admin`; error messages now report bytes.

Mirrors the reviewed-and-merged pgagroal approach and keeps pgagroal / pgexporter / pgmoneta aligned (pgexporter port: pgexporter/pgexporter#562).

Closes #1221.
