### PR TITLE
[#1213]feat: parallel Azure blob upload using worker pool

### DIFF
--- a/benchmarks/cases/backup_azure.c
+++ b/benchmarks/cases/backup_azure.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * A full backup to Azure Blob Storage (emulated by Azurite).
+ *
+ * The measured phase is remote_azure: the time the storage engine spends
+ * transferring the backup. The other phases (basebackup, compression, hash)
+ * are shared work that this case's change does not touch, and act as a
+ * built-in control — they should read "no change" in a compare; if they
+ * don't, the run picked up noise or an unrelated regression.
+ *
+ * Azurite runs on the same host, so the absolute numbers are not production
+ * Azure figures. What they do measure faithfully is how much of the wall
+ * clock the engine spends waiting on one request at a time, which is what
+ * per-file upload parallelism removes.
+ */
+
+/* bench */
+#include <bench.h>
+
+/* test harness */
+#include <mctf_se.h>
+
+BENCH_CASE(backup_azure, MCTF_BACKEND_AZURITE)
+{
+   return mctf_se_backup("primary");
+}

--- a/src/libpgmoneta/se_azure.c
+++ b/src/libpgmoneta/se_azure.c
@@ -28,16 +28,20 @@
 
 /* pgmoneta */
 #include <pgmoneta.h>
+#include <deque.h>
+#include <files.h>
 #include <http.h>
 #include <logging.h>
+#include <manifest.h>
+#include <progress.h>
 #include <security.h>
 #include <storage.h>
 #include <utils.h>
+#include <workers.h>
 #include <workflow.h>
 
 /* system */
 #include <assert.h>
-#include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -46,9 +50,25 @@ static int azure_storage_setup(char* name, struct art*);
 static int azure_storage_execute(char* name, struct art*);
 static int azure_storage_teardown(char* name, struct art*);
 
-static int azure_upload_files(char* local_root, char* azure_root, char* relative_path);
+struct azure_transfer_task
+{
+   struct worker_common common;
+   int server;
+   bool progress_enabled;
+   char azure_root[MAX_PATH];
+   char remote_path[MAX_PATH];
+   char local_root[MAX_PATH];
+   char local_path[MAX_PATH];
+};
+
+static int azure_upload_files(char* local_root, char* azure_root, int server, int compression, int encryption);
 static int azure_send_upload_request(char* local_root, char* azure_root, char* relative_path);
 static int azure_add_request_headers(struct http_request* request, char* auth_value, char* utc_date);
+static void do_upload_file(struct worker_common* wc);
+static int azure_create_transfer_task(int server, char* azure_root, char* remote_path,
+                                      char* local_root, char* local_path,
+                                      struct workers* workers, struct azure_transfer_task** task);
+static int azure_upload_one_file(struct azure_transfer_task* task);
 
 static char* azure_get_host(void);
 static char* azure_get_basepath(int server, char* identifier);
@@ -143,7 +163,7 @@ azure_storage_execute(char* name __attribute__((unused)), struct art* nodes)
       goto error;
    }
 
-   if (azure_upload_files(local_root, azure_root, ""))
+   if (azure_upload_files(local_root, azure_root, server, temp_backup->compression, temp_backup->encryption))
    {
       goto error;
    }
@@ -204,113 +224,240 @@ azure_storage_teardown(char* name __attribute__((unused)), struct art* nodes)
 }
 
 static int
