### PR TITLE
[#1257] Fix infinite loop in pgmoneta_remove_prefix when the input does not start with the prefix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,3 +58,4 @@ Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 Mostafa Mahmoud <mm1471800@gmail.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
+Krishna Lokhande <krishlokhande45@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -65,6 +65,7 @@ Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 Mostafa Mahmoud <mm1471800@gmail.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
+Krishna Lokhande <krishlokhande45@gmail.com> 
 ```
 
 ## Committers

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -1696,8 +1696,8 @@ pgmoneta_remove_prefix(char* orig, char* prefix)
 {
    char* res = NULL;
    int idx = 0;
-   int len1 = strlen(orig);
-   int len2 = strlen(prefix);
+   int len1 = 0;
+   int len2 = 0;
    int len = 0;
    if (orig == NULL)
    {
@@ -1709,15 +1709,24 @@ pgmoneta_remove_prefix(char* orig, char* prefix)
       res = pgmoneta_append(res, orig);
       return res;
    }
-   while (idx < len1 && idx < len2)
+   len1 = strlen(orig);
+   len2 = strlen(prefix);
+   while (idx < len1 && idx < len2 && orig[idx] == prefix[idx])
    {
-      if (orig[idx] == prefix[idx])
-      {
-         idx++;
-      }
+      idx++;
+   }
+   if (idx < len2)
+   {
+      // does not start with the prefix
+      res = pgmoneta_append(res, orig);
+      return res;
    }
    len = len1 - idx + 1;
    res = malloc(len);
+   if (res == NULL)
+   {
+      return NULL;
+   }
    res[len - 1] = 0;
    if (len > 1)
    {

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -448,6 +448,30 @@ MCTF_TEST(test_utils_string_manipulation)
    free(res);
    res = NULL;
 
+   // test remove_prefix without a matching prefix
+
+   s = strdup("hello");
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "strdup failed");
+   res = pgmoneta_remove_prefix(s, "world");
+   MCTF_ASSERT_PTR_NONNULL(res, cleanup, "remove_prefix mismatch failed");
+   MCTF_ASSERT_STR_EQ(res, "hello", cleanup, "remove_prefix mismatch result mismatch");
+   free(s);
+   s = NULL;
+   free(res);
+   res = NULL;
+
+   // test remove_prefix with a partial prefix match
+
+   s = strdup("data/x");
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "strdup failed");
+   res = pgmoneta_remove_prefix(s, "dat0/");
+   MCTF_ASSERT_PTR_NONNULL(res, cleanup, "remove_prefix partial match failed");
+   MCTF_ASSERT_STR_EQ(res, "data/x", cleanup, "remove_prefix partial match result mismatch");
+   free(s);
+   s = NULL;
+   free(res);
+   res = NULL;
+
    // test remove_suffix
 
    s = strdup("test.txt");


### PR DESCRIPTION
## Summary

`pgmoneta_remove_prefix()` in `src/libpgmoneta/utils.c` contained an unbounded scan loop that never terminated when the input string did not start with the given prefix: the loop only advanced its index inside the equality branch, so the first mismatching character spun the loop forever (100% CPU).

Fixes #1257

## Changes

- Move the equality check into the loop condition (`while (idx < len1 && idx < len2 && orig[idx] == prefix[idx])`) so scanning stops at the first divergence point.
- If `orig` does not start with `prefix` (`idx < len2` after the loop), return a copy of `orig` unchanged, mirroring how `pgmoneta_remove_suffix()` returns the original string when `pgmoneta_ends_with()` fails.
- Compute `strlen(orig)`/`strlen(prefix)` only after the `NULL` checks (previously `strlen(NULL)` was evaluated before the guard, which is undefined behavior).
- Check the `malloc` return value in the same function, as suggested in the issue.
- Add regression tests to `test/testcases/test_utils.c`: full mismatch (`"hello""/"world"`) and partial common prefix (`"data/x"`/`"dat0/"`).

## Behavior

| Input | Before | After |
| --- | --- | --- |
| `(\"hello\", \"world\")` | hangs forever | returns copy of `orig` |
| `(\"data/x\", \"dat0/\")` | hangs forever | returns copy of `orig` |
| `(\"pre_test\", \"pre_\")` | `test` | `test` (unchanged) |
| `(\"abc\", \"\")`, `(x, NULL)` | copy of `orig` | copy of `orig` (unchanged) |

Current in-tree callers are safe by construction and keep their existing behavior:
- `src/libpgmoneta/link.c:89`
- `src/libpgmoneta/restore.c:343`

## Verification

- Standalone harness comparing old vs new implementation confirms the old loop spins on a mismatch while the new code terminates and returns the expected values for mismatch, partial-match, empty-prefix, shorter-orig, and NULL cases.
- Regression tests added next to the existing `remove_prefix` case in `MCTF_TEST(test_utils_string_manipulation)`.
- Full build not run locally due to missing build dependencies (cmake/libev); changes are limited to this function plus tests.