### PR TITLE
Check the results used when reading the backup checksum file

### DIFF
--- a/src/libpgmoneta/se_ssh.c
+++ b/src/libpgmoneta/se_ssh.c
@@ -797,10 +797,6 @@ read_latest_backup_sha256(char* path)
       goto error;
    }
 
-   fclose(file);
-
-   file = fopen(path, "r");
-
    memset(&buffer[0], 0, sizeof(buffer));
 
    while ((fgets(&buffer[0], sizeof(buffer), file)) != NULL)
@@ -819,10 +815,17 @@ read_latest_backup_sha256(char* path)
 
       ptr = strtok(NULL, ":");
 
+      if (ptr == NULL)
+      {
+         free(file_path);
+         goto error;
+      }
+
       hash = (char*)malloc(strlen(ptr));
 
       if (hash == NULL)
       {
+         free(file_path);
          goto error;
       }
 


### PR DESCRIPTION
`read_latest_backup_sha256()` in `se_ssh.c` uses two results without checking them.

**The second `fopen` is unchecked.** The function opens the file, checks it, then closes and reopens it:

```c
file = fopen(path, "r");
if (file == NULL)
{
   goto error;
}

fclose(file);

file = fopen(path, "r");   /* not checked */

...
while ((fgets(&buffer[0], sizeof(buffer), file)) != NULL)
```

The close and reopen have no effect — nothing reads from the handle in between — so the checked open is thrown away and replaced by an unchecked one. If the second `fopen` fails, `fgets` gets NULL. Removing the two lines is enough; the remaining open is already checked.

**The second `strtok` is unchecked.** Each line is parsed as `path:hash`:

```c
ptr = strtok(&buffer[0], ":");
if (ptr == NULL) { goto error; }
file_path = pgmoneta_append(NULL, ptr);

ptr = strtok(NULL, ":");

hash = (char*)malloc(strlen(ptr));   /* strlen(NULL) if the line has no ':' */
```

The first result is checked, the second is not. A line in the checksum file without a `:` — a truncated or partially written manifest — makes `strtok` return NULL and `strlen` dereference it. Same shape as the unchecked `strtok` fixed in #1252.

While adding that check: `file_path` is already allocated at both `goto error` points inside the loop, so it is freed there now instead of being leaked.

## Verification

cppcheck 2.21.0 reported `nullPointerOutOfResources` at the `fgets` line and reports nothing there after the change. Verified by reading, not by driving a malformed checksum file through a live SSH backup — I have no remote server set up here, and I would rather say that than imply otherwise. `clang-format` reports no changes.
