### PR TITLE
Add a cppcheck job to CI, gated on a baseline

### DIFF
--- a/.github/cppcheck-baseline.txt
+++ b/.github/cppcheck-baseline.txt
@@ -1,0 +1,76 @@
+# cppcheck findings known to exist on main, as 'id:file count' pairs.
+#
+# CI fails when a file gains findings of a kind it did not have, or gains more of a
+# kind it already had, so new code cannot add to this list.
+#
+# Counts rather than line numbers, so ordinary edits do not churn the file. The
+# line number is asked for and then stripped, because cppcheck collapses messages
+# that format identically - without it every file would report at most one finding
+# per kind and the check could never fail.
+#
+# When a finding is fixed, lower the count or delete the line in the same PR.
+#
+# Regenerate with:
+#   cppcheck --enable=warning --inline-suppr --quiet --template='{id}:{file}:{line}' \
+#       -I src/include src/ 2>&1 | grep -E '^[a-zA-Z]+:' | sed 's/:[0-9]*$//' \
+#       | sort | uniq -c | awk '{printf "%s %s
+#
+", $2, $1}' | sort
+IOWithoutPositioning:src/admin.c 1
+arrayIndexOutOfBoundsCond:src/libpgmoneta/utils.c 2
+ctunullpointer:src/libpgmoneta/message.c 2
+ctunullpointer:src/libpgmoneta/wf_backup_incremental.c 1
+ctunullpointer:src/libpgmoneta/workflow.c 1
+ctunullpointerOutOfMemory:src/libpgmoneta/info.c 1
+ctunullpointerOutOfMemory:src/libpgmoneta/json.c 1
+identicalInnerCondition:src/libpgmoneta/se_ssh.c 1
+identicalInnerCondition:src/libpgmoneta/wf_link.c 1
+invalidscanf:src/libpgmoneta/utils.c 1
+invalidscanf:src/libpgmoneta/wf_backup_incremental.c 2
+memleakOnRealloc:src/libpgmoneta/csv.c 1
+memleakOnRealloc:src/libpgmoneta/network.c 1
+nullPointer:src/libpgmoneta/logging.c 1
+nullPointerArithmeticOutOfMemory:src/libpgmoneta/restore.c 2
+nullPointerArithmeticOutOfMemory:src/libpgmoneta/utils.c 1
+nullPointerOutOfMemory:src/libpgmoneta/art.c 17
+nullPointerOutOfMemory:src/libpgmoneta/brt.c 3
+nullPointerOutOfMemory:src/libpgmoneta/bzip2_compression.c 4
+nullPointerOutOfMemory:src/libpgmoneta/compression.c 4
+nullPointerOutOfMemory:src/libpgmoneta/console.c 1
+nullPointerOutOfMemory:src/libpgmoneta/deque.c 9
+nullPointerOutOfMemory:src/libpgmoneta/gzip_compression.c 4
+nullPointerOutOfMemory:src/libpgmoneta/json.c 9
+nullPointerOutOfMemory:src/libpgmoneta/keep.c 1
+nullPointerOutOfMemory:src/libpgmoneta/lz4_compression.c 6
+nullPointerOutOfMemory:src/libpgmoneta/message.c 13
+nullPointerOutOfMemory:src/libpgmoneta/network.c 1
+nullPointerOutOfMemory:src/libpgmoneta/restore.c 22
+nullPointerOutOfMemory:src/libpgmoneta/rfile.c 3
+nullPointerOutOfMemory:src/libpgmoneta/se_azure.c 5
+nullPointerOutOfMemory:src/libpgmoneta/se_s3.c 1
+nullPointerOutOfMemory:src/libpgmoneta/security.c 19
+nullPointerOutOfMemory:src/libpgmoneta/stream.c 4
+nullPointerOutOfMemory:src/libpgmoneta/utils.c 30
+nullPointerOutOfMemory:src/libpgmoneta/vfile_local.c 5
+nullPointerOutOfMemory:src/libpgmoneta/walfile/rm_standby.c 2
+nullPointerOutOfMemory:src/libpgmoneta/walfile/wal_summary.c 4
+nullPointerOutOfMemory:src/libpgmoneta/wf_bzip2.c 1
+nullPointerOutOfMemory:src/libpgmoneta/wf_sha256.c 5
+nullPointerOutOfMemory:src/libpgmoneta/wf_sha512.c 5
+nullPointerOutOfMemory:src/libpgmoneta/zstandard_compression.c 4
+nullPointerOutOfResources:src/libpgmoneta/se_ssh.c 1
+nullPointerRedundantCheck:src/cli.c 2
+nullPointerRedundantCheck:src/libpgmoneta/archive.c 2
+nullPointerRedundantCheck:src/libpgmoneta/console.c 1
+nullPointerRedundantCheck:src/libpgmoneta/info.c 7
+nullPointerRedundantCheck:src/libpgmoneta/restore.c 1
+nullPointerRedundantCheck:src/libpgmoneta/utils.c 6
+nullPointerRedundantCheck:src/libpgmoneta/walfile.c 2
+nullPointerRedundantCheck:src/libpgmoneta/wf_restore.c 1
+nullPointerRedundantCheck:src/libpgmoneta/wf_sha512.c 1
+pointerSize:src/libpgmoneta/walfile/rm_gist.c 2
+pointerSize:src/libpgmoneta/walfile/rm_xact.c 15
+pointerSize:src/libpgmoneta/wf_retention.c 1
+syntaxError:src/libpgmoneta/walfile/wal_reader.c 1
+uselessAssignmentPtrArg:src/libpgmoneta/message.c 2
+uselessAssignmentPtrArg:src/libpgmoneta/wf_backup_incremental.c 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,57 @@ on:
   workflow_dispatch:
 
 jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cppcheck
