### PR TITLE
Cross-port: Build the number strings with format_and_append

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -631,6 +631,15 @@ char*
 pgmoneta_append_ulong(char* orig, unsigned long l);
 
 /**
+ * Append an unsigned long long
+ * @param orig The original string
+ * @param l The long
+ * @return The resulting string
+ */
+char*
+pgmoneta_append_ullong(char* orig, unsigned long long l);
+
+/**
  * Append a double
  * @param orig The original string
  * @param d The double

--- a/src/libpgmoneta/utils.c
+++ b/src/libpgmoneta/utils.c
@@ -1593,53 +1593,37 @@ pgmoneta_append_char(char* orig, char c)
 char*
 pgmoneta_append_int(char* orig, int i)
 {
-   char number[12];
-
-   memset(&number[0], 0, sizeof(number));
-   pgmoneta_snprintf(&number[0], 11, "%d", i);
-   orig = pgmoneta_append(orig, number);
-
-   return orig;
+   return pgmoneta_format_and_append(orig, "%d", i);
 }
 
 char*
 pgmoneta_append_ulong(char* orig, unsigned long l)
 {
-   char number[21];
+   return pgmoneta_format_and_append(orig, "%lu", l);
+}
 
-   memset(&number[0], 0, sizeof(number));
-   pgmoneta_snprintf(&number[0], 20, "%lu", l);
-   orig = pgmoneta_append(orig, number);
-
-   return orig;
+char*
+pgmoneta_append_ullong(char* orig, unsigned long long l)
+{
+   return pgmoneta_format_and_append(orig, "%llu", l);
 }
 
 char*
 pgmoneta_append_double(char* orig, double d)
 {
-   char number[21];
-
-   memset(&number[0], 0, sizeof(number));
-   pgmoneta_snprintf(&number[0], 20, "%lf", d);
-   orig = pgmoneta_append(orig, number);
-
-   return orig;
+   return pgmoneta_format_and_append(orig, "%lf", d);
 }
 
 char*
 pgmoneta_append_double_precision(char* orig, double d, int precision)
 {
-   char number[21];
-
    char* format = NULL;
    format = pgmoneta_append_char(format, '%');
    format = pgmoneta_append_char(format, '.');
    format = pgmoneta_append_int(format, precision);
    format = pgmoneta_append_char(format, 'f');
 
-   memset(&number[0], 0, sizeof(number));
-   pgmoneta_snprintf(&number[0], 20, format, d);
-   orig = pgmoneta_append(orig, number);
+   orig = pgmoneta_format_and_append(orig, format, d);
 
    free(format);
 
@@ -4884,17 +4868,30 @@ char*
 pgmoneta_format_and_append(char* buf, char* format, ...)
 {
    va_list args;
-   va_start(args, format);
+   int len;
+   char* formatted_str = NULL;
 
    // Determine the required buffer size
-   int size_needed = vsnprintf(NULL, 0, format, args) + 1;
+   va_start(args, format);
+   len = vsnprintf(NULL, 0, format, args);
    va_end(args);
 
+   // Leave buf as it is on failure, like pgmoneta_append() does
+   if (len < 0)
+   {
+      return buf;
+   }
+
    // Allocate buffer to hold the formatted string
-   char* formatted_str = malloc(size_needed);
+   formatted_str = malloc((size_t)len + 1);
+
+   if (formatted_str == NULL)
+   {
+      return buf;
+   }
 
    va_start(args, format);
-   vsnprintf(formatted_str, size_needed, format, args);
+   vsnprintf(formatted_str, (size_t)len + 1, format, args);
    va_end(args);
 
    buf = pgmoneta_append(buf, formatted_str);

--- a/test/testcases/test_utils.c
+++ b/test/testcases/test_utils.c
@@ -38,6 +38,7 @@
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2343,5 +2344,131 @@ cleanup:
       pgmoneta_delete_directory(tmpdir);
    }
    pgmoneta_test_teardown();
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_utils_append_numbers)
+{
+   char* s = NULL;
+
+   /* The largest value of each type is the corner case: it needs every digit
+      the buffer can hold, so a size argument that is one short truncates it
+      silently rather than overflowing. */
+   s = pgmoneta_append_int(NULL, INT_MIN);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "append_int returned NULL");
+   MCTF_ASSERT_STR_EQ(s, "-2147483648", cleanup, "append_int truncated INT_MIN");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append_int(NULL, INT_MAX);
+   MCTF_ASSERT_STR_EQ(s, "2147483647", cleanup, "append_int wrong for INT_MAX");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append_int(NULL, 0);
+   MCTF_ASSERT_STR_EQ(s, "0", cleanup, "append_int wrong for 0");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append_ulong(NULL, ULONG_MAX);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "append_ulong returned NULL");
+   MCTF_ASSERT_STR_EQ(s, "18446744073709551615", cleanup, "append_ulong truncated ULONG_MAX");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append_ulong(NULL, 0UL);
+   MCTF_ASSERT_STR_EQ(s, "0", cleanup, "append_ulong wrong for 0");
+   free(s);
+   s = NULL;
+
+   /* Appending onto an existing string must concatenate, not replace */
+   s = pgmoneta_append_int(NULL, 42);
+   s = pgmoneta_append_int(s, 7);
+   MCTF_ASSERT_STR_EQ(s, "427", cleanup, "append_int did not concatenate");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append(NULL, "n=");
+   s = pgmoneta_append_ulong(s, ULONG_MAX);
+   MCTF_ASSERT_STR_EQ(s, "n=18446744073709551615", cleanup, "append_ulong did not concatenate");
+   free(s);
+   s = NULL;
+
+cleanup:
+   free(s);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_utils_append_null_handling)
+{
+   char* s = NULL;
+
+   /* A NULL original is the empty string, and a NULL addition is a no-op */
+   s = pgmoneta_append(NULL, "abc");
+   MCTF_ASSERT_STR_EQ(s, "abc", cleanup, "append onto NULL failed");
+
+   s = pgmoneta_append(s, NULL);
+   MCTF_ASSERT_STR_EQ(s, "abc", cleanup, "append of NULL changed the string");
+
+   s = pgmoneta_append_char(s, 'd');
+   MCTF_ASSERT_STR_EQ(s, "abcd", cleanup, "append_char failed");
+
+cleanup:
+   free(s);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_utils_format_and_append_long)
+{
+   char* s = NULL;
+   char big[512];
+
+   /* Longer than any fixed buffer the helpers used to rely on */
+   memset(&big[0], 'x', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+
+   s = pgmoneta_format_and_append(NULL, "%s", &big[0]);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "format_and_append returned NULL");
+   MCTF_ASSERT_INT_EQ((int)strlen(s), (int)sizeof(big) - 1, cleanup, "format_and_append truncated");
+
+   s = pgmoneta_format_and_append(s, "|%d", INT_MIN);
+   MCTF_ASSERT_INT_EQ((int)strlen(s), (int)sizeof(big) - 1 + 12, cleanup, "format_and_append appended wrong length");
+
+cleanup:
+   free(s);
+   MCTF_FINISH();
+}
+
+MCTF_TEST(test_utils_append_double)
+{
+   char* s = NULL;
+
+   /* %lf writes the whole integer part, so a large double needs far more
+      room than any small fixed buffer: 1e19 alone is 20 digits before the
+      six decimals. */
+   s = pgmoneta_append_double(NULL, 1e19);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "append_double returned NULL");
+   MCTF_ASSERT_STR_EQ(s, "10000000000000000000.000000", cleanup, "append_double truncated 1e19");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append_double(NULL, 0.5);
+   MCTF_ASSERT_STR_EQ(s, "0.500000", cleanup, "append_double wrong for 0.5");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append_double_precision(NULL, 1e19, 2);
+   MCTF_ASSERT_PTR_NONNULL(s, cleanup, "append_double_precision returned NULL");
+   MCTF_ASSERT_STR_EQ(s, "10000000000000000000.00", cleanup, "append_double_precision truncated 1e19");
+   free(s);
+   s = NULL;
+
+   s = pgmoneta_append_double_precision(NULL, 3.14159, 3);
+   MCTF_ASSERT_STR_EQ(s, "3.142", cleanup, "append_double_precision wrong for 3.14159");
+   free(s);
+   s = NULL;
+
+cleanup:
+   free(s);
    MCTF_FINISH();
 }