-azure_upload_files(char* local_root, char* azure_root, char* relative_path)
+azure_create_transfer_task(int server, char* azure_root, char* remote_path,
+                           char* local_root, char* local_path,
+                           struct workers* workers, struct azure_transfer_task** task)
 {
-   char* local_path = NULL;
-   char* relative_file;
-   char* new_file;
-   bool copied_files = false;
-   DIR* dir;
-   struct dirent* entry;
+   struct azure_transfer_task* t = NULL;
 
-   local_path = pgmoneta_append(local_path, local_root);
-   if (strlen(relative_path) > 0)
-   {
-      if (!pgmoneta_ends_with(local_root, "/"))
-      {
-         local_path = pgmoneta_append(local_path, "/");
-      }
-      local_path = pgmoneta_append(local_path, relative_path);
-   }
+   *task = NULL;
 
-   if (!(dir = opendir(local_path)))
+   if (azure_root == NULL || remote_path == NULL || local_path == NULL)
    {
       goto error;
    }
 
-   while ((entry = readdir(dir)) != NULL)
+   if (strlen(azure_root) >= MAX_PATH || strlen(remote_path) >= MAX_PATH || strlen(local_path) >= MAX_PATH)
    {
-      if (entry->d_type == DT_DIR)
+      pgmoneta_log_error("Azure transfer path too long");
+      goto error;
+   }
+
+   if (local_root != NULL && strlen(local_root) >= MAX_PATH)
+   {
+      pgmoneta_log_error("Azure local root path too long");
+      goto error;
+   }
+
+   t = (struct azure_transfer_task*)malloc(sizeof(struct azure_transfer_task));
+   if (t == NULL)
+   {
+      goto error;
+   }
+
+   memset(t, 0, sizeof(struct azure_transfer_task));
+   pgmoneta_snprintf(t->azure_root, sizeof(t->azure_root), "%s", azure_root);
+   pgmoneta_snprintf(t->remote_path, sizeof(t->remote_path), "%s", remote_path);
+   pgmoneta_snprintf(t->local_path, sizeof(t->local_path), "%s", local_path);
+   if (local_root != NULL)
+   {
+      pgmoneta_snprintf(t->local_root, sizeof(t->local_root), "%s", local_root);
+   }
+
+   t->common.workers = workers;
+   t->server = server;
+   t->progress_enabled = (server >= 0 && pgmoneta_is_progress_enabled(server));
+
+   *task = t;
+
+   return 0;
+
+error:
+   free(t);
+   return 1;
+}
+
+static int
+azure_upload_one_file(struct azure_transfer_task* task)
+{
+   if (azure_send_upload_request(task->local_root, task->azure_root, task->remote_path))
+   {
+      pgmoneta_log_error("Azure upload: failed %s", task->remote_path);
+      return 1;
+   }
+
+   if (task->progress_enabled)
+   {
+      pgmoneta_progress_increment(task->server, 1);
+   }
+
+   return 0;
+}
+
+static void
+do_upload_file(struct worker_common* wc)
+{
+   struct azure_transfer_task* task = (struct azure_transfer_task*)wc;
+
+   if (azure_upload_one_file(task))
+   {
+      pgmoneta_record_failure(task->common.workers != NULL ? task->common.workers->outcome : NULL,
+                              "Azure upload failed: %s", task->remote_path);
+   }
+
+   free(task);
+}
+
+static int azure_upload_metadata_files(char* local_root, char* azure_root);
+
+static int
+azure_upload_metadata_files(char* local_root, char* azure_root)
+{
+   if (azure_send_upload_request(local_root, azure_root, "backup.manifest"))
+   {
+      pgmoneta_log_error("Azure upload: failed to upload backup.manifest");
+      return 1;
+   }
+   if (azure_send_upload_request(local_root, azure_root, "backup.sha512"))
+   {
+      pgmoneta_log_error("Azure upload: failed to upload backup.sha512");
+      return 1;
+   }
+   if (azure_send_upload_request(local_root, azure_root, "backup.info"))
+   {
+      pgmoneta_log_error("Azure upload: failed to upload backup.info");
+      return 1;
+   }
+
+   return 0;
+}
+
+static int
+azure_upload_files(char* local_root, char* azure_root, int server, int compression, int encryption)
+{
+   int number_of_workers = 0;
+   char* manifest_path = NULL;
+   char* file_path = NULL;
+   char* relative_file = NULL;
+   char* suffix = NULL;
+   struct deque* paths = NULL;
+   struct deque_iterator* iter = NULL;
+   struct workers* workers = NULL;
+   struct azure_transfer_task* task = NULL;
+
+   manifest_path = pgmoneta_append(manifest_path, local_root);
+   manifest_path = pgmoneta_append(manifest_path, "backup.manifest");
+
+   if (pgmoneta_extraction_get_suffix(compression, encryption, &suffix))
+   {
+      pgmoneta_log_error("Azure upload: failed to determine file suffix");
+      goto error;
+   }
+
+   number_of_workers = pgmoneta_get_number_of_workers(server);
+   if (number_of_workers > 0)
+   {
+      pgmoneta_workers_initialize(number_of_workers, &workers);
+   }
+
+   if (pgmoneta_manifest_get_paths(manifest_path, &paths))
+   {
+      pgmoneta_log_error("Azure upload: failed to read manifest %s", manifest_path);
+      goto error;
+   }
+
+   pgmoneta_deque_iterator_create(paths, &iter);
+
+   if (pgmoneta_is_progress_enabled(server))
+   {
+      pgmoneta_progress_set_total(server, pgmoneta_deque_size(paths));
+   }
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      file_path = iter->tag;
+
+      relative_file = NULL;
+      relative_file = pgmoneta_append(relative_file, "data/");
+      relative_file = pgmoneta_append(relative_file, file_path);
+
+      if (suffix != NULL &&
+          !pgmoneta_ends_with(file_path, "backup_label") &&
+          !pgmoneta_ends_with(file_path, "backup_manifest"))
       {
-         char relative_dir[1024];
-
-         if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
-         {
-            continue;
-         }
-
-         if (strlen(relative_path) > 0)
-         {
-            pgmoneta_snprintf(relative_dir, sizeof(relative_dir), "%s/%s", relative_path, entry->d_name);
-         }
-         else
-         {
-            pgmoneta_snprintf(relative_dir, sizeof(relative_dir), "%s", entry->d_name);
-         }
-
-         azure_upload_files(local_root, azure_root, relative_dir);
+         relative_file = pgmoneta_append(relative_file, suffix);
       }
-      else
+
+      if (azure_create_transfer_task(server, azure_root, relative_file, local_root, relative_file,
+                                     workers, &task))
       {
-         copied_files = true;
+         pgmoneta_log_error("Azure upload: failed to create transfer task");
+         free(relative_file);
+         goto error;
+      }
 
-         relative_file = NULL;
-
-         if (strlen(relative_path) > 0)
+      if (workers != NULL && pgmoneta_workers_outcome_ok(workers))
+      {
+         if (pgmoneta_workers_add(workers, do_upload_file, (struct worker_common*)task))
          {
-            relative_file = pgmoneta_append(relative_file, relative_path);
-            relative_file = pgmoneta_append(relative_file, "/");
-         }
-         relative_file = pgmoneta_append(relative_file, entry->d_name);
-
-         if (azure_send_upload_request(local_root, azure_root, relative_file))
-         {
+            free(task);
+            task = NULL;
+            pgmoneta_log_error("Azure upload: failed to queue worker task");
             free(relative_file);
             goto error;
          }
-
-         free(relative_file);
+         task = NULL;
       }
-   }
+      else
+      {
+         if (azure_upload_one_file(task))
+         {
+            free(task);
+            task = NULL;
+            free(relative_file);
+            goto error;
+         }
+         free(task);
+         task = NULL;
+      }
 
