### PR TITLE
[#1243] Include unistd.h in wal_summary.c for mkdtemp

### DIFF
--- a/src/libpgmoneta/walfile/wal_summary.c
+++ b/src/libpgmoneta/walfile/wal_summary.c
@@ -41,6 +41,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <libgen.h>
+#include <unistd.h>
 
 static char* summary_file_name(uint64_t s_lsn, uint64_t e_lsn);
 static int summarize_walfile(char* path, uint64_t start_lsn, uint64_t end_lsn, block_ref_table* brt);


### PR DESCRIPTION
Fixes #1243.

One line. `wal_summary.c` includes neither `<stdlib.h>` nor `<unistd.h>` directly and picks up `<stdlib.h>` transitively through `pgmoneta.h`. glibc declares `mkdtemp` there, which is why Linux CI is unaffected, but macOS declares it only in `<unistd.h>`, so the build fails:

```
wal_summary.c:205:8: error: call to undeclared function 'mkdtemp' [-Wimplicit-function-declaration]
wal_summary.c:205:33: error: comparison between pointer and integer ('int' and 'void *')
                            [-Werror,-Wpointer-integer-compare]
```

The second error follows from the first: with no declaration `mkdtemp` is assumed to return `int`, so `== NULL` compares an integer against a pointer.

Every other file in the tree that uses `mkdtemp` or `mkstemp` — `admin.c`, `walinfo.c`, `walfilter.c`, `utils.c` — already includes `<unistd.h>`; this file was the only one that did not.

## Verification

- Before: build fails on macOS at `wal_summary.c`.
- After: full build succeeds and produces all six binaries (`pgmoneta`, `pgmoneta-admin`, `pgmoneta-cli`, `pgmoneta-config`, `pgmoneta-walfilter`, `pgmoneta-walinfo`).
- `clang-format` reports no changes for the file.
- No behaviour change on Linux — the declaration is already visible there via `<stdlib.h>`.

Independent of #1242, which touches different files.