### PR TITLE
[#1247] Clear freed pointers in add_user and update_user

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -872,14 +872,20 @@ password:
    fputs(entry, users_file);
 
    free(entry);
+   entry = NULL;
    free(master_key);
+   master_key = NULL;
    free(encrypted);
+   encrypted = NULL;
    free(encoded);
+   encoded = NULL;
    if (do_free)
    {
       free(password);
+      password = NULL;
    }
    free(verify);
+   verify = NULL;
 
    fflush(users_file);
    fclose(users_file);
@@ -1237,13 +1243,18 @@ password:
    }
 
    free(master_key);
+   master_key = NULL;
    free(encrypted);
+   encrypted = NULL;
    free(encoded);
+   encoded = NULL;
    if (do_free)
    {
       free(password);
+      password = NULL;
    }
    free(verify);
+   verify = NULL;
 
    fclose(users_file);
    users_file = NULL;


### PR DESCRIPTION
Fixes #1247.

`add_user` and `update_user` free `entry`, `master_key`, `encrypted`, `encoded`, `password` and `verify` on the success path, then call `pgmoneta_management_create_outcome_success` and `create_response`, both of which `goto error`. The `error:` label frees the same pointers again.

Setting them to NULL after the free makes the second free a no-op, which is what the surrounding code already does for `users_file`.

`clang --analyze` reported `Attempt to free released memory` at `admin.c:919` and `admin.c:1287` before the change and reports neither after. Builds clean, no `clang-format` changes.
