### PR TITLE
doc: Add LibYAML dependency to build instructions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,3 +60,4 @@ Mostafa Mahmoud <mm1471800@gmail.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
 Krishna Lokhande <krishlokhande45@gmail.com>
 Loay Tarek <loaytareq44@gmail.com>
+Mohamed Sobea <mohameed.sobea@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Don't forget to indicate your pgmoneta version.
 You can use the follow command, if you are using a [Fedora](https://getfedora.org/) based platform:
 
 ```
-dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libasan libasan-static
+dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libyaml libyaml-devel libasan libasan-static
 ```
 
 in order to get the necessary dependencies.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ guide for first-run configuration once the package is installed.
 - [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
 - [libssh](https://www.libssh.org/)
 - [libarchive](http://www.libarchive.org/)
+- [LibYAML](https://pyyaml.org/wiki/LibYAML)
 - [rst2man](https://docutils.sourceforge.io/) (man pages)
 
 #### Optional dependencies (for building documentation)
@@ -116,7 +117,7 @@ dnf install git gcc clang clang-analyzer clang-tools-extra cmake make \
             systemd systemd-devel zlib zlib-devel \
             libzstd libzstd-devel lz4 lz4-devel \
             libssh libssh-devel python3-docutils libatomic \
-            bzip2 bzip2-devel libarchive libarchive-devel \
+            bzip2 bzip2-devel libarchive libarchive-devel libyaml libyaml-devel \
             libasan libasan-static
 ```
 

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -45,7 +45,7 @@ This will install PostgreSQL 17.
 #### Basic dependencies
 
 ``` sh
-dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libasan libasan-static
+dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libyaml libyaml-devel libasan libasan-static
 ```
 
 #### Generate user and developer guide

--- a/doc/DISTRIBUTIONS.md
+++ b/doc/DISTRIBUTIONS.md
@@ -21,7 +21,7 @@
 
 On Fedora, these can be installed using `dnf` or `yum`:
 ```
-dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libasan libasan-static pandoc texlive-scheme-basic 'tex(footnote.sty)' texlive-babel-spanish
+dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libyaml libyaml-devel libasan libasan-static pandoc texlive-scheme-basic 'tex(footnote.sty)' texlive-babel-spanish
 ```
 On Rocky, before you install the required packages, some additional repositories, CodeReady Builder and EPEL in this case, need to be enabled or installed first.
 ```

--- a/doc/manual/en/75-building.md
+++ b/doc/manual/en/75-building.md
@@ -11,7 +11,7 @@ The main build system is defined in [CMakeLists.txt][cmake_txt]. The flags for S
 Install the dependencies with
 
 ```sh
-dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libasan libasan-static
+dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libyaml libyaml-devel libasan libasan-static
 ```
 
 To build [**pgmoneta**][pgmoneta] in release mode:

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -67,6 +67,7 @@ Mostafa Mahmoud <mm1471800@gmail.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
 Krishna Lokhande <krishlokhande45@gmail.com>
 Loay Tarek <loaytareq44@gmail.com>
+Mohamed Sobea <mohameed.sobea@gmail.com> 
 ```
 
 ## Committers

--- a/doc/manual/es/75-building.md
+++ b/doc/manual/es/75-building.md
@@ -11,7 +11,7 @@ El sistema de compilación principal se define en [CMakeLists.txt][cmake_txt]. L
 Instala las dependencias con
 
 ```sh
-dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libasan libasan-static
+dnf install git gcc clang clang-analyzer clang-tools-extra cmake make libev libev-devel openssl openssl-devel systemd systemd-devel zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel libssh libssh-devel python3-docutils libatomic bzip2 bzip2-devel libarchive libarchive-devel libyaml libyaml-devel libasan libasan-static
 ```
 
 Para construir [**pgmoneta**][pgmoneta] en modo de release:

--- a/doc/manual/es/97-acknowledgement.md
+++ b/doc/manual/es/97-acknowledgement.md
@@ -64,6 +64,7 @@ Harshit Shaw <shawharshit116@gmail.com>
 Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 Mostafa Mahmoud <mm1471800@gmail.com>
+Mohamed Sobea <mohameed.sobea@gmail.com>
 ```
 
 ## Committers

--- a/pgmoneta.spec
+++ b/pgmoneta.spec
@@ -7,7 +7,7 @@ URL:           https://github.com/pgmoneta/pgmoneta
 Source0:       %{name}-%{version}.tar.gz
 
 BuildRequires: gcc cmake make python3-docutils zlib zlib-devel libzstd libzstd-devel lz4 lz4-devel bzip2 bzip2-devel ncurses-devel
-BuildRequires: libev libev-devel openssl openssl-devel systemd systemd-devel libssh libssh-devel libarchive libarchive-devel liburing-devel
+BuildRequires: libev libev-devel openssl openssl-devel systemd systemd-devel libssh libssh-devel libarchive libarchive-devel libyaml libyaml-devel liburing-devel
 Requires:      libev openssl systemd zlib libzstd lz4 bzip2 libssh libarchive liburing
 
 %description


### PR DESCRIPTION
Closes #1279

Adds the missing `LibYAML` package references.