### PR TITLE
Leave room for the terminator when reading a password

### DIFF
--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -853,7 +853,7 @@ pgmoneta_get_password(void)
 
    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
-   while ((c = getchar()) != '\n' && c != EOF && i < MAX_PASSWORD_LENGTH)
+   while ((c = getchar()) != '\n' && c != EOF && i < MAX_PASSWORD_LENGTH - 1)
    {
       p[i++] = c;
    }
@@ -3088,7 +3088,7 @@ pgmoneta_translate_file_size(uint64_t size)
    char* units[] = {"B", "kB", "MB", "GB", "TB", "PB"};
    int i = 0;
 
-   while (sz >= 1024 && i < 6)
+   while (sz >= 1024 && i < (int)(sizeof(units) / sizeof(units[0])) - 1)
    {
       sz /= 1024.0;
       i++;


### PR DESCRIPTION
Part of the sweep from pgmoneta/pgmoneta#1242.

`get_password` reads into a fixed stack buffer:

```c
   char p[MAX_PASSWORD_LENGTH];
   ...
   while ((c = getchar()) != '\n' && c != EOF && i < MAX_PASSWORD_LENGTH)
   {
      p[i++] = c;
   }
   p[i] = '\0';
```

The loop stops when `i` reaches `MAX_PASSWORD_LENGTH`, so a password of exactly that many characters leaves `i == MAX_PASSWORD_LENGTH` and the terminator is written to `p[MAX_PASSWORD_LENGTH]` — one byte past the end of the array. `MAX_PASSWORD_LENGTH` is 8192, so it takes a deliberately long entry to reach, but it is reachable from the interactive prompt.

Stopping one character earlier keeps the terminator inside the buffer.

The same function exists with the same bound in pgmoneta, pgagroal, pgexporter and pgvictoria, so this is going to all four.

## Also in this PR

`pgmoneta_translate_file_size` has:

```c
   char* units[] = {"B", "kB", "MB", "GB", "TB", "PB"};   /* 6 entries */
   while (sz >= 1024 && i < 6)
```

The loop lets `i` reach 6, and `units[6]` is one past the end. Bounded against the array size rather than a literal.

## Verification

- cppcheck reported `arrayIndexOutOfBoundsCond` on this line and reports none after.
- `clang-format` reports no changes.
- Builds clean.
