### PR TITLE
[#1247] Clear freed pointers on the remaining error paths

### DIFF
--- a/src/libpgmoneta/extension.c
+++ b/src/libpgmoneta/extension.c
@@ -387,6 +387,7 @@ pgmoneta_extension_parse_version(char* version_str, struct version* version)
    }
 
    free(str_copy);
+   str_copy = NULL;
 
    if (version->major == -1)
    {

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -1359,6 +1359,7 @@ error:
    if (transfer_buffer != NULL)
    {
       free(transfer_buffer);
+      transfer_buffer = NULL;
    }
    if (decoded_buffer != NULL)
    {
@@ -1509,6 +1510,7 @@ pgmoneta_management_write_json(SSL* ssl, int socket, uint8_t compression, uint8_
       }
 
       free(transfer_buffer);
+      transfer_buffer = NULL;
       s = encoded;
       encoded = NULL;
    }
@@ -1531,6 +1533,7 @@ error:
    if (transfer_buffer != NULL)
    {
       free(transfer_buffer);
+      transfer_buffer = NULL;
    }
    if (compressed_buffer != NULL)
    {

--- a/src/libpgmoneta/message.c
+++ b/src/libpgmoneta/message.c
@@ -2608,6 +2608,7 @@ pgmoneta_receive_extra_files(SSL* ssl, int socket, char* username, char* source_
             free(dest_dir);
             free(dest_path);
             free(paths[j]);
+            paths[j] = NULL;
             qr = NULL;
          }
          free(paths);

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -5132,6 +5132,7 @@ pgmoneta_split(const char* string, char*** results, int* count, char delimiter)
    if (!temp)
    {
       free(temp_results);
+      temp_results = NULL;
       goto error;
    }
 

--- a/src/libpgmoneta/walfile/rm_standby.c
+++ b/src/libpgmoneta/walfile/rm_standby.c
@@ -161,7 +161,9 @@ pgmoneta_wal_standby_desc(char* buf, struct decoded_xlog_record* record)
                                           relname);
 
          free(dbname);
+         dbname = NULL;
          free(relname);
+         relname = NULL;
       }
    }
    else if (info == XLOG_RUNNING_XACTS)

--- a/src/libpgmoneta/walfile/wal_reader.c
+++ b/src/libpgmoneta/walfile/wal_reader.c
@@ -1215,8 +1215,11 @@ get_record_block_ref_info(char* buf, struct decoded_xlog_record* record, bool pr
       }
 
       free(dbname);
+      dbname = NULL;
       free(spcname);
+      spcname = NULL;
       free(relname);
+      relname = NULL;
    }
 
    return buf;

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -1474,6 +1474,7 @@ write_incremental_file(int server, SSL* ssl, int socket, char* backup_data,
       if ((size_t)binary_data_length < block_size)
       {
          free(binary_data);
+         binary_data = NULL;
          break;
       }
 
@@ -1486,6 +1487,7 @@ write_incremental_file(int server, SSL* ssl, int socket, char* backup_data,
       }
 
       free(binary_data);
+      binary_data = NULL;
    }
 
    /* Handle truncation, by padding with 0 */
@@ -1506,6 +1508,7 @@ done:
 
 error:
    free(binary_data);
+   binary_data = NULL;
    free(filepath);
    free(file_name);
    free(rel_path);
@@ -1556,6 +1559,7 @@ write_full_file(int server, SSL* ssl, int socket, char* backup_data,
       if (binary_data_length == 0)
       {
          free(binary_data);
+         binary_data = NULL;
          break;
       }
 
@@ -1568,6 +1572,7 @@ write_full_file(int server, SSL* ssl, int socket, char* backup_data,
 
       offset += binary_data_length;
       free(binary_data);
+      binary_data = NULL;
    }
 
    free(filepath);
@@ -1576,6 +1581,7 @@ write_full_file(int server, SSL* ssl, int socket, char* backup_data,
    return 0;
 error:
    free(binary_data);
+   binary_data = NULL;
    free(filepath);
    if (file != NULL)
    {

--- a/src/libpgmoneta/wf_retention.c
+++ b/src/libpgmoneta/wf_retention.c
@@ -228,7 +228,9 @@ retention_execute(char* name __attribute__((unused)), struct art* nodes)
       }
 
       free(retention_keep);
+      retention_keep = NULL;
       free(d);
+      d = NULL;
    }
 
    return 0;


### PR DESCRIPTION
Fixes #1247 (the remaining eight sites). #1248 covers `admin.c`; this covers the rest and is independent of it.

I said on #1247 that I had not read these through and would not claim them. I have now read all eight, and they are all the same shape as `add_user`: a pointer is freed on the success path or inside a loop, is never cleared, and an `error:` label or a later loop iteration frees it again.

| file | pointer | how the second free is reached |
|---|---|---|
| `extension.c` | `str_copy` | freed, then the `version->major == -1` check below it does `goto error`, and the label's `if (str_copy) free(str_copy);` guard cannot help because the pointer was not cleared |
| `wf_retention.c` | `retention_keep` | declared **outside** the per-server loop and only reassigned when a server has backups, so a server with zero backups frees the previous server's buffer again |
| `wal_reader.c` | `dbname`, `spcname`, `relname` | freed at the end of the block, error label frees all three again |
| `rm_standby.c` | `dbname`, `relname` | freed inside the lock loop, error label frees them again |
| `utils.c` | `temp_results` | freed before `goto error`; the label then **iterates and dereferences** `temp_results[i]` before freeing it again, so this one is a use-after-free as well |
| `message.c` | `paths[j]` | freed per iteration, the label frees every element of the array |
| `wf_backup_incremental.c` | `binary_data` | freed at several points that are followed by `goto error` |
| `management.c` | `transfer_buffer` | freed on three paths that lack the `transfer_buffer = NULL;` the neighbouring branches already have |

That last one is worth noting: `management.c` already clears `transfer_buffer` after four of its frees and not after the others, so the file contradicts itself.

Clearing each pointer makes the second free a no-op, which is the same fix as #1248 and matches what the surrounding code already does for file handles.

## Verification

- Full build succeeds; `clang-format` reports no changes for any of the eight files.
- `clang --analyze` reported `Attempt to free released memory` at 10 sites across the tree. After this branch, the only two remaining are `admin.c:919` and `admin.c:1287` — which are exactly what #1248 fixes on its own branch.
- Verified by reading each path, not by triggering them at runtime.

None of these require an allocation failure; they only need the error path or the relevant loop iteration to be taken.