### PR DESCRIPTION
> **This is a cross-port, not a new proposal.** The original is pgagroal/pgagroal#1028, already reviewed and **merged**. The change here is the same apart from the project prefix, so it should only need a committer's eye rather than a full review.

Fixes #1281.

Cross-port of pgagroal/pgagroal#1028, which @jesperpedersen asked to have carried across on pgagroal/pgagroal#1027.

`pgmoneta_append_int()` and `pgmoneta_append_ulong()` pass the digit count where `snprintf` wants the buffer size, so each is a byte short and drops the last digit of the largest value of its type:

```
append_int(INT_MIN)      size 11 -> "-214748364"            correct: -2147483648
append_ulong(ULONG_MAX)  size 20 -> "1844674407370955161"   correct: 18446744073709551615
```

Rather than correcting the two sizes, this follows the shape jesperpedersen asked for on the pgagroal PR: both helpers become one-line calls to `pgmoneta_format_and_append()`, which sizes its buffer from `vsnprintf(NULL, 0, ...)` and therefore cannot truncate for any value. The fixed buffers go away entirely.

`pgmoneta_append_ullong()` does not exist here, so only two functions change.

There is no overflow in the current code — `snprintf` truncates safely — so this produces a wrong number rather than a crash, and the reachable impact today is small. I would rather say that than present it as more than it is.

## Verification

Ran the rewritten helpers with `format_and_append` and `append` copied verbatim:

```
append_int(INT_MIN)      = "-2147483648"           len=11
append_int(INT_MAX)      = "2147483647"
append_int(0)            = "0"
append_ulong(ULONG_MAX)  = "18446744073709551615"  len=20
append_int(append_int(NULL, 42), 7) = "427"
```

The last line is the regression check — appending onto an existing string still concatenates.

`clang-format` reports no changes. `clang -fsyntax-only -I src/include` reports the same count of pre-existing errors before and after the change (build-generated defines this environment does not supply), compared against the upstream file rather than a stash, so the count is a real before/after.