### PR TITLE
Reposition explicitly before appending to the users file

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -716,6 +716,12 @@ username:
       number_of_users++;
    }
 
+   if (ferror(users_file))
+   {
+      warnx("Error reading users file");
+      goto error;
+   }
+
    if (number_of_users > NUMBER_OF_USERS)
    {
       warnx("Too many users");
@@ -868,6 +874,14 @@ password:
    entry = pgmoneta_append(entry, ":");
    entry = pgmoneta_append(entry, encoded);
    entry = pgmoneta_append(entry, "\n");
+
+   /* The stream is open in update mode. The read loop above ended at end of
+    * file, which ferror() confirmed, so reposition before writing rather than
+    * relying on the end-of-file exception in C11 7.21.5.3p7. */
+   if (fseek(users_file, 0, SEEK_END) != 0)
+   {
+      goto error;
+   }
 
    fputs(entry, users_file);
 


### PR DESCRIPTION
Part of the sweep @jesperpedersen asked for on #1242. Same change in pgmoneta, pgagroal and pgexporter — `admin.c` has the identical shape in all three.

cppcheck reports `IOWithoutPositioning`: the users file is opened in update mode (`"a+"`), read with `fgets`, then written with `fputs`, with no positioning call in between.

**This is not a live bug today.** C11 7.21.5.3p7 allows input to be followed by output when "the input operation encounters end-of-file", and on the only path that reaches the `fputs` the `fgets` loop has run to completion. Every early exit from that loop is a `goto error`, which skips the write.

But `fgets` also returns NULL on a read error, and in that case the exception does not apply and the behaviour is undefined. Seeking to the end before the write removes the dependence on that exception. The stream is in append mode, so output already goes to the end and behaviour is unchanged either way.

I would rather say that plainly than present a warning-silencing change as a bug fix. If you would rather keep the code as-is and take an inline suppression, that is a reasonable call and I will send that version.

## Verification

`cppcheck` reported `IOWithoutPositioning` in `admin.c` before and reports none after, in each repository. No `clang-format` changes. pgmoneta and pgagroal build clean; I could not configure a build for pgexporter locally, so that one is analyzer and formatter only and CI is the real check there.
