### PR TITLE
[#1245] Check realloc results before using them

### DIFF
--- a/src/libpgmoneta/csv.c
+++ b/src/libpgmoneta/csv.c
@@ -62,6 +62,7 @@ bool
 pgmoneta_csv_next_row(struct csv_reader* reader, int* num_col, char*** cols)
 {
    char** cs = NULL;
+   char** tmp = NULL;
    char* col = NULL;
    char* last_tok = NULL;
    int num = 0;
@@ -78,7 +79,12 @@ pgmoneta_csv_next_row(struct csv_reader* reader, int* num_col, char*** cols)
    col = strtok_r(reader->line, ",", &reader->saveptr);
    while (col != NULL)
    {
-      cs = realloc(cs, (num + 1) * sizeof(char*));
+      tmp = realloc(cs, (num + 1) * sizeof(char*));
+      if (tmp == NULL)
+      {
+         goto error;
+      }
+      cs = tmp;
       cs[num] = col;
       num++;
       col = strtok_r(NULL, ",", &reader->saveptr);

--- a/src/libpgmoneta/memory.c
+++ b/src/libpgmoneta/memory.c
@@ -124,6 +124,11 @@ pgmoneta_memory_dynamic_append(void* orig, size_t orig_size, void* append, size_
    {
       s = orig_size + append_size;
       d = realloc(orig, s);
+      if (d == NULL)
+      {
+         *new_size = orig_size;
+         return orig;
+      }
       memcpy(d + orig_size, append, append_size);
    }
    else

--- a/src/libpgmoneta/network.c
+++ b/src/libpgmoneta/network.c
@@ -83,6 +83,7 @@ pgmoneta_bind(char* hostname, int port, int** fds, int* length)
              (ifa->ifa_flags & IFF_UP))
          {
             int* new_fds = NULL;
+            int* tmp_fds = NULL;
             int new_length = 0;
 
             memset(addr, 0, sizeof(addr));
@@ -106,13 +107,25 @@ pgmoneta_bind(char* hostname, int port, int** fds, int* length)
 
             if (star_fds == NULL)
             {
-               star_fds = malloc(new_length * sizeof(int));
+               tmp_fds = malloc(new_length * sizeof(int));
+               if (tmp_fds == NULL)
+               {
+                  free(new_fds);
+                  continue;
+               }
+               star_fds = tmp_fds;
                memcpy(star_fds, new_fds, new_length * sizeof(int));
                star_length = new_length;
             }
             else
             {
-               star_fds = realloc(star_fds, (star_length + new_length) * sizeof(int));
+               tmp_fds = realloc(star_fds, (star_length + new_length) * sizeof(int));
+               if (tmp_fds == NULL)
+               {
+                  free(new_fds);
+                  continue;
+               }
+               star_fds = tmp_fds;
                memcpy(star_fds + star_length, new_fds, new_length * sizeof(int));
                star_length += new_length;
             }


### PR DESCRIPTION
Fixes #1245.

Three sites overwrote the only pointer to a buffer with the result of `realloc` and then dereferenced it unchecked. Since `realloc` returns NULL *without* freeing the original, each one leaked the original allocation and then wrote through NULL.

| file | before | after |
|---|---|---|
| `csv.c:81` | `cs = realloc(cs, ...)` then `cs[num] = col` | realloc into `tmp`, on NULL `goto error` — the existing label frees the still-valid `cs` |
| `network.c:115` | `star_fds = realloc(star_fds, ...)` then `memcpy` | realloc into `tmp_fds`, on NULL free `new_fds` and `continue`, matching what the loop already does on bind failure |
| `network.c:108` | `star_fds = malloc(...)` then `memcpy` | same treatment — this branch had the identical problem |
| `memory.c:126` | `d = realloc(orig, s)` then `memcpy` | on NULL, restore `*new_size = orig_size` and return `orig` unchanged |

This follows the shape already used by `pgmoneta_append` (`utils.c:1542`): realloc into a new variable, check it, and only then commit to it. 15 of the 18 realloc assignments in the tree already do this.

The `memory.c` case needed a decision about ownership, since the caller (`message.c:1200`) does `data = pgmoneta_memory_dynamic_append(data, ...)`. Returning the original pointer and the original size keeps the caller's buffer valid and drops only the append, which is the same choice `pgmoneta_append` already makes.

## Verification

- Builds clean.
- `cppcheck --enable=warning -I src/include src/` previously reported two `memleakOnRealloc` errors; both are gone and no new findings appear.
- `clang-format` reports no changes for the three files.

## Scope

Deliberately limited to the realloc-specific case. Roughly 204 of 342 allocations in the tree are followed by a NULL check, so unchecked allocation generally is a broader pattern I have not touched here — see #1245 for that reasoning.

These are OOM-only paths, so practical severity is low.