### PR TITLE
Check the allocations that grow the YAML rule arrays

### DIFF
--- a/src/include/yaml_utils.h
+++ b/src/include/yaml_utils.h
@@ -88,8 +88,8 @@ int pgmoneta_parse_yaml_config(const char* filename, config_t* config);
  * @param current_key Pointer to the current key being processed.
  * @param config Pointer to the configuration structure to populate.
  */
-void handle_scalar_event(yaml_event_t* event, parser_state_t* state,
-                         char** current_key, config_t* config);
+int handle_scalar_event(yaml_event_t* event, parser_state_t* state,
+                        char** current_key, config_t* config);
 
 /**
  * Cleans up the configuration structure.

--- a/src/libpgmoneta/yaml_utils.c
+++ b/src/libpgmoneta/yaml_utils.c
@@ -65,6 +65,7 @@ pgmoneta_parse_yaml_config(const char* filename, config_t* config)
    parser_state_t state = STATE_START;
    char* current_key = NULL;
    int done = 0;
+   int rc = 0;
 
    while (!done)
    {
@@ -146,7 +147,11 @@ pgmoneta_parse_yaml_config(const char* filename, config_t* config)
             break;
 
          case YAML_SCALAR_EVENT:
-            handle_scalar_event(&event, &state, &current_key, config);
+            if (handle_scalar_event(&event, &state, &current_key, config))
+            {
+               rc = -1;
+               done = 1;
+            }
             break;
 
          case YAML_DOCUMENT_END_EVENT:
@@ -168,10 +173,10 @@ pgmoneta_parse_yaml_config(const char* filename, config_t* config)
    yaml_parser_delete(&parser);
    fclose(file);
 
-   return 0;
+   return rc;
 }
 
-void
+int
 handle_scalar_event(yaml_event_t* event, parser_state_t* state,
                     char** current_key, config_t* config)
 {
@@ -226,24 +231,50 @@ handle_scalar_event(yaml_event_t* event, parser_state_t* state,
 
       case STATE_OPERATIONS_SEQUENCE:
          // Add operation to operations array
-         config->operations = realloc(
-            config->operations,
-            (config->operation_count + 1) * sizeof(char*));
-         config->operations[config->operation_count] = strdup(value);
-         config->operation_count++;
+         {
+            char** tmp_operations = NULL;
+            char* operation = NULL;
+
+            tmp_operations = realloc(config->operations,
+                                     (config->operation_count + 1) * sizeof(char*));
+            if (tmp_operations == NULL)
+            {
+               return 1;
+            }
+            config->operations = tmp_operations;
+
+            operation = strdup(value);
+            if (operation == NULL)
+            {
+               return 1;
+            }
+            config->operations[config->operation_count] = operation;
+            config->operation_count++;
+         }
          break;
 
       case STATE_XIDS_SEQUENCE:
          // Add XID to the XIDs array
-         config->xids = realloc(config->xids,
-                                (config->xid_count + 1) * sizeof(int));
-         config->xids[config->xid_count] = atoi(value);
-         config->xid_count++;
+         {
+            int* tmp_xids = NULL;
+
+            tmp_xids = realloc(config->xids, (config->xid_count + 1) * sizeof(int));
+            if (tmp_xids == NULL)
+            {
+               return 1;
+            }
+            config->xids = tmp_xids;
+
+            config->xids[config->xid_count] = atoi(value);
+            config->xid_count++;
+         }
          break;
 
       default:
          break;
    }
+
+   return 0;
 }
 
 void


### PR DESCRIPTION
`handle_scalar_event()` grows two arrays without checking the results:

```c
config->operations = realloc(config->operations, (config->operation_count + 1) * sizeof(char*));
config->operations[config->operation_count] = strdup(value);
config->operation_count++;
```

On failure `realloc` returns NULL while leaving the old array allocated, so overwriting `config->operations` leaks everything parsed so far and the next line writes through the NULL. The `xids` case a few lines below has the same shape, and the `strdup` result was unchecked too.

Same class as #1266 and the merged #1246.

## How the failure is reported

`handle_scalar_event()` was `void`, but the parse loop it runs in belongs to `pgmoneta_parse_yaml_config()`, which already returns `int`, and its caller already tests that — `walfilter.c:576` does `if (pgmoneta_parse_yaml_config(yaml_file, &yaml_config))`. So the channel existed; this uses it. The handler now returns non-zero on an allocation failure, the loop stops and the existing cleanup at the end of the function runs before returning -1.

The declaration in `yaml_utils.h` changes from `void` to `int` accordingly. `handle_scalar_event()` has no callers outside `yaml_utils.c`, so nothing else is affected, and ignoring an `int` return is source-compatible in any case.

## Verification

`clang -fsyntax-only -I src/include` is clean and `clang-format` reports no changes. I could not drive a real allocation failure through a walfilter run, so this is verified by reading plus the compiler rather than at runtime.
