### PR TITLE
Bound the directory listing in the walinfo browser

### DIFF
--- a/src/walinfo.c
+++ b/src/walinfo.c
@@ -3983,7 +3983,8 @@ show_wal_file_selector(struct ui_state* state)
       int dir_count = 0;
       int file_count = 0;
 
-      strcpy(entries[dir_count].name, "..");
+      pgmoneta_snprintf(entries[dir_count].name, sizeof(entries[dir_count].name),
+                        "%s", "..");
       entries[dir_count].is_dir = true;
       dir_count++;
 
@@ -4008,7 +4009,13 @@ show_wal_file_selector(struct ui_state* state)
          {
             if (S_ISDIR(st.st_mode))
             {
-               strcpy(temp_dirs[temp_dir_idx++], entry->d_name);
+               if (temp_dir_idx < (int)(sizeof(temp_dirs) / sizeof(temp_dirs[0])))
+               {
+                  pgmoneta_snprintf(temp_dirs[temp_dir_idx],
+                                    sizeof(temp_dirs[temp_dir_idx]), "%s",
+                                    entry->d_name);
+                  temp_dir_idx++;
+               }
             }
             else if (S_ISREG(st.st_mode))
             {
@@ -4029,7 +4036,14 @@ show_wal_file_selector(struct ui_state* state)
 
                   if (is_hex)
                   {
-                     strcpy(temp_files[temp_file_idx++], entry->d_name);
+                     if (temp_file_idx <
+                         (int)(sizeof(temp_files) / sizeof(temp_files[0])))
+                     {
+                        pgmoneta_snprintf(temp_files[temp_file_idx],
+                                          sizeof(temp_files[temp_file_idx]),
+                                          "%s", entry->d_name);
+                        temp_file_idx++;
+                     }
                   }
                }
             }
@@ -4044,9 +4058,10 @@ show_wal_file_selector(struct ui_state* state)
             if (strcmp(temp_dirs[i], temp_dirs[j]) > 0)
             {
                char tmp[256];
-               strcpy(tmp, temp_dirs[i]);
-               strcpy(temp_dirs[i], temp_dirs[j]);
-               strcpy(temp_dirs[j], tmp);
+               pgmoneta_snprintf(tmp, sizeof(tmp), "%s", temp_dirs[i]);
+               pgmoneta_snprintf(temp_dirs[i], sizeof(temp_dirs[i]), "%s",
+                                 temp_dirs[j]);
+               pgmoneta_snprintf(temp_dirs[j], sizeof(temp_dirs[j]), "%s", tmp);
             }
          }
       }
@@ -4058,23 +4073,31 @@ show_wal_file_selector(struct ui_state* state)
             if (strcmp(temp_files[i], temp_files[j]) > 0)
             {
                char tmp[256];
-               strcpy(tmp, temp_files[i]);
-               strcpy(temp_files[i], temp_files[j]);
-               strcpy(temp_files[j], tmp);
+               pgmoneta_snprintf(tmp, sizeof(tmp), "%s", temp_files[i]);
+               pgmoneta_snprintf(temp_files[i], sizeof(temp_files[i]), "%s",
+                                 temp_files[j]);
+               pgmoneta_snprintf(temp_files[j], sizeof(temp_files[j]), "%s",
+                                 tmp);
             }
          }
       }
 
-      for (int i = 0; i < temp_dir_idx; i++)
+      int entries_max = (int)(sizeof(entries) / sizeof(entries[0]));
+
+      for (int i = 0; i < temp_dir_idx && dir_count < entries_max; i++)
       {
-         strcpy(entries[dir_count].name, temp_dirs[i]);
+         pgmoneta_snprintf(entries[dir_count].name,
+                           sizeof(entries[dir_count].name), "%s", temp_dirs[i]);
          entries[dir_count].is_dir = true;
          dir_count++;
       }
 
-      for (int i = 0; i < temp_file_idx; i++)
+      for (int i = 0; i < temp_file_idx && dir_count + file_count < entries_max;
+           i++)
       {
-         strcpy(entries[dir_count + file_count].name, temp_files[i]);
+         pgmoneta_snprintf(entries[dir_count + file_count].name,
+                           sizeof(entries[dir_count + file_count].name), "%s",
+                           temp_files[i]);
          entries[dir_count + file_count].is_dir = false;
          file_count++;
       }


### PR DESCRIPTION
`show_wal_file_selector()` in `walinfo.c` collects a directory listing into fixed stack arrays and never checks the indices:

```c
char temp_dirs[999][256];
char temp_files[999][256];
int temp_dir_idx = 0;
int temp_file_idx = 0;

while ((entry = readdir(dir)) != NULL)
{
   ...
   strcpy(temp_dirs[temp_dir_idx++], entry->d_name);
   ...
   strcpy(temp_files[temp_file_idx++], entry->d_name);
}
```

Neither index is bounded, so a directory with more than 999 entries writes past the end of a stack array. The names themselves are fine — `d_name` is at most 255 bytes and the rows are 256 — it is the row count that is unchecked.

This is reachable in ordinary use rather than as a corner case: the files collected here are the ones whose first 24 characters are hex, which is exactly the WAL segment naming scheme, and a WAL archive of any age holds far more than 999 segments.

There is a third write with the same problem. `entries` holds 1000 rows, but the two copy loops after the scan can move up to 999 directories **and** 999 files into it, plus the `".."` entry added first:

```c
for (int i = 0; i < temp_dir_idx; i++)
{
   strcpy(entries[dir_count].name, temp_dirs[i]);
   ...
}
for (int i = 0; i < temp_file_idx; i++)
{
   strcpy(entries[dir_count + file_count].name, temp_files[i]);
   ...
}
```

So even with the first two bounded, the total can still reach 1999 rows in a 1000-row array.

This bounds all three. A listing larger than the arrays is truncated rather than overflowing; I kept the existing arrays and behaviour rather than moving to a dynamic listing, since that is a bigger change and you may prefer a different shape for it. Happy to do that instead if you would rather the browser showed everything.

## Verification

`clang -fsyntax-only -I src/include` is clean, and `clang-format` reports no changes — I checked that `walinfo.c` is format-clean upstream first, so this is not adding drift. I have not run the browser against a WAL directory of more than 999 segments, so the overflow is established by reading the bounds rather than by triggering it.
