### PR TITLE
Remove the inner checks that cannot be false

### DIFF
--- a/src/libpgmoneta/se_ssh.c
+++ b/src/libpgmoneta/se_ssh.c
@@ -328,10 +328,7 @@ ssh_storage_backup_execute(char* name __attribute__((unused)), struct art* nodes
       {
          if (pgmoneta_is_backup_struct_valid(server, backups[j]))
          {
-            if (next_newest == -1)
-            {
-               next_newest = j;
-            }
+            next_newest = j;
          }
       }
    }

--- a/src/libpgmoneta/wf_link.c
+++ b/src/libpgmoneta/wf_link.c
@@ -142,10 +142,7 @@ link_execute(char* name __attribute__((unused)), struct art* nodes)
          if (pgmoneta_is_backup_struct_valid(server, backups[j]) &&
              backups[j]->major_version == backups[number_of_backups - 1]->major_version)
          {
-            if (next_newest == -1)
-            {
-               next_newest = j;
-            }
+            next_newest = j;
          }
       }
 


### PR DESCRIPTION
`ssh_storage_backup_execute()` and `link_execute()` both walk the backup list with `next_newest == -1` **in the for condition**:

```c
for (int j = number_of_backups - 2; j >= 0 && next_newest == -1; j--)
{
   if (pgmoneta_is_backup_struct_valid(server, backups[j]))
   {
      if (next_newest == -1)   /* always true when reached */
      {
         next_newest = j;
      }
   }
}
```

The inner test can only be reached while the loop condition still holds, so it is always true; and once it assigns, the loop condition ends the loop before the next body runs. Removing it keeps the same first-match behaviour.

cppcheck 2.21.0 reports these as `identicalInnerCondition` and reports neither after. No behaviour change, so nothing to test beyond a clean build; `clang-format` reports no changes.

Dropped the `uselessAssignmentPtrArg` half of the original PR per @jesperpedersen — `p = NULL;` after `free(p)` is a house convention here, so those three lines are restored.