### PR TITLE
Reap exited children when the event loop stops

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1002,6 +1002,15 @@ main(int argc, char** argv)
       ev_loop(main_loop, 0);
    }
 
+   /* sigchld_cb is an event watcher, so it stops running the moment the loop
+    * is broken. Any child exiting during the shutdown sequence below would
+    * therefore stay a zombie for the rest of the process's life. Reap what has
+    * already exited before starting it. */
+   while (waitpid(-1, NULL, WNOHANG) > 0)
+   {
+      ;
+   }
+
    pgmoneta_log_info("Shutdown");
 #ifdef HAVE_SYSTEMD
    sd_notify(0, "STOPPING=1");


### PR DESCRIPTION
Relates to #1143.

`sigchld_cb` is an `ev_signal` watcher, so it only runs while the event loop is running. `shutdown_cb` calls `ev_break(loop, EVBREAK_ALL)` straight away, and the loop is gone for the rest of `main()` — through `shutdown_management()`, `shutdown_metrics()`, `shutdown_nagios()`, `shutdown_console()`, `shutdown_mgt()`, `ev_loop_destroy()`, the frees, `remove_pidfile()`, `pgmoneta_stop_logging()` and both `pgmoneta_destroy_shared_memory()` calls. Nothing reaps on that path, so a child exiting during shutdown stays a zombie until the process finally returns.

This drains what has already exited, immediately after the loop stops.

**This is not the fix for #1143**, and I would rather not have it read as one. The `ps` output in that report shows a zombie next to a *running* `pgmoneta: main`, which is a zombie during normal operation — something this does not explain, since `sigchld_cb` should be reaping then. I raised that distinction on the issue on 2026-08-28 along with two questions that would separate the causes, and offered this piece separately; nobody objected, so here it is on its own. Happy to close it if you would rather keep everything in one change once the main cause is known.

## Verification

`clang -fsyntax-only -I src/include` is clean and `clang-format` reports no changes. `sys/wait.h` is already included. I have not reproduced the zombie state, so this is verified by reading the shutdown path rather than at runtime.