+        run: |
+          sudo apt update -y
+          sudo apt install -y cppcheck
+          cppcheck --version
+
+      - name: Run cppcheck against the known baseline
+        run: |
+          # The line number is requested and then stripped: cppcheck collapses messages
+          # that format identically, so without it a file reports at most one finding
+          # per kind and this check could never fail.
+          cppcheck --enable=warning --inline-suppr --quiet \
+                   --template='{id}:{file}:{line}' \
+                   -I src/include src/ 2>&1 \
+            | grep -E '^[a-zA-Z]+:src/' | sed 's/:[0-9]*$//' | sort | uniq -c \
+            | awk '{printf "%s %s\n", $2, $1}' | sort > /tmp/cppcheck-current.txt || true
+
+          grep -v '^#' .github/cppcheck-baseline.txt | grep -E '^[a-zA-Z]+:' | sort > /tmp/cppcheck-baseline.txt
+
+          status=0
+          while read -r key count; do
+            was=$(awk -v k="$key" '$1 == k {print $2}' /tmp/cppcheck-baseline.txt)
+            was=${was:-0}
+            if [ "$count" -gt "$was" ]; then
+              echo "$key: $was in the baseline, $count now"
+              status=1
+            fi
+          done < /tmp/cppcheck-current.txt
+
+          if [ "$status" -ne 0 ]; then
+            echo ""
+            echo "This change adds cppcheck findings. Fix them, or if they are false"
+            echo "positives add an inline suppression and say why in the pull request."
+            exit 1
+          fi
+
+          while read -r key count; do
+            now=$(awk -v k="$key" '$1 == k {print $2}' /tmp/cppcheck-current.txt)
+            now=${now:-0}
+            if [ "$now" -lt "$count" ]; then
+              echo "$key: down from $count to $now, please update .github/cppcheck-baseline.txt"
+            fi
+          done < /tmp/cppcheck-baseline.txt
+
+          echo "No new cppcheck findings."
+
   format-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Following up on the offer in #1242 / #1247. Easy to close if you would rather not have this — it is a policy decision, not a bug fix.

CI currently runs clang-format, builds and tests, but no static analysis. That is why the defects behind #1241, #1245 and #1247 sat there: nothing was looking for them.

## Why it is a baseline rather than a plain run

`cppcheck --enable=warning` on `main` reports **244 findings**. Failing on any of them would break every build immediately, and dumping 244 warnings into the log that nobody can act on is worse than not running it.

So the job compares against a checked-in baseline of what already exists and fails only when a file gains findings of a kind it did not have, or gains **more** of a kind it already had. New code cannot add to the list; the existing 244 can be worked off whenever you feel like it. When a finding is fixed the job prints which baseline line to lower, so the file does not silently drift.

The baseline records counts per `id` and `file`, not line numbers, so ordinary edits do not churn it.

## One detail worth knowing

The job asks cppcheck for `{id}:{file}:{line}` and then strips the line number. That looks redundant but is not: **cppcheck collapses messages that format identically**, so with a `{id}:{file}` template a file reports at most one finding of each kind no matter how many it actually has.

I had written it that way first and the check silently could never fail. I found it by deliberately injecting a `p = realloc(p, n)` into `csv.c` and watching the job pass. Worth mentioning because the same trap applies to anyone regenerating the baseline by hand.

## Verified

- Clean tree: passes.
- With a `memleakOnRealloc` injected into `csv.c`: fails with
  `memleakOnRealloc:src/libpgmoneta/csv.c: baseline 1 -> now 2`.
- Removing the injection: passes again.
- The workflow YAML parses.

## Caveat I cannot check from here

The baseline was generated with **cppcheck 2.21.0 on macOS**. `ubuntu-latest` ships a different version and may report a slightly different set. If the first CI run fails on version drift rather than on a real regression, tell me and I will regenerate the baseline from that run's output — or pin the cppcheck version in the job, whichever you prefer.

## Interaction with the open fix PRs

#1242, #1246, #1248 and #1249 each remove findings that are in this baseline. Whichever lands first, the others will need their baseline lines lowered — the job prints exactly which. Happy to sequence this one last to keep that simple.
