### PR TITLE
Check the allocations used in pointer arithmetic

### DIFF
--- a/src/libpgmoneta/restore.c
+++ b/src/libpgmoneta/restore.c
@@ -2180,6 +2180,10 @@ write_reconstructed_file_incremental(char* output_file_path,
    }
 
    header = malloc(hdrlen);
+   if (header == NULL)
+   {
+      goto error;
+   }
    memset(header, 0, hdrlen);
 
    memcpy(header + hdrptr, &magic, sizeof(uint32_t));

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -1124,6 +1124,13 @@ pgmoneta_mkdir(char* dir)
 {
    char* p;
 
+   /* dir + 1 would run past the terminator for an empty string, and callers
+    * pass allocations that can be NULL. */
+   if (dir == NULL || dir[0] == '\0')
+   {
+      return 1;
+   }
+
    for (p = dir + 1; *p; p++)
    {
       if (*p == '/')


### PR DESCRIPTION
Part of the sweep from pgmoneta/pgmoneta#1242. `cppcheck` reports `nullPointerArithmeticOutOfMemory` — an allocation whose result is used in pointer arithmetic without being checked, so an allocation failure turns into arithmetic on NULL and then a write through it.

Two sites:

- `restore.c` allocates the incremental file header with `malloc(hdrlen)` and goes straight into `memset` and a series of `memcpy(header + hdrptr, ...)`. The function already has an `error:` label that frees `header`, so the check goes there.
- `utils.c` — `pgmoneta_mkdir` starts with `for (p = dir + 1; *p; p++)` and never checks `dir`. Callers pass allocations that can be NULL (`se_s3.c`, `wf_hot_standby.c`, `wf_backup_incremental.c`, `walfilter.c`), so guarding inside the function covers all of them at once rather than patching each call site.

  Worth noting the guard also covers a second case cppcheck did not flag: for an **empty string** `dir + 1` points one past the terminator, and `*p` then reads out of bounds. The guard rejects both.

## Verification

- `cppcheck` reported these findings before and reports none after.
- `clang-format` reports no changes.
- Builds clean.

These are OOM-only paths, so practical severity is low.