-   if (!copied_files)
-   {
-      relative_file = NULL;
-
-      relative_file = pgmoneta_append(relative_file, relative_path);
-      relative_file = pgmoneta_append(relative_file, "/.pgmoneta");
-
-      new_file = NULL;
-
-      new_file = pgmoneta_append(new_file, local_root);
-      new_file = pgmoneta_append(new_file, relative_file);
-
-      FILE* file = fopen(new_file, "w");
-
-      pgmoneta_permission(new_file, 6, 4, 4);
-
-      azure_send_upload_request(local_root, azure_root, relative_file);
-
-      fflush(file);
-      fclose(file);
-
-      remove(new_file);
-
-      free(new_file);
       free(relative_file);
+      relative_file = NULL;
    }
 
-   closedir(dir);
+   pgmoneta_workers_wait(workers);
+   if (workers != NULL && !pgmoneta_workers_outcome_ok(workers))
+   {
+      pgmoneta_workers_log_failures(workers);
+      goto error;
+   }
+   pgmoneta_workers_destroy(workers);
 
-   free(local_path);
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(paths);
+   iter = NULL;
+   paths = NULL;
+
+   /* upload metadata files last (commit marker) */
+   if (azure_upload_metadata_files(local_root, azure_root))
+   {
+      goto error;
+   }
+
+   free(manifest_path);
+   free(suffix);
 
    return 0;
 
 error:
 
-   closedir(dir);
-
-   free(local_path);
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(paths);
+   pgmoneta_workers_wait(workers);
+   pgmoneta_workers_destroy(workers);
+   free(manifest_path);
+   free(suffix);
+   free(task);
 
    return 1;
 }
