### PR TITLE
Check the hex dump line before measuring it

### DIFF
--- a/src/libpgmoneta/logging.c
+++ b/src/libpgmoneta/logging.c
@@ -488,6 +488,15 @@ retry:
                      }
                   }
 
+                  /* pgmoneta_append() returns its input on allocation
+                     failure, so l is still NULL if the first append failed. */
+                  if (l == NULL)
+                  {
+                     free(n);
+                     n = NULL;
+                     break;
+                  }
+
                   if (strlen(l) == LINE_LENGTH * 2)
                   {
                      full_line = true;
@@ -496,8 +505,8 @@ retry:
                   {
                      if (strlen(l) < LINE_LENGTH * 2)
                      {
-                        int chars_missing = (LINE_LENGTH * 2) - strlen(l);
-                        for (int i = 0; i < chars_missing; i++)
+                        size_t chars_missing = (LINE_LENGTH * 2) - strlen(l);
+                        for (size_t i = 0; i < chars_missing; i++)
                         {
                            l = pgmoneta_append_char(l, ' ');
                         }


### PR DESCRIPTION
`pgmoneta_append()` returns its input unchanged when the `realloc` fails, so appending to a NULL pointer leaves it NULL. In the non-ASCII branch of the hex dump, `l` starts as NULL and is only built up by `pgmoneta_append()`, then `strlen(l)` is called on it, so an allocation failure there is a NULL dereference in the logger.

The loop above always runs at least once (`remaining > 0` makes `count` at least 1), so this needs the allocation to fail, not an empty input. Same class as #1246.

Stop the dump if the line could not be built, rather than measuring it. The `n` buffer is freed on that path, and the lock is released after the loop as before.

Also changed `chars_missing` and its loop variable to `size_t`, since they are compared against and derived from `strlen()`.

## Verification

`cppcheck` reported `nullPointer` on `logging.c:491` and reports none after. Builds clean, `clang-format` reports no changes.

I used an AI assistant while preparing this. I understand the change and can explain it.
