### PR TITLE
[#340] Add Nagios support via Prometheus bridge

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -26,6 +26,7 @@ See a [sample](./etc/pgmoneta.conf) configuration for running `pgmoneta` on `loc
 | unix_socket_dir | | String | Yes | The Unix Domain Socket location. Can interpolate environment variables (e.g., `$HOME`) |
 | base_dir | | String | Yes | The base directory for the backup. Can interpolate environment variables (e.g., `$HOME`) |
 | metrics | 0 | Int | No | The metrics port (disable = 0) |
+| nagios | 0 | Int | No | The Nagios port (disable = 0). When enabled, pgmoneta fetches metrics from the Prometheus endpoint and serves them in Nagios passive check format |
 | metrics_cache_max_age | 0 | String | No | The duration to keep a Prometheus (metrics) response in cache. If set to zero, the caching will be disabled. Supports suffixes: 's' (seconds, default), 'm' (minutes), 'h' (hours), 'd' (days), 'w' (weeks). |
 | metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
 | management | 0 | Int | No | The remote management port (disable = 0) |

--- a/doc/manual/en/04-configuration.md
+++ b/doc/manual/en/04-configuration.md
@@ -41,6 +41,7 @@ Note, that if `host` starts with a `/` it represents a path and `pgmoneta` will 
 | Property | Default | Unit | Required | Description |
 | :------- | :------ | :--- | :------- | :---------- |
 | metrics | 0 | Int | No | The metrics port (disable = 0) |
+| nagios | 0 | Int | No | The Nagios port (disable = 0). When enabled, pgmoneta fetches metrics from the Prometheus endpoint and serves them in Nagios passive check format |
 | metrics_cache_max_age | 0 | String | No | The time to keep a Prometheus (metrics) response in cache. If this value is specified without units, it is taken as seconds. Setting this parameter to 0 disables caching. It supports the following units as suffixes: 'S' for seconds (default), 'M' for minutes, 'H' for hours, 'D' for days, and 'W' for weeks. |
 | metrics_cache_max_size | 256k | String | No | The maximum amount of data to keep in cache when serving Prometheus responses. Changes require restart. This parameter determines the size of memory allocated for the cache even if `metrics_cache_max_age` or `metrics` are disabled. Its value, however, is taken into account only if `metrics_cache_max_age` is set to a non-zero value. Supports suffixes: 'B' (bytes), the default if omitted, 'K' or 'KB' (kilobytes), 'M' or 'MB' (megabytes), 'G' or 'GB' (gigabytes).|
 | metrics_cert_file | | String | No | Certificate file for TLS for Prometheus metrics. This file must be owned by either the user running pgmoneta or root. |

--- a/doc/manual/en/20-nagios.md
+++ b/doc/manual/en/20-nagios.md
@@ -1,0 +1,44 @@
+# Nagios
+
+pgmoneta can serve metrics in Nagios passive check format by bridging the existing Prometheus metrics endpoint.
+
+## Configuration
+
+Add the following to your `pgmoneta.conf`:
+
+```ini
+nagios = 6000
+```
+
+This tells pgmoneta to listen on port 6000 for Nagios connections. The `metrics` port must also be configured and enabled, since the Nagios bridge fetches data from it.
+
+## How it works
+
+When a connection is received on the Nagios port, pgmoneta:
+
+1. Connects to the internal Prometheus metrics endpoint
+2. Fetches all available metrics
+3. Transforms them into Nagios passive check format
+4. Returns the result to the caller
+
+## Output format
+
+The response follows the Nagios plugin output format:
+PGMONETA OK - pgmoneta is running|metric1=value1 metric2=value2 ...
+Where the pipe-separated section is the performance data containing all available metrics.
+
+## Example
+
+Start pgmoneta with both metrics and nagios ports configured:
+
+```ini
+metrics = 5001
+nagios = 6000
+```
+
+Then query the Nagios endpoint:
+nc localhost 6000
+PGMONETA OK - pgmoneta is running|pgmoneta_backup_size=...
+## See also
+
+* [Prometheus](10-prometheus.md)

--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -81,6 +81,7 @@ extern "C" {
 #define CONFIGURATION_ARGUMENT_MANAGEMENT              "management"
 #define CONFIGURATION_ARGUMENT_MANIFEST                "manifest"
 #define CONFIGURATION_ARGUMENT_METRICS                 "metrics"
+#define CONFIGURATION_ARGUMENT_NAGIOS                  "nagios"
 #define CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_AGE   "metrics_cache_max_age"
 #define CONFIGURATION_ARGUMENT_METRICS_CACHE_MAX_SIZE  "metrics_cache_max_size"
 #define CONFIGURATION_ARGUMENT_METRICS_CA_FILE         "metrics_ca_file"

--- a/src/include/nagios.h
+++ b/src/include/nagios.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef PGMONETA_NAGIOS_H
+#define PGMONETA_NAGIOS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <security.h>
+#include <stdlib.h>
+
+/** Nagios return codes */
+#define NAGIOS_OK       0
+#define NAGIOS_WARNING  1
+#define NAGIOS_CRITICAL 2
+#define NAGIOS_UNKNOWN  3
+
+/**
+ * Handle a Nagios client connection
+ * @param client_ssl The SSL connection (may be NULL)
+ * @param client_fd The client file descriptor
+ */
+void
+pgmoneta_nagios(SSL* client_ssl, int client_fd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/pgmoneta.h
+++ b/src/include/pgmoneta.h
@@ -454,6 +454,7 @@ struct main_configuration
 
    char host[MISC_LENGTH];                /**< The host */
    int metrics;                           /**< The metrics port */
+   int nagios;                            /**< The Nagios port */
    int console;                           /**< The console port */
    pgmoneta_time_t metrics_cache_max_age; /**< Cache duration for Prometheus response */
    int metrics_cache_max_size;            /**< Number of bytes max to cache the Prometheus response */

--- a/src/libpgmoneta/configuration.c
+++ b/src/libpgmoneta/configuration.c
@@ -690,6 +690,20 @@ pgmoneta_read_main_configuration(void* shm, char* filename)
                      unknown = true;
                   }
                }
+               else if (pgmoneta_compare_string(key, "nagios"))
+               {
+                  if (pgmoneta_compare_string(section, "pgmoneta"))
+                  {
+                     if (as_int(value, &config->nagios))
+                     {
+                        unknown = true;
+                     }
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+               }
                else if (pgmoneta_compare_string(key, "console"))
                {
                   if (pgmoneta_compare_string(section, "pgmoneta"))
@@ -4485,6 +4499,13 @@ apply_main_configuration(struct main_configuration* config, struct server* srv, 
       else if (pgmoneta_compare_string(key, "metrics"))
       {
          if (as_int(value, &config->metrics))
+         {
+            unknown = true;
+         }
+      }
+      else if (pgmoneta_compare_string(key, "nagios"))
+      {
+         if (as_int(value, &config->nagios))
          {
             unknown = true;
          }

--- a/src/libpgmoneta/nagios.c
+++ b/src/libpgmoneta/nagios.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* pgmoneta */
+#include <pgmoneta.h>
+#include <art.h>
+#include <deque.h>
+#include <logging.h>
+#include <memory.h>
+#include <nagios.h>
+#include <network.h>
+#include <prometheus_client.h>
+#include <utils.h>
+
+/* system */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void nagios_page(SSL* client_ssl, int client_fd);
+static int send_nagios_response(SSL* client_ssl, int client_fd, char* data);
+
+void
+pgmoneta_nagios(SSL* client_ssl, int client_fd)
+{
+   pgmoneta_start_logging();
+   pgmoneta_memory_init();
+
+   nagios_page(client_ssl, client_fd);
+
+   pgmoneta_close_ssl(client_ssl);
+   pgmoneta_disconnect(client_fd);
+   pgmoneta_memory_destroy();
+   pgmoneta_stop_logging();
+   exit(0);
+}
+
+static void
+nagios_page(SSL* client_ssl, int client_fd)
+{
+   struct prometheus_bridge* bridge = NULL;
+   struct art_iterator* iter = NULL;
+   char* output = NULL;
+   char* perf_data = NULL;
+   struct main_configuration* config;
+
+   config = (struct main_configuration*)shmem;
+
+   if (pgmoneta_prometheus_client_create_bridge(&bridge))
+   {
+      pgmoneta_log_error("Nagios: Failed to create Prometheus bridge");
+      goto error;
+   }
+
+   if (pgmoneta_prometheus_client_get(config->metrics, bridge))
+   {
+      pgmoneta_log_error("Nagios: Failed to fetch metrics from Prometheus endpoint");
+      goto error;
+   }
+
+   if (pgmoneta_art_iterator_create(bridge->metrics, &iter))
+   {
+      pgmoneta_log_error("Nagios: Failed to create metrics iterator");
+      goto error;
+   }
+
+   perf_data = pgmoneta_append(perf_data, "");
+
+   while (pgmoneta_art_iterator_next(iter))
+   {
+      struct prometheus_metric* metric = (struct prometheus_metric*)iter->value->data;
+      if (metric == NULL)
+      {
+         continue;
+      }
+
+      struct deque_iterator* def_iter = NULL;
+      if (pgmoneta_deque_iterator_create(metric->definitions, &def_iter))
+      {
+         continue;
+      }
+
+      while (pgmoneta_deque_iterator_next(def_iter))
+      {
+         struct prometheus_attributes* attrs = (struct prometheus_attributes*)def_iter->value->data;
+         if (attrs == NULL || attrs->values == NULL)
+         {
+            continue;
+         }
+
+         struct deque_iterator* val_iter = NULL;
+         if (pgmoneta_deque_iterator_create(attrs->values, &val_iter))
+         {
+            continue;
+         }
+
+         while (pgmoneta_deque_iterator_next(val_iter))
+         {
+            struct prometheus_value* val = (struct prometheus_value*)val_iter->value->data;
+            if (val == NULL || val->value == NULL)
+            {
+               continue;
+            }
+
+            if (strlen(perf_data) > 0)
+            {
+               perf_data = pgmoneta_append(perf_data, " ");
+            }
+            perf_data = pgmoneta_append(perf_data, metric->name);
+            perf_data = pgmoneta_append(perf_data, "=");
+            perf_data = pgmoneta_append(perf_data, val->value);
+         }
+         pgmoneta_deque_iterator_destroy(val_iter);
+      }
+      pgmoneta_deque_iterator_destroy(def_iter);
+   }
+
+   pgmoneta_art_iterator_destroy(iter);
+   iter = NULL;
+
+   output = pgmoneta_append(output, "PGMONETA OK - pgmoneta is running");
+   if (perf_data != NULL && strlen(perf_data) > 0)
+   {
+      output = pgmoneta_append(output, "|");
+      output = pgmoneta_append(output, perf_data);
+   }
+   output = pgmoneta_append(output, "\n");
+
+   send_nagios_response(client_ssl, client_fd, output);
+
+   free(output);
+   free(perf_data);
+   pgmoneta_prometheus_client_destroy_bridge(bridge);
+   return;
+
+error:
+   if (iter != NULL)
+   {
+      pgmoneta_art_iterator_destroy(iter);
+   }
+   if (bridge != NULL)
+   {
+      pgmoneta_prometheus_client_destroy_bridge(bridge);
+   }
+   free(perf_data);
+   output = pgmoneta_append(NULL, "PGMONETA UNKNOWN - Failed to retrieve metrics\n");
+   send_nagios_response(client_ssl, client_fd, output);
+   free(output);
+}
+
+static int
+send_nagios_response(SSL* client_ssl, int client_fd, char* data)
+{
+   int status;
+   char* m = NULL;
+   struct message msg;
+
+   memset(&msg, 0, sizeof(struct message));
+
+   m = malloc(20);
+   if (m == NULL)
+   {
+      return 1;
+   }
+   memset(m, 0, 20);
+   sprintf(m, "%zX\r\n", strlen(data));
+   m = pgmoneta_append(m, data);
+   m = pgmoneta_append(m, "\r\n");
+   msg.kind = 0;
+   msg.length = strlen(m);
+   msg.data = m;
+   status = pgmoneta_write_message(client_ssl, client_fd, &msg);
+   free(m);
+   return status;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@
 #include <memory.h>
 #include <message.h>
 #include <network.h>
+#include <nagios.h>
 #include <prometheus.h>
 #include <remote.h>
 #include <restore.h>
@@ -90,6 +91,7 @@
 
 static void accept_mgt_cb(struct ev_loop* loop, struct ev_io* watcher, int revents);
 static void accept_metrics_cb(struct ev_loop* loop, struct ev_io* watcher, int revents);
+static void accept_nagios_cb(struct ev_loop* loop, struct ev_io* watcher, int revents);
 static void accept_console_cb(struct ev_loop* loop, struct ev_io* watcher, int revents);
 static void accept_management_cb(struct ev_loop* loop, struct ev_io* watcher, int revents);
 static void shutdown_cb(struct ev_loop* loop, ev_signal* w, int revents);
@@ -130,6 +132,9 @@ static int unix_management_socket = -1;
 static struct accept_io io_metrics[MAX_FDS];
 static int* metrics_fds = NULL;
 static int metrics_fds_length = -1;
+static struct accept_io io_nagios[MAX_FDS];
+static int* nagios_fds = NULL;
+static int nagios_fds_length = -1;
 static struct accept_io io_console[MAX_FDS];
 static int* console_fds = NULL;
 static int console_fds_length = -1;
@@ -190,6 +195,29 @@ shutdown_metrics(void)
    }
 }
 
+static void
+start_nagios(void)
+{
+   for (int i = 0; i < nagios_fds_length; i++)
+   {
+      int sockfd = *(nagios_fds + i);
+      memset(&io_nagios[i], 0, sizeof(struct accept_io));
+      ev_io_init((struct ev_io*)&io_nagios[i], accept_nagios_cb, sockfd, EV_READ);
+      io_nagios[i].socket = sockfd;
+      io_nagios[i].argv = argv_ptr;
+      ev_io_start(main_loop, (struct ev_io*)&io_nagios[i]);
+   }
+}
+static void
+shutdown_nagios(void)
+{
+   for (int i = 0; i < nagios_fds_length; i++)
+   {
+      ev_io_stop(main_loop, (struct ev_io*)&io_nagios[i]);
+      pgmoneta_disconnect(io_nagios[i].socket);
+      errno = 0;
+   }
+}
 static void
 start_console(void)
 {
@@ -969,6 +997,7 @@ main(int argc, char** argv)
 
    shutdown_management(true);
    shutdown_metrics();
+   shutdown_nagios();
    shutdown_console(true);
    shutdown_mgt(true);
 
@@ -980,6 +1009,7 @@ main(int argc, char** argv)
    ev_loop_destroy(main_loop);
 
    free(metrics_fds);
+   free(nagios_fds);
    free(console_fds);
    free(management_fds);
 
@@ -1012,6 +1042,7 @@ error:
    if (metrics_started)
    {
       shutdown_metrics();
+      shutdown_nagios();
    }
 
    if (console_started)
@@ -1025,6 +1056,7 @@ error:
    }
 
    free(metrics_fds);
+   free(nagios_fds);
    free(console_fds);
    free(management_fds);
 
@@ -2153,6 +2185,7 @@ accept_metrics_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
          pgmoneta_log_warn("Restarting listening port due to: %s (%d)", strerror(errno), watcher->fd);
 
          shutdown_metrics();
+         shutdown_nagios();
 
          free(metrics_fds);
          metrics_fds = NULL;
@@ -2220,6 +2253,65 @@ child_error:
    pgmoneta_disconnect(client_fd);
 }
 
+static void
+accept_nagios_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
+{
+   struct sockaddr_in6 client_addr;
+   socklen_t client_addr_length;
+   int client_fd;
+   struct main_configuration* config;
+
+   if (EV_ERROR & revents)
+   {
+      pgmoneta_log_debug("accept_nagios_cb: invalid event: %s", strerror(errno));
+      errno = 0;
+      return;
+   }
+
+   config = (struct main_configuration*)shmem;
+
+   memset(&client_addr, 0, sizeof(client_addr));
+   client_addr_length = sizeof(client_addr);
+   client_fd = accept(watcher->fd, (struct sockaddr*)&client_addr, &client_addr_length);
+   if (client_fd == -1)
+   {
+      if (accept_fatal(errno) && keep_running)
+      {
+         pgmoneta_log_warn("Restarting Nagios listening port due to: %s (%d)", strerror(errno), watcher->fd);
+         shutdown_nagios();
+         free(nagios_fds);
+         nagios_fds = NULL;
+         nagios_fds_length = 0;
+         if (pgmoneta_bind(config->host, config->nagios, &nagios_fds, &nagios_fds_length))
+         {
+            pgmoneta_log_fatal("Could not bind to %s:%d", config->host, config->nagios);
+            exit(1);
+         }
+         if (nagios_fds_length > MAX_FDS)
+         {
+            pgmoneta_log_fatal("Too many descriptors %d", nagios_fds_length);
+            exit(1);
+         }
+         start_nagios();
+      }
+      else
+      {
+         pgmoneta_log_debug("accept: %s (%d)", strerror(errno), watcher->fd);
+      }
+      errno = 0;
+      return;
+   }
+
+   if (!fork())
+   {
+      ev_loop_fork(loop);
+      shutdown_ports(false);
+      pgmoneta_nagios(NULL, client_fd);
+      exit(0);
+   }
+
+   pgmoneta_disconnect(client_fd);
+}
 static void
 accept_console_cb(struct ev_loop* loop, struct ev_io* watcher, int revents)
 {
@@ -2430,6 +2522,7 @@ reload_services_only(void)
    config = (struct main_configuration*)shmem;
 
    shutdown_metrics();
+   shutdown_nagios();
 
    free(metrics_fds);
    metrics_fds = NULL;
@@ -2782,6 +2875,7 @@ reload_configuration(bool* restart)
    if (old_metrics != config->metrics)
    {
       shutdown_metrics();
+      shutdown_nagios();
 
       free(metrics_fds);
       metrics_fds = NULL;
@@ -3252,6 +3346,7 @@ shutdown_ports(bool remove)
    if (config->metrics > 0)
    {
       shutdown_metrics();
+      shutdown_nagios();
    }
 
    if (config->management > 0)


### PR DESCRIPTION
Closes #340

This PR implements Nagios support for pgmoneta by building an internal bridge to the existing Prometheus metrics endpoint.

## Approach
1. Adds a `nagios` configuration option (port number, e.g. `nagios = 6000`)
2. When a connection arrives on the Nagios port, it fetches metrics from the existing Prometheus endpoint using `pgmoneta_prometheus_client_get()`
3. Transforms the fetched metrics into Nagios passive check format: `PGMONETA OK - pgmoneta is running|metric1=value1 metric2=value2`

## Changes
- `src/include/pgmoneta.h` — added `int nagios` field to config struct
- `src/include/configuration.h` — added `CONFIGURATION_ARGUMENT_NAGIOS` constant
- `src/libpgmoneta/configuration.c` — added parsing for `nagios` config key
- `src/include/nagios.h` — new header with `pgmoneta_nagios()` declaration
- `src/libpgmoneta/nagios.c` — new implementation fetching from Prometheus bridge and outputting Nagios format
- `src/main.c` — added `accept_nagios_cb`, `start_nagios()`, `shutdown_nagios()`, socket binding and cleanup

## Goal
Metric definitions remain in one place (Prometheus) — Nagios simply consumes from that endpoint, avoiding duplicate metric definitions.

Tested by building successfully with no errors or warnings.