@@ -682,7 +829,7 @@ azure_upload(int server, char* label, int compression __attribute__((unused)), i
    local_root = pgmoneta_get_server_backup_identifier(server, label);
    azure_root = azure_get_basepath(server, label);
 
-   rc = azure_upload_files(local_root, azure_root, "");
+   rc = azure_upload_files(local_root, azure_root, server, compression, encryption);
 
    free(local_root);
    free(azure_root);

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -4406,13 +4406,14 @@ get_server_basepath(int server)
 int
 pgmoneta_get_timestamp_ISO8601_format(char* short_date, char* long_date)
 {
+   struct tm tm_buffer;
    time_t now = time(&now);
    if (now == -1)
    {
       return 1;
    }
 
-   struct tm* ptm = gmtime(&now);
+   struct tm* ptm = gmtime_r(&now, &tm_buffer);
    if (ptm == NULL)
    {
       return 1;
@@ -4434,13 +4435,14 @@ pgmoneta_get_timestamp_ISO8601_format(char* short_date, char* long_date)
 int
 pgmoneta_get_timestamp_UTC_format(char* utc_date)
 {
+   struct tm tm_buffer;
    time_t now = time(&now);
    if (now == -1)
    {
       return 1;
    }
 
-   struct tm* ptm = gmtime(&now);
+   struct tm* ptm = gmtime_r(&now, &tm_buffer);
    if (ptm == NULL)
    {
       return 1;

--- a/src/libpgmoneta/workflow.c
+++ b/src/libpgmoneta/workflow.c
@@ -586,6 +586,9 @@ wf_backup(void)
       current = current->next;
    }
 
+   current->next = pgmoneta_create_sha512();
+   current = current->next;
+
    if ((config->storage_engine & STORAGE_ENGINE_SSH) ||
        (config->storage_engine & STORAGE_ENGINE_S3) ||
        (config->storage_engine & STORAGE_ENGINE_AZURE))
@@ -593,9 +596,6 @@ wf_backup(void)
       current->next = pgmoneta_storage_create_remote();
       current = current->next;
    }
-
-   current->next = pgmoneta_create_sha512();
-   current = current->next;
 
 #ifdef DEBUG
    current = head;
@@ -780,6 +780,9 @@ wf_post_rollup(struct backup* backup)
       current = current->next;
    }
 
+   current->next = pgmoneta_create_sha512();
+   current = current->next;
+
    if ((config->storage_engine & STORAGE_ENGINE_SSH) ||
        (config->storage_engine & STORAGE_ENGINE_S3) ||
        (config->storage_engine & STORAGE_ENGINE_AZURE))
@@ -787,9 +790,6 @@ wf_post_rollup(struct backup* backup)
       current->next = pgmoneta_storage_create_remote();
       current = current->next;
    }
-
-   current->next = pgmoneta_create_sha512();
-   current = current->next;
 
 #ifdef DEBUG
    current = head;
@@ -867,6 +867,9 @@ wf_incremental_backup(void)
       current = current->next;
    }
 
+   current->next = pgmoneta_create_sha512();
+   current = current->next;
+
    if ((config->storage_engine & STORAGE_ENGINE_SSH) ||
        (config->storage_engine & STORAGE_ENGINE_S3) ||
        (config->storage_engine & STORAGE_ENGINE_AZURE))
@@ -874,9 +877,6 @@ wf_incremental_backup(void)
       current->next = pgmoneta_storage_create_remote();
       current = current->next;
    }
-
-   current->next = pgmoneta_create_sha512();
-   current = current->next;
 
 #ifdef DEBUG
    current = head;

--- a/test/include/mctf_se.h
+++ b/test/include/mctf_se.h
@@ -231,6 +231,28 @@ mctf_se_context_for(int backend);
 int
 mctf_se_azure_blob_count(void);
 
+/**
+ * Count the blobs in the active Azurite container whose name starts with
+ * @p prefix. Scoping by prefix keeps a count meaningful when the container
+ * holds more than one backup.
+ *
+ * @param prefix The blob-name prefix, e.g. "pgmoneta/primary/backup/<label>/"
+ * @return Number of matching blobs (>= 0), or -1 on error / no active backend
+ */
+int
+mctf_se_azure_blob_count_prefix(const char* prefix);
+
+/**
+ * Whether a blob with exactly this name exists in the active Azurite
+ * container.
+ *
+ * @param name The blob name, relative to the container, e.g.
+ *             "primary/<label>/backup.info"
+ * @return true when the blob exists, otherwise false
+ */
+bool
+mctf_se_azure_blob_exists(const char* name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/libpgmonetatest/mctf_se.c
+++ b/test/libpgmonetatest/mctf_se.c
@@ -40,6 +40,7 @@
 #include <utils.h>
 
 /* system */
+#include <ctype.h>
 #include <signal.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -539,8 +540,43 @@ mctf_se_context_for(int backend)
    return NULL;
 }
 
-int
-mctf_se_azure_blob_count(void)
+/*
+ * Percent-encode a value for use in a query string. A blob prefix contains
+ * '/' and may contain other reserved characters, and is signed decoded but
+ * sent encoded.
+ */
+static void
+azure_urlencode(const char* in, char* out, size_t size)
+{
+   static const char* hex = "0123456789ABCDEF";
+   size_t o = 0;
+
+   for (size_t i = 0; in[i] != '\0' && o + 4 < size; i++)
+   {
+      unsigned char c = (unsigned char)in[i];
+
+      if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+      {
+         out[o++] = (char)c;
+      }
+      else
+      {
+         out[o++] = '%';
+         out[o++] = hex[c >> 4];
+         out[o++] = hex[c & 0x0F];
+      }
+   }
+
+   out[o] = '\0';
+}
+
+/*
+ * Fetch one page of list-blobs XML, restricted to @p prefix ("" for the whole
+ * container). At most 5000 blobs come back; see azure_list_blobs_xml for why
+ * the harness does not page past that.
+ */
+static int
+azure_list_blobs_page(const char* prefix, char** xml)
 {
    const struct mctf_se* ctx = mctf_se_context_for(MCTF_BACKEND_AZURITE);
    char utc_date[UTC_TIME_LENGTH];
@@ -557,8 +593,9 @@ mctf_se_azure_blob_count(void)
    struct http_response* response = NULL;
    char request_path[512];
    char* body = NULL;
-   char* p = NULL;
-   int count = -1;
+   int rc = 1;
+
+   *xml = NULL;
 
    if (ctx == NULL || ctx->driver == NULL)
    {
@@ -576,6 +613,8 @@ mctf_se_azure_blob_count(void)
     * Content-Length is empty (not "0") for GET requests.
     * Canonical resource uses the account name twice for path-style URLs:
     *   /{account}/{account}/{container}\ncomp:list\nrestype:container
+    * Query parameters are signed in alphabetical order, so marker sits
+    * between comp and restype, and is signed decoded but sent encoded.
     */
    string_to_sign = pgmoneta_append(string_to_sign, "GET\n\n\n\n\n\n\n\n\n\n\n\n");
    string_to_sign = pgmoneta_append(string_to_sign, "x-ms-date:");
@@ -586,7 +625,13 @@ mctf_se_azure_blob_count(void)
    string_to_sign = pgmoneta_append(string_to_sign, ctx->access_key);
    string_to_sign = pgmoneta_append(string_to_sign, "/");
    string_to_sign = pgmoneta_append(string_to_sign, ctx->bucket);
-   string_to_sign = pgmoneta_append(string_to_sign, "\ncomp:list\nrestype:container");
+   string_to_sign = pgmoneta_append(string_to_sign, "\ncomp:list");
+   if (prefix != NULL && prefix[0] != '\0')
+   {
+      string_to_sign = pgmoneta_append(string_to_sign, "\nprefix:");
+      string_to_sign = pgmoneta_append(string_to_sign, (char*)prefix);
+   }
+   string_to_sign = pgmoneta_append(string_to_sign, "\nrestype:container");
 
    if (pgmoneta_base64_decode((char*)ctx->secret_key, strlen(ctx->secret_key), (void**)&signing_key, &signing_key_length))
    {
@@ -619,6 +664,16 @@ mctf_se_azure_blob_count(void)
                      "/%s/%s?restype=container&comp=list",
                      ctx->access_key, ctx->bucket);
 
+   if (prefix != NULL && prefix[0] != '\0')
+   {
+      char encoded[1024];
+      char tail[1100];
+
+      azure_urlencode(prefix, encoded, sizeof(encoded));
+      pgmoneta_snprintf(tail, sizeof(tail), "&prefix=%s", encoded);
+      strncat(request_path, tail, sizeof(request_path) - strlen(request_path) - 1);
+   }
+
    if (pgmoneta_http_request_create(PGMONETA_HTTP_GET, request_path, &request))
    {
       goto done;
@@ -638,7 +693,6 @@ mctf_se_azure_blob_count(void)
       goto done;
    }
 
-   /* Count <Blob> tags in the XML response to determine how many blobs exist. */
    body = malloc(response->payload.data_size + 1);
    if (body == NULL)
    {
@@ -647,13 +701,9 @@ mctf_se_azure_blob_count(void)
    memcpy(body, response->payload.data, response->payload.data_size);
    body[response->payload.data_size] = '\0';
 
-   count = 0;
-   p = body;
-   while ((p = strstr(p, "<Blob>")) != NULL)
-   {
-      count++;
-      p += 6;
-   }
+   *xml = body;
+   body = NULL;
+   rc = 0;
 
 done:
    free(body);
@@ -666,5 +716,111 @@ done:
    pgmoneta_http_response_destroy(response);
    pgmoneta_http_destroy(connection);
 
+   return rc;
+}
+
+/*
+ * Fetch the listing for @p prefix.
+ *
+ * This deliberately reads a single page and does not follow NextMarker.
+ * Every question the harness asks is about one backup, and a prefix of
+ * "<base>/<server>/backup/<label>/" selects roughly a thousand blobs — well
+ * inside the 5000 a page holds — so paging would buy nothing. It would also
+ * cost something real: Azurite issues a fresh marker on each request, so a
+ * continuation loop cannot recognise that it is being handed the same page
+ * again and grows without bound.
+ *
+ * The unscoped listing used by mctf_se_azure_blob_count is therefore capped
+ * at 5000. That is fine for "is anything there at all", which is all it is
+ * asked; a caller that needs an exact number must pass a prefix.
+ */
+static int
+azure_list_blobs_xml(const char* prefix, char** xml)
+{
+   return azure_list_blobs_page(prefix, xml);
+}
+
+int
+mctf_se_azure_blob_count(void)
+{
+   char* xml = NULL;
+   char* p = NULL;
+   int count = -1;
+
+   if (azure_list_blobs_xml("", &xml))
+   {
+      goto done;
+   }
+
+   /* Count <Blob> tags in the XML response to determine how many blobs exist. */
+   count = 0;
+   p = xml;
+   while ((p = strstr(p, "<Blob>")) != NULL)
+   {
+      count++;
+      p += 6;
+   }
+
+done:
+   free(xml);
+
    return count;
+}
+
+int
+mctf_se_azure_blob_count_prefix(const char* prefix)
+{
+   char* xml = NULL;
+   char* p = NULL;
+   int count = -1;
+
+   /* The server does the filtering, so the response holds only the wanted
+    * blobs and stays within one page for a single backup.
+    */
+   if (prefix == NULL || azure_list_blobs_xml(prefix, &xml))
+   {
+      goto done;
+   }
+
+   count = 0;
+   p = xml;
+   while ((p = strstr(p, "<Blob>")) != NULL)
+   {
+      count++;
+      p += 6;
+   }
+
+done:
+   free(xml);
+
+   return count;
+}
+
+bool
+mctf_se_azure_blob_exists(const char* name)
+{
+   char* xml = NULL;
+   char* needle = NULL;
+   bool found = false;
+
+   /* Listing with the full name as the prefix returns at most this one blob. */
+   if (name == NULL || azure_list_blobs_xml(name, &xml))
+   {
+      goto done;
+   }
+
+   /* Match the element rather than a bare substring, so that a blob named
+    * "x/backup.info" does not answer for "backup.info".
+    */
+   needle = pgmoneta_append(needle, "<Name>");
+   needle = pgmoneta_append(needle, (char*)name);
+   needle = pgmoneta_append(needle, "</Name>");
+
+   found = strstr(xml, needle) != NULL;
+
+done:
+   free(needle);
+   free(xml);
+
+   return found;
 }

--- a/test/testcases/test_azure.c
+++ b/test/testcases/test_azure.c
@@ -46,6 +46,8 @@
 #include <mctf_container.h>
 #include <mctf_se.h>
 #include <tscommon.h>
+#include <deque.h>
+#include <manifest.h>
 #include <utils.h>
 
 #include <stdlib.h>
@@ -185,6 +187,95 @@ MCTF_INTEGRATION_TEST(test_azure_second_backup_succeeds)
       mctf_sh(NULL, "grep -q 'STATUS=1' %s/backup/primary/backup/%s/backup.info",
               mctf_se_run_dir(), label2) == 0,
       cleanup, "second backup.info does not contain STATUS=1");
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/*
+ * The upload is driven by backup.manifest and runs one file per worker task,
+ * so the blobs for a label must be exactly the manifest entries plus the three
+ * metadata files. A count is what catches a dropped file: a worker whose
+ * failure is swallowed, or a task freed before its request is sent, still
+ * leaves a backup that reports STATUS=1 and a container that is not empty.
+ */
+static int
+manifest_entry_count(const char* label)
+{
+   char manifest_path[MAX_PATH];
+   struct deque* paths = NULL;
+   int count = -1;
+
+   snprintf(manifest_path, sizeof(manifest_path), "%s/backup/primary/backup/%s/backup.manifest",
+            mctf_se_run_dir(), label);
+
+   if (pgmoneta_manifest_get_paths(manifest_path, &paths))
+   {
+      return -1;
+   }
+
+   count = (int)pgmoneta_deque_size(paths);
+
+   pgmoneta_deque_destroy(paths);
+
+   return count;
+}
+
+MCTF_INTEGRATION_TEST(test_azure_uploads_every_manifest_file)
+{
+   char prefix[MAX_PATH];
+   int entries;
+   int blobs;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+   MCTF_ASSERT(shared_label[0] != '\0', cleanup, "no backup label available");
+
+   entries = manifest_entry_count(shared_label);
+   MCTF_ASSERT(entries > 0, cleanup, "could not read backup.manifest");
+
+   snprintf(prefix, sizeof(prefix), "pgmoneta/primary/backup/%s/", shared_label);
+   blobs = mctf_se_azure_blob_count_prefix(prefix);
+
+   /* backup.manifest, backup.sha512 and backup.info are uploaded after the
+    * worker pool drains, and are not themselves manifest entries.
+    */
+   MCTF_ASSERT(blobs == entries + 3, cleanup,
+               "Azurite holds %d blobs under %s (%d in the container overall) but the "
+               "manifest has %d entries (expected %d) — the parallel upload dropped "
+               "or duplicated files",
+               blobs, prefix, mctf_se_azure_blob_count_prefix(""), entries, entries + 3);
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/*
+ * The three metadata files are the commit marker: they are uploaded only once
+ * every data blob has landed, so a reader that sees backup.info can rely on
+ * the rest being there. This pins that ordering contract.
+ */
+MCTF_INTEGRATION_TEST(test_azure_uploads_metadata_commit_markers)
+{
+   const char* metadata[] = {"backup.manifest", "backup.sha512", "backup.info"};
+   char name[MAX_PATH];
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+   MCTF_ASSERT(shared_label[0] != '\0', cleanup, "no backup label available");
+
+   for (int i = 0; i < 3; i++)
+   {
+      snprintf(name, sizeof(name), "pgmoneta/primary/backup/%s/%s", shared_label, metadata[i]);
+      MCTF_ASSERT(mctf_se_azure_blob_exists(name), cleanup,
+                  "%s was not uploaded to Azure", metadata[i]);
+   }
 
 cleanup:
    MCTF_FINISH();


### PR DESCRIPTION
- closes #1213 

benchmark results:
```
case         : backup_azure
iterations   : 5 (median)
build        : Release
machine      : 8 cores, Linux
baseline     : bench-base @ d2e85f2
candidate    : bench-cand @ 334c261

phase                     baseline     candidate  change
--------------------  ------------  ------------  ------------
total                      12690ms        8487ms  1.50x faster
basebackup                  3274ms        3383ms  no change
manifest                      29ms          32ms  no change
hash                          41ms          40ms  no change
linking                       21ms          19ms  no change

phase (emulated)          baseline     candidate  change
--------------------  ------------  ------------  ------------
remote_azure                8514ms        4889ms  1.74x faster

Emulated phases upload to a local container (Azurite, Garage, SFTP),
not a real object store. They show the direction of a change, not a
figure you can quote for production.

Differences below 10% are reported as no change.
```

what changes? 
- Replaced Azure’s serial directory walk with manifest-based uploads and a worker pool, matching S3’s data-first, metadata-last model.
- Moved `SHA512` generation before remote uploads so `backup.sha512` is available before cloud uploads begin.
- Made timestamp formatting thread-safe with `gmtime_r` for parallel Azure and S3 uploads.