### PR TITLE
Bound the sscanf field widths when parsing backup_label

### DIFF
--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -4083,7 +4083,8 @@ pgmoneta_read_checkpoint_info(char* directory, char** chkptpos)
    {
       if (pgmoneta_starts_with(buffer, "CHECKPOINT LOCATION"))
       {
-         numfields = sscanf(buffer, "CHECKPOINT LOCATION: %s\n", chkpt);
+         /* chkpt holds MISC_LENGTH bytes */
+         numfields = sscanf(buffer, "CHECKPOINT LOCATION: %127s\n", chkpt);
          if (numfields != 1)
          {
             pgmoneta_log_error("Error parsing checkpoint wal location");

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -1188,7 +1188,8 @@ add_incremental_label_fields(char* label_file_path, char* prev_data)
          char buf[MAX_PATH];
 
          memset(buf, 0, sizeof(buf));
-         if (sscanf(read_buffer, "START WAL LOCATION: %s\n", buf) != 1)
+         /* buf holds MAX_PATH bytes */
+         if (sscanf(read_buffer, "START WAL LOCATION: %1023s\n", buf) != 1)
          {
             pgmoneta_log_error("Error parsing start wal location");
             goto error;
@@ -1211,7 +1212,8 @@ add_incremental_label_fields(char* label_file_path, char* prev_data)
          char buf[MAX_PATH];
 
          memset(buf, 0, sizeof(buf));
-         if (sscanf(read_buffer, "START TIMELINE: %s\n", buf) != 1)
+         /* buf holds MAX_PATH bytes */
+         if (sscanf(read_buffer, "START TIMELINE: %1023s\n", buf) != 1)
          {
             pgmoneta_log_error("Error parsing start timeline");
             goto error;


### PR DESCRIPTION
Continuing the sweep, per @jesperpedersen on #1242 — *"We should fix all warnings/errors found by clang or cppcheck, so go ahead with the PRs for all projects."*

Three `sscanf` calls read `%s` into a fixed-size destination with no field width, so a `backup_label` line longer than the destination overflows it:

| site | destination | width added |
|---|---|---|
| `wf_backup_incremental.c` — `START WAL LOCATION` | `char buf[MAX_PATH]` | `%1023s` |
| `wf_backup_incremental.c` — `START TIMELINE` | `char buf[MAX_PATH]` | `%1023s` |
| `utils.c` — `CHECKPOINT LOCATION` | `malloc(MISC_LENGTH)` | `%127s` |

`MAX_PATH` is 1024 and `MISC_LENGTH` is 128, so the widths are one less than the buffer to leave room for the terminator. I added a short comment at each site naming the constant, since the width and the buffer size have to stay in step.

The input is the `backup_label` written into the backup directory, so this is not reachable from a network peer, but the parse is unbounded regardless of where the file came from.

## Verification

- `cppcheck --enable=warning` reported `invalidscanf` at all three sites and reports none after.
- `clang-format` reports no changes.
- Builds clean.

## Deliberately not in this PR

cppcheck also reports `invalidScanfArgType_int` at `server.c:1587`, `server.c:1589`, `wal.c:1169` and `wal.c:1173` — `%x` needs `unsigned int *` and is given `signed int *`.

`wal.c` is a straightforward type change, but `server.c` is not: it does

```c
sscanf(hex_chr_str, "%x", &hi);
sscanf(hex_chr_str, "%x", &lo);
if (hi == -1 || lo == -1)
```

`sscanf` never writes `-1`; on a failed conversion it leaves the variable untouched, so that check does not detect anything today, and making the variables `unsigned` would quietly turn it into a comparison that is always false. The right fix is to check the return value of `sscanf` instead, which is a behaviour change rather than a type change.

I would rather send that separately so it can be reviewed on its own terms. Say the word and I will.
