### PR TITLE
[#1241] Fix user index lookup and guard the not-found case

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Harshit Shaw <shawharshit116@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 Mostafa Mahmoud <mm1471800@gmail.com>
+R Sai Pranav <rajasaipranav0@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -64,6 +64,7 @@ Harshit Shaw <shawharshit116@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 Mostafa Mahmoud <mm1471800@gmail.com>
+R Sai Pranav <rajasaipranav0@gmail.com>
 ```
 
 ## Committers

--- a/src/libpgmoneta/wf_backup.c
+++ b/src/libpgmoneta/wf_backup.c
@@ -162,6 +162,13 @@ basebackup_execute(char* name __attribute__((unused)), struct art* nodes)
          usr = i;
       }
    }
+
+   if (usr == -1)
+   {
+      pgmoneta_log_error("User not found for server: %d", server);
+      goto error;
+   }
+
    // establish a connection, with replication flag set
    if (pgmoneta_server_authenticate(server, "postgres", config->common.users[usr].username, config->common.users[usr].password, false, &ssl, &socket) != AUTH_SUCCESS)
    {

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -264,6 +264,13 @@ incr_backup_execute_14_to_16(char* name __attribute__((unused)), struct art* nod
          usr = i;
       }
    }
+
+   if (usr == -1)
+   {
+      pgmoneta_log_error("User not found for server: %d", server);
+      goto error;
+   }
+
    // establish a connection, with replication flag set
    if (pgmoneta_server_authenticate(server, "postgres", config->common.users[usr].username, config->common.users[usr].password, false, &ssl, &socket) != AUTH_SUCCESS)
    {
@@ -743,6 +750,13 @@ incr_backup_execute_17_plus(char* name __attribute__((unused)), struct art* node
          usr = i;
       }
    }
+
+   if (usr == -1)
+   {
+      pgmoneta_log_error("User not found for server: %d", server);
+      goto error;
+   }
+
    // establish a connection, with replication flag set
    if (pgmoneta_server_authenticate(server, "postgres", config->common.users[usr].username, config->common.users[usr].password, false, &ssl, &socket) != AUTH_SUCCESS)
    {

--- a/src/main.c
+++ b/src/main.c
@@ -2713,8 +2713,14 @@ valid_cb(struct ev_loop* loop __attribute__((unused)), ev_periodic* w __attribut
             {
                if (pgmoneta_compare_string(config->common.servers[i].username, config->common.users[j].username))
                {
-                  usr = i;
+                  usr = j;
                }
+            }
+
+            if (usr == -1)
+            {
+               pgmoneta_log_error("User not found for server: %s", config->common.servers[i].name);
+               continue;
             }
 
             auth = pgmoneta_server_authenticate(i, "postgres",


### PR DESCRIPTION
Fixes #1241.

## What

**`src/main.c`** — the outer loop indexes servers (`i`), the inner loop indexes users (`j`), but the match assigned `usr = i`. `usr` is only ever used to index `config->common.users[]`, so a successful match picked another user's credentials whenever the two indices differed, and read past the end of the array when the server index exceeded `number_of_users`. Now assigns `j`.

**Four sites indexed `users[usr]` without checking for the `-1` sentinel**, which reads `users[-1]` when a server's username matches no configured user:

- `src/libpgmoneta/wf_backup.c`
- `src/libpgmoneta/wf_backup_incremental.c` (two sites)
- `src/main.c` (the same site as above)

`wal.c`, `wf_extra.c`, `extension.c` and the other `main.c` site already guard this and log before bailing out, so the added guards follow that convention — `pgmoneta_log_error` then `goto error`, except in `main.c` where the lookup sits inside the per-server loop and `continue` is the equivalent.

`wf_extra.c` and `wf_backup.c` are near-identical around the lookup, same comment and same `pgmoneta_server_authenticate` call, with only `wf_extra.c` carrying the guard — which is what suggested these were omissions rather than an invariant.

## Verification

- Builds clean.
- `clang-format` reports no changes for the three touched files.
- `cppcheck --enable=warning -I src/include src/` previously reported four `negativeIndex` errors (`Array 'config->common.users[64]' accessed at index -1`); all four are gone, and no new findings are introduced.

I have not driven this with a live misconfigured server, so the runtime symptom is reasoned from the code path rather than observed.

## Notes

Kept to one commit per CONTRIBUTING. Happy to split the index fix from the guards if you would rather review them separately.

Unrelated, and deliberately **not** included here: `src/libpgmoneta/walfile/wal_summary.c` does not compile on macOS because `mkdtemp` is declared in `<unistd.h>` there while glibc declares it in `<stdlib.h>`, and neither header is included directly. I patched it locally to get a build. Say the word and I will open that as its own issue and PR.