### PR TITLE
Validate the hex and xlogpos conversions instead of trusting sscanf

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1350,10 +1350,11 @@ pgmoneta_lsn_to_string(uint64_t lsn);
 /**
  * Generate the lsn integer given a lsn string format %X/%X
  * @param lsn string value
- * @return The lsn integer
+ * @param lsn_out [out] The lsn integer, set to 0 if lsn could not be parsed
+ * @return 0 upon success, otherwise 1
  */
-uint64_t
-pgmoneta_string_to_lsn(char* lsn);
+int
+pgmoneta_string_to_lsn(char* lsn, uint64_t* lsn_out);
 
 /**
  * Check if the path to a file is an incremental path

--- a/src/libpgmoneta/server.c
+++ b/src/libpgmoneta/server.c
@@ -486,7 +486,11 @@ pgmoneta_server_checkpoint(int srv, SSL* ssl, int socket, uint64_t* c_lsn, uint3
    chkpt_lsn = pgmoneta_query_response_get_data(response, 0);
    timeline = pgmoneta_query_response_get_data(response, 1);
 
-   *c_lsn = pgmoneta_string_to_lsn(chkpt_lsn);
+   if (pgmoneta_string_to_lsn(chkpt_lsn, c_lsn))
+   {
+      pgmoneta_log_error("Unable to parse checkpoint LSN");
+      goto error;
+   }
    *tli = atoi(timeline);
 
    pgmoneta_free_query_response(response);
@@ -1547,7 +1551,8 @@ transform_hex_bytea_to_binary(char* hex_bytea, uint8_t** out, int* len)
    size_t binary_len = 0;
    uint8_t* binary_out = NULL;
    char* hb = NULL;
-   int hi, lo;
+   unsigned int hi = 0;
+   unsigned int lo = 0;
    char hex_chr_str[2] = {0};
 
    /* check if valid hex bytea string */
@@ -1584,10 +1589,13 @@ transform_hex_bytea_to_binary(char* hex_bytea, uint8_t** out, int* len)
    for (size_t i = 0; i < binary_len; i++)
    {
       hex_chr_str[0] = hb[2 * i];
-      sscanf(hex_chr_str, "%x", &hi);
+      if (sscanf(hex_chr_str, "%x", &hi) != 1)
+      {
+         pgmoneta_log_error("invalid hex character encountered");
+         goto error;
+      }
       hex_chr_str[0] = hb[2 * i + 1];
-      sscanf(hex_chr_str, "%x", &lo);
-      if (hi == -1 || lo == -1)
+      if (sscanf(hex_chr_str, "%x", &lo) != 1)
       {
          pgmoneta_log_error("invalid hex character encountered");
          goto error;

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -4998,19 +4998,31 @@ pgmoneta_lsn_to_string(uint64_t lsn)
    return result;
 }
 
-uint64_t
-pgmoneta_string_to_lsn(char* lsn)
+int
+pgmoneta_string_to_lsn(char* lsn, uint64_t* lsn_out)
 {
    uint32_t hi = 0;
    uint32_t lo = 0;
 
-   if (lsn == NULL)
+   if (lsn_out == NULL)
    {
-      return 0;
+      return 1;
    }
 
-   sscanf(lsn, "%X/%X", &hi, &lo);
-   return ((uint64_t)hi << 32) + (uint64_t)lo;
+   *lsn_out = 0;
+
+   if (lsn == NULL)
+   {
+      return 1;
+   }
+
+   if (sscanf(lsn, "%X/%X", &hi, &lo) != 2)
+   {
+      return 1;
+   }
+
+   *lsn_out = ((uint64_t)hi << 32) + (uint64_t)lo;
+   return 0;
 }
 
 bool

--- a/src/libpgmoneta/wal.c
+++ b/src/libpgmoneta/wal.c
@@ -1158,21 +1158,17 @@ wal_xlog_offset(size_t xlogptr, int segsize)
 static int
 wal_convert_xlogpos(char* xlogpos, int segsize, uint32_t* high32, uint32_t* low32)
 {
-   char* ptr = NULL;
-   int num = 0;
-   if (xlogpos == NULL || !pgmoneta_contains(xlogpos, "/"))
+   uint64_t lsn = 0;
+
+   if (pgmoneta_string_to_lsn(xlogpos, &lsn))
    {
       pgmoneta_log_error("WAL unable to convert xlogpos");
       return 1;
    }
-   ptr = strtok(xlogpos, "/");
-   sscanf(ptr, "%x", &num);
-   *high32 = num;
 
-   ptr = strtok(NULL, "/");
-   sscanf(ptr, "%x", &num);
+   *high32 = (uint32_t)(lsn >> 32);
    // discard in-segment offset
-   *low32 = num & (~(segsize - 1));
+   *low32 = (uint32_t)lsn & ~((uint32_t)segsize - 1);
    return 0;
 }
 

--- a/src/libpgmoneta/wf_backup_incremental.c
+++ b/src/libpgmoneta/wf_backup_incremental.c
@@ -301,7 +301,11 @@ incr_backup_execute_14_to_16(char* name __attribute__((unused)), struct art* nod
    prev_backup_data = pgmoneta_get_server_backup_identifier_data(server, incremental_label);
    pgmoneta_read_checkpoint_info(prev_backup_data, &chkpt_lsn);
 
-   prev_backup_chkpt_lsn = pgmoneta_string_to_lsn(chkpt_lsn);
+   if (pgmoneta_string_to_lsn(chkpt_lsn, &prev_backup_chkpt_lsn))
+   {
+      pgmoneta_log_error("Unable to parse checkpoint LSN of the preceding backup");
+      goto error;
+   }
 
    tag = pgmoneta_append(tag, "pgmoneta_");
    tag = pgmoneta_append(tag, label);
@@ -312,7 +316,11 @@ incr_backup_execute_14_to_16(char* name __attribute__((unused)), struct art* nod
       pgmoneta_log_error("Incremental backup couldn't start");
       goto error;
    }
-   start_backup_lsn = pgmoneta_string_to_lsn(start_backup_xlog);
+   if (pgmoneta_string_to_lsn(start_backup_xlog, &start_backup_lsn))
+   {
+      pgmoneta_log_error("Unable to parse start backup LSN");
+      goto error;
+   }
 
    wal_dir = pgmoneta_get_server_wal(server);
 

--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -430,7 +430,10 @@ wal_get_known_values_for_field(struct ui_state* state, int field, const char* pa
             // Apply bound filtering for End LSN (field 2)
             if (field == 2 && field_inputs != NULL && wal_input_has_content(field_inputs[1]))
             {
-               uint64_t start_lsn_val = pgmoneta_string_to_lsn(field_inputs[1]);
+               uint64_t start_lsn_val = 0;
+
+               /* A malformed bound leaves the value at 0, which disables the filter */
+               pgmoneta_string_to_lsn(field_inputs[1], &start_lsn_val);
                if (start_lsn_val != 0 && *dynamic_array_out != NULL)
                {
                   char** results = *dynamic_array_out;
@@ -438,7 +441,9 @@ wal_get_known_values_for_field(struct ui_state* state, int field, const char* pa
 
                   for (int i = 0; results[i] != NULL; i++)
                   {
-                     uint64_t cand_lsn = pgmoneta_string_to_lsn(results[i]);
+                     uint64_t cand_lsn = 0;
+
+                     pgmoneta_string_to_lsn(results[i], &cand_lsn);
                      if (cand_lsn > start_lsn_val)
                      {
                         if (valid_count != i)
@@ -459,7 +464,10 @@ wal_get_known_values_for_field(struct ui_state* state, int field, const char* pa
             // Apply reciprocal bound filtering for Start LSN (field 1)
             if (field == 1 && field_inputs != NULL && wal_input_has_content(field_inputs[2]))
             {
-               uint64_t end_lsn_val = pgmoneta_string_to_lsn(field_inputs[2]);
+               uint64_t end_lsn_val = 0;
+
+               /* A malformed bound leaves the value at 0, which disables the filter */
+               pgmoneta_string_to_lsn(field_inputs[2], &end_lsn_val);
                if (end_lsn_val != 0 && *dynamic_array_out != NULL)
                {
                   char** results = *dynamic_array_out;
@@ -467,7 +475,9 @@ wal_get_known_values_for_field(struct ui_state* state, int field, const char* pa
 
                   for (int i = 0; results[i] != NULL; i++)
                   {
-                     uint64_t cand_lsn = pgmoneta_string_to_lsn(results[i]);
+                     uint64_t cand_lsn = 0;
+
+                     pgmoneta_string_to_lsn(results[i], &cand_lsn);
                      if (cand_lsn < end_lsn_val)
                      {
                         if (valid_count != i)
@@ -3721,14 +3731,18 @@ handle_search_input(struct ui_state* state)
 
    if (strlen(start_lsn_input) > 0)
    {
-      criteria.start_lsn = pgmoneta_string_to_lsn(start_lsn_input);
-      criteria.has_start_lsn = true;
+      if (!pgmoneta_string_to_lsn(start_lsn_input, &criteria.start_lsn))
+      {
+         criteria.has_start_lsn = true;
+      }
    }
 
    if (strlen(end_lsn_input) > 0)
    {
-      criteria.end_lsn = pgmoneta_string_to_lsn(end_lsn_input);
-      criteria.has_end_lsn = true;
+      if (!pgmoneta_string_to_lsn(end_lsn_input, &criteria.end_lsn))
+      {
+         criteria.has_end_lsn = true;
+      }
    }
 
    if (strlen(xid_input) > 0)
@@ -3874,14 +3888,18 @@ handle_filter_input(struct ui_state* state)
 
    if (strlen(start_lsn_input) > 0)
    {
-      state->filters.start_lsn = pgmoneta_string_to_lsn(start_lsn_input);
-      state->filters.has_start_lsn = true;
+      if (!pgmoneta_string_to_lsn(start_lsn_input, &state->filters.start_lsn))
+      {
+         state->filters.has_start_lsn = true;
+      }
    }
 
    if (strlen(end_lsn_input) > 0)
    {
-      state->filters.end_lsn = pgmoneta_string_to_lsn(end_lsn_input);
-      state->filters.has_end_lsn = true;
+      if (!pgmoneta_string_to_lsn(end_lsn_input, &state->filters.end_lsn))
+      {
+         state->filters.has_end_lsn = true;
+      }
    }
 
    if (strlen(xid_input) > 0)

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -833,13 +833,23 @@ MCTF_TEST(test_utils_string_extras)
    // pgmoneta_lsn_to_string / pgmoneta_string_to_lsn
 
    uint64_t lsn = 0x123456789ABCDEF0;
+   uint64_t parsed_lsn = 0;
+   char truncated_lsn[] = "ABC/";
+
    s = pgmoneta_lsn_to_string(lsn);
    MCTF_ASSERT_PTR_NONNULL(s, cleanup, "lsn_to_string failed");
-   MCTF_ASSERT_INT_EQ(pgmoneta_string_to_lsn(s), lsn, cleanup, "string_to_lsn round-trip failed");
+   MCTF_ASSERT_INT_EQ(pgmoneta_string_to_lsn(s, &parsed_lsn), 0, cleanup, "string_to_lsn failed");
+   MCTF_ASSERT_INT_EQ(parsed_lsn, lsn, cleanup, "string_to_lsn round-trip failed");
    free(s);
    s = NULL;
 
-   MCTF_ASSERT_INT_EQ(pgmoneta_string_to_lsn(NULL), 0, cleanup, "string_to_lsn NULL should return 0");
+   parsed_lsn = 1;
+   MCTF_ASSERT_INT_EQ(pgmoneta_string_to_lsn(NULL, &parsed_lsn), 1, cleanup, "string_to_lsn NULL should fail");
+   MCTF_ASSERT_INT_EQ(parsed_lsn, 0, cleanup, "string_to_lsn NULL should zero the result");
+
+   parsed_lsn = 1;
+   MCTF_ASSERT_INT_EQ(pgmoneta_string_to_lsn(truncated_lsn, &parsed_lsn), 1, cleanup, "string_to_lsn should reject a truncated lsn");
+   MCTF_ASSERT_INT_EQ(parsed_lsn, 0, cleanup, "string_to_lsn should zero the result on failure");
 
    // pgmoneta_split
 


### PR DESCRIPTION
Follow-up to #1251, which flagged these four `invalidScanfArgType_int` findings but left them out — neither is really an argument-type problem.

## `server.c` — the failure check never fired

```c
int hi, lo;
sscanf(hex_chr_str, "%x", &hi);
...
if (hi == -1 || lo == -1)
```

`sscanf` never writes `-1`; on a failed conversion it returns 0 and leaves the variable untouched. So an invalid hex character was never detected — the loop silently reused the previous iteration's value — and on the first iteration `hi` and `lo` are uninitialised, so the comparison read indeterminate memory. Now checks each return value and initialises both.

Making them `unsigned` without this would have been worse: the `== -1` test would become always-false, which reads as intentional.

## `wal.c` — `strtok` result used without a NULL check

The guard above only proves a `/` is present. An `xlogpos` of `"ABC/"` satisfies it, and then the second `strtok` returns NULL and `sscanf` dereferences it. Both pointers and both conversions are now checked, failing the way the function already fails on bad input. The offset mask is now `~((unsigned int)segsize - 1)` so the operand types match after `num` became unsigned.

## Verification

`cppcheck` reported `invalidScanfArgType_int` four times and reports none after. Builds clean, no `clang-format` changes. Verified by reading, not by driving a malformed `xlogpos` through at runtime.
