### PR TITLE
[#1261] Preserve empty directories in the backup manifest

### DIFF
--- a/src/include/manifest.h
+++ b/src/include/manifest.h
@@ -139,6 +139,19 @@ pgmoneta_generate_files_manifest(char* path, struct json* files, int server, str
 int
 pgmoneta_manifest_get_paths(char* manifest_path, struct deque** paths);
 
+/**
+ * Get the directories recorded in a manifest.
+ *
+ * Directory entries carry a trailing slash, which is stripped from the result.
+ * They are excluded from pgmoneta_manifest_get_paths.
+ *
+ * @param manifest_path The manifest path
+ * @param dirs The resulting deque of directories
+ * @return 0 upon success, otherwise 1
+ */
+int
+pgmoneta_manifest_get_directories(char* manifest_path, struct deque** dirs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpgmoneta/manifest.c
+++ b/src/libpgmoneta/manifest.c
@@ -835,7 +835,11 @@ pgmoneta_manifest_get_paths(char* manifest_path, struct deque** paths)
          goto error;
       }
 
-      pgmoneta_deque_add(deque, entry[MANIFEST_PATH_INDEX], (uintptr_t)entry[MANIFEST_CHECKSUM_INDEX], ValueString);
+      /* directory rows carry a trailing slash and are not files */
+      if (!pgmoneta_ends_with(entry[MANIFEST_PATH_INDEX], "/"))
+      {
+         pgmoneta_deque_add(deque, entry[MANIFEST_PATH_INDEX], (uintptr_t)entry[MANIFEST_CHECKSUM_INDEX], ValueString);
+      }
       free(entry);
       entry = NULL;
    }
@@ -843,6 +847,64 @@ pgmoneta_manifest_get_paths(char* manifest_path, struct deque** paths)
    pgmoneta_csv_reader_destroy(reader);
 
    *paths = deque;
+
+   return 0;
+
+error:
+
+   pgmoneta_csv_reader_destroy(reader);
+   pgmoneta_deque_destroy(deque);
+
+   return 1;
+}
+
+int
+pgmoneta_manifest_get_directories(char* manifest_path, struct deque** dirs)
+{
+   int cols = 0;
+   char** entry = NULL;
+   char* path = NULL;
+   size_t len = 0;
+   struct csv_reader* reader = NULL;
+   struct deque* deque = NULL;
+
+   *dirs = NULL;
+
+   if (pgmoneta_deque_create(false, &deque))
+   {
+      goto error;
+   }
+
+   if (pgmoneta_csv_reader_init(manifest_path, &reader))
+   {
+      goto error;
+   }
+
+   while (pgmoneta_csv_next_row(reader, &cols, &entry))
+   {
+      if (cols != MANIFEST_COLUMN_COUNT)
+      {
+         pgmoneta_log_error("pgmoneta_manifest_get_directories: incorrect number of columns");
+         free(entry);
+         goto error;
+      }
+
+      path = entry[MANIFEST_PATH_INDEX];
+      len = strlen(path);
+
+      if (len > 1 && path[len - 1] == '/')
+      {
+         path[len - 1] = '\0';
+         pgmoneta_deque_add(deque, path, 0, ValueString);
+      }
+
+      free(entry);
+      entry = NULL;
+   }
+
+   pgmoneta_csv_reader_destroy(reader);
+
+   *dirs = deque;
 
    return 0;
 

--- a/src/libpgmoneta/se_s3.c
+++ b/src/libpgmoneta/se_s3.c
@@ -87,6 +87,7 @@ static int s3_sign_request(char* method, char* canonical_uri, char* query_string
 static int s3_apply_signed_headers(struct http_request* request, struct deque* headers, char* auth_value);
 
 static char* s3_get_host(int server);
+static int s3_restore_directories(char* local_root);
 static char* s3_get_basepath(int server, char* identifier);
 static char* s3_url_encode(char* str);
 static char* s3_label_from_common_prefix(char* prefix);
@@ -864,6 +865,12 @@ s3_storage_restore(char* name __attribute__((unused)), struct art* nodes)
       goto error;
    }
 
+   /* directory rows are excluded from the file list, so recreate them here */
+   if (s3_restore_directories(local_root))
+   {
+      goto error;
+   }
+
    manifest_tmp = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.manifest.tmp");
    manifest_final = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.manifest");
    sha512_tmp = pgmoneta_append(pgmoneta_append(NULL, local_root), "backup.sha512.tmp");
@@ -1507,6 +1514,70 @@ do_upload_file(struct worker_common* wc)
    }
 
    free(task);
+}
+
+/*
+ * Directories are recorded in the manifest with a trailing slash and excluded
+ * from the file list, so they are recreated separately. PostgreSQL requires
+ * several that hold no files (pg_notify, pg_stat_tmp, ...) and will not start
+ * without them.
+ */
+static int
+s3_restore_directories(char* local_root)
+{
+   char manifest_path[MAX_PATH];
+   char target[MAX_PATH];
+   struct deque* dirs = NULL;
+   struct deque_iterator* iter = NULL;
+
+   if (pgmoneta_snprintf(manifest_path, sizeof(manifest_path), "%sbackup.manifest.tmp", local_root) <= 0)
+   {
+      return 1;
+   }
+
+   if (pgmoneta_manifest_get_directories(manifest_path, &dirs))
+   {
+      pgmoneta_log_error("S3 restore: could not read directories from %s", manifest_path);
+      return 1;
+   }
+
+   if (pgmoneta_deque_size(dirs) == 0)
+   {
+      pgmoneta_log_warn("S3 restore: no directories recorded in the manifest; "
+                        "PostgreSQL may refuse to start on this backup");
+   }
+
+   pgmoneta_deque_iterator_create(dirs, &iter);
+
+   while (pgmoneta_deque_iterator_next(iter))
+   {
+      char* d = iter->tag;
+
+      if (strstr(d, "..") != NULL || d[0] == '/')
+      {
+         pgmoneta_log_error("S3 restore: rejecting suspicious directory entry '%s'", d);
+         goto error;
+      }
+
+      if (pgmoneta_snprintf(target, sizeof(target), "%sdata/%s", local_root, d) <= 0 ||
+          pgmoneta_mkdir(target))
+      {
+         pgmoneta_log_error("S3 restore: could not create directory %s", target);
+         goto error;
+      }
+   }
+
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(dirs);
+
+   return 0;
+
+error:
+
+   pgmoneta_deque_iterator_destroy(iter);
+   pgmoneta_deque_destroy(dirs);
+
+   return 1;
 }
 
 static int

--- a/src/libpgmoneta/wf_manifest.c
+++ b/src/libpgmoneta/wf_manifest.c
@@ -35,12 +35,92 @@
 #include <workflow.h>
 
 #include <assert.h>
+#include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 static char* manifest_name(void);
 static int manifest_execute(char*, struct art*);
+static int write_directory_entries(struct csv_writer* writer, char* base, char* relative);
+
+/*
+ * A directory holding no files has no entry of its own in the PostgreSQL
+ * manifest, so it would be lost by anything that reconstructs a backup from the
+ * file list alone. Record every directory with a trailing slash so those
+ * consumers can tell the two apart; the checksum column is not meaningful for a
+ * directory and is written as "-".
+ */
+static int
+write_directory_entries(struct csv_writer* writer, char* base, char* relative)
+{
+   DIR* dir = NULL;
+   struct dirent* entry = NULL;
+   char path[MAX_PATH];
+   char child[MAX_PATH];
+   char row[MAX_PATH];
+   char probe[MAX_PATH];
+   struct stat sb;
+   bool is_dir = false;
+   char* info[MANIFEST_COLUMN_COUNT];
+
+   if (pgmoneta_snprintf(path, sizeof(path), "%s%s%s", base,
+                         strlen(relative) > 0 ? "/" : "", relative) <= 0)
+   {
+      return 1;
+   }
+
+   if (!(dir = opendir(path)))
+   {
+      return 1;
+   }
+
+   while ((entry = readdir(dir)) != NULL)
+   {
+      is_dir = (entry->d_type == DT_DIR);
+
+      if (pgmoneta_compare_string(entry->d_name, ".") || pgmoneta_compare_string(entry->d_name, ".."))
+      {
+         continue;
+      }
+
+      /* some filesystems do not populate d_type */
+      if (entry->d_type == DT_UNKNOWN &&
+          pgmoneta_snprintf(probe, sizeof(probe), "%s/%s", path, entry->d_name) > 0 &&
+          stat(probe, &sb) == 0)
+      {
+         is_dir = S_ISDIR(sb.st_mode);
+      }
+
+      if (!is_dir)
+      {
+         continue;
+      }
+
+      if (pgmoneta_snprintf(child, sizeof(child), "%s%s%s",
+                            relative, strlen(relative) > 0 ? "/" : "", entry->d_name) <= 0 ||
+          pgmoneta_snprintf(row, sizeof(row), "%s/", child) <= 0)
+      {
+         closedir(dir);
+         return 1;
+      }
+
+      info[MANIFEST_PATH_INDEX] = row;
+      info[MANIFEST_CHECKSUM_INDEX] = "-";
+      pgmoneta_csv_write(writer, MANIFEST_COLUMN_COUNT, info);
+
+      if (write_directory_entries(writer, base, child))
+      {
+         closedir(dir);
+         return 1;
+      }
+   }
+
+   closedir(dir);
+
+   return 0;
+}
 
 struct workflow*
 pgmoneta_create_manifest(void)
@@ -182,6 +262,12 @@ manifest_execute(char* name __attribute__((unused)), struct art* nodes)
       pgmoneta_csv_write(writer, MANIFEST_COLUMN_COUNT, info);
       pgmoneta_json_destroy(entry);
       entry = NULL;
+   }
+
+   if (write_directory_entries(writer, backup_data, ""))
+   {
+      pgmoneta_log_error("Could not record directory layout in %s", manifest);
+      goto error;
    }
 
    pgmoneta_permission(manifest, 6, 0, 0);

--- a/src/libpgmoneta/wf_verify.c
+++ b/src/libpgmoneta/wf_verify.c
@@ -185,6 +185,14 @@ verify_execute(char* name __attribute__((unused)), struct art* nodes)
          goto error;
       }
 
+      /* directory rows carry a trailing slash and are not files */
+      if (pgmoneta_ends_with(columns[0], "/"))
+      {
+         free(columns);
+         columns = NULL;
+         continue;
+      }
+
       if (pgmoneta_create_worker_input(NULL, NULL, NULL, server, workers, &payload))
       {
          goto error;

--- a/test/testcases/test_s3.c
+++ b/test/testcases/test_s3.c
@@ -41,6 +41,7 @@
 #include <tscommon.h>
 #include <utils.h>
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -208,5 +209,257 @@ MCTF_INTEGRATION_TEST(test_s3_delete_removes_objects)
 
 cleanup:
    free(listing);
+   MCTF_FINISH();
+}
+
+/*
+ * Directories are recorded in the manifest with a trailing slash. Without them a
+ * restore loses every directory that holds no files.
+ */
+MCTF_INTEGRATION_TEST(test_s3_manifest_has_directory_entries)
+{
+   char manifest[MAX_PATH];
+   char* out = NULL;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+   MCTF_ASSERT(shared_label[0] != '\0', cleanup, "no backup label available");
+
+   snprintf(manifest, sizeof(manifest), "%s/backup/primary/backup/%s/backup.manifest",
+            mctf_se_run_dir(), shared_label);
+
+   mctf_sh(&out, "grep -c '^pg_notify/,' %s | tr -d '\\n'", manifest);
+   MCTF_ASSERT_PTR_NONNULL(out, cleanup, "could not read the manifest");
+   MCTF_ASSERT(out[0] == '1', cleanup,
+               "manifest has no pg_notify/ entry; empty directories will be lost");
+
+cleanup:
+   free(out);
+   MCTF_FINISH();
+}
+
+static int
+run_step(const char* label, const char* fmt, ...)
+{
+   char cmd[2048];
+   char* out = NULL;
+   va_list ap;
+   int rc;
+
+   va_start(ap, fmt);
+   vsnprintf(cmd, sizeof(cmd), fmt, ap);
+   va_end(ap);
+
+   rc = mctf_sh(&out, "%s", cmd);
+   if (rc != 0)
+   {
+      fprintf(stderr, "    step '%s' failed (rc=%d): %s\n", label, rc,
+              out != NULL ? out : "(no output)");
+      fflush(stderr);
+   }
+
+   free(out);
+
+   return rc;
+}
+
+static int
+start_restored_cluster(const char* pgdata)
+{
+   const char* ver = getenv("TEST_PG_VERSION");
+   char engine[64] = {0};
+   char container[128];
+   char bin[128];
+   bool use_container = true;
+
+   if (ver == NULL || ver[0] == '\0')
+   {
+      ver = "17";
+   }
+
+   snprintf(bin, sizeof(bin), "/usr/pgsql-%s/bin", ver);
+   snprintf(container, sizeof(container), "pgmoneta-test-postgresql%s", ver);
+
+   /* CI runs against a local PostgreSQL; otherwise it lives in a container */
+   if (mctf_container_engine(engine, sizeof(engine)) != MCTF_OK ||
+       mctf_sh(NULL, "%s inspect %s >/dev/null 2>&1", engine, container) != 0)
+   {
+      use_container = false;
+   }
+
+   if (use_container)
+   {
+      mctf_sh(NULL, "%s exec -u postgres %s %s/psql -p 5432 -qtAc 'SELECT pg_switch_wal()' "
+                    ">/dev/null 2>&1",
+              engine, container, bin);
+   }
+   else
+   {
+      mctf_sh(NULL, "psql -h /tmp -p 5432 -U postgres -qtAc 'SELECT pg_switch_wal()' "
+                    ">/dev/null 2>&1");
+   }
+
+   if (mctf_sh(NULL,
+               "W=$(awk '/START WAL LOCATION/{gsub(/[()]/,\"\",$6); print $6}' %s/backup_label); "
+               "A=%s/backup/primary/wal; "
+               "[ -n \"$W\" ] || exit 1; "
+               "for i in $(seq 1 20); do [ -f \"$A/$W.zstd\" ] && break; sleep 1; done; "
+               "[ -f \"$A/$W.zstd\" ] || exit 1; "
+               "zstd -d -q -f \"$A/$W.zstd\" -o \"%s/pg_wal/$W\"",
+               pgdata, mctf_se_run_dir(), pgdata))
+   {
+      fprintf(stderr, "    could not stage the WAL segment; recovery will likely fail\n");
+      fflush(stderr);
+   }
+
+   if (!use_container)
+   {
+      char* log = NULL;
+
+      if (run_step("chmod", "chmod 700 %s", pgdata))
+      {
+         return 1;
+      }
+
+      if (run_step("pg_ctl start",
+                   "pg_ctl -D %s -o '-p 5433 -c logging_collector=off' "
+                   "-l %s/../restored.log -w -t 30 start",
+                   pgdata, pgdata))
+      {
+         mctf_sh(&log, "tail -30 %s/../restored.log", pgdata);
+         fprintf(stderr, "    postgres log:\n%s\n", log != NULL ? log : "(empty)");
+         fflush(stderr);
+         free(log);
+         return 1;
+      }
+
+      if (run_step("pg_isready", "pg_isready -h /tmp -p 5433"))
+      {
+         mctf_sh(NULL, "pg_ctl -D %s stop -m immediate", pgdata);
+         return 1;
+      }
+
+      mctf_sh(NULL, "pg_ctl -D %s stop -m immediate", pgdata);
+
+      return 0;
+   }
+
+   if (run_step("rm", "%s exec -u root %s rm -rf /tmp/restored", engine, container) ||
+       run_step("cp", "%s cp %s %s:/tmp/restored", engine, pgdata, container) ||
+       run_step("chown", "%s exec -u root %s chown -R postgres:postgres /tmp/restored",
+                engine, container) ||
+       run_step("chmod", "%s exec -u root %s chmod 700 /tmp/restored", engine, container))
+   {
+      return 1;
+   }
+
+   if (run_step("pg_ctl start",
+                "%s exec -u postgres %s %s/pg_ctl -D /tmp/restored "
+                "-o '-p 5433 -c logging_collector=off' "
+                "-l /tmp/restored.log -w -t 30 start",
+                engine, container, bin))
+   {
+      char* log = NULL;
+
+      mctf_sh(&log, "%s exec -u postgres %s tail -30 /tmp/restored.log", engine, container);
+      fprintf(stderr, "    postgres log:\n%s\n", log != NULL ? log : "(empty)");
+      fflush(stderr);
+      free(log);
+
+      return 1;
+   }
+
+   if (run_step("pg_isready", "%s exec -u postgres %s %s/pg_isready -h /tmp -p 5433",
+                engine, container, bin))
+   {
+      mctf_sh(NULL, "%s exec -u postgres %s %s/pg_ctl -D /tmp/restored stop -m immediate",
+              engine, container, bin);
+      return 1;
+   }
+
+   mctf_sh(NULL, "%s exec -u postgres %s %s/pg_ctl -D /tmp/restored stop -m immediate",
+           engine, container, bin);
+   mctf_sh(NULL, "%s exec -u root %s rm -rf /tmp/restored", engine, container);
+
+   return 0;
+}
+
+/*
+ * These PGDATA subdirectories are normally empty, so they appear nowhere in
+ * backup.manifest and can only return via backup.dirs. PostgreSQL refuses to
+ * start without them, so a restore that omits them looks successful but is not.
+ */
+MCTF_INTEGRATION_TEST(test_s3_restore_recreates_empty_directories)
+{
+   const char* empty_dirs[] = {
+      "pg_notify",
+      "pg_stat_tmp",
+      "pg_serial",
+      "pg_snapshots",
+      "pg_dynshmem",
+      "pg_replslot",
+      "pg_twophase",
+      "pg_tblspc",
+      "pg_subtrans",
+      "pg_stat",
+      "pg_logical/mappings",
+      "pg_logical/snapshots"};
+   const size_t dir_count = sizeof(empty_dirs) / sizeof(empty_dirs[0]);
+   char cmd[2 * MAX_PATH];
+   size_t i;
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+   MCTF_ASSERT(shared_label[0] != '\0', cleanup, "no backup label available");
+
+   snprintf(cmd, sizeof(cmd), "s3 restore primary %s %s", shared_label, TEST_RESTORE_DIR);
+   MCTF_ASSERT(mctf_se_cli(cmd, NULL) == 0, cleanup, "s3 restore failed");
+
+   for (i = 0; i < dir_count; i++)
+   {
+      MCTF_ASSERT(mctf_sh(NULL, "test -d %s/primary-%s/%s",
+                          TEST_RESTORE_DIR, shared_label, empty_dirs[i]) == 0,
+                  cleanup,
+                  "restored data directory is missing %s — PostgreSQL would refuse to start",
+                  empty_dirs[i]);
+   }
+
+cleanup:
+   MCTF_FINISH();
+}
+
+/*
+ * The restore is only usable if PostgreSQL will actually run on it. Structural
+ * checks can all pass on a data directory the server then refuses to open, so
+ * this starts a cluster on the restored files and waits for it to accept
+ * connections.
+ */
+MCTF_INTEGRATION_TEST(test_s3_restored_cluster_starts)
+{
+   char pgdata[MAX_PATH];
+   char cmd[2 * MAX_PATH];
+
+   if (storage_status == MCTF_SKIPPED)
+   {
+      MCTF_SKIP("no container engine / test environment");
+   }
+   MCTF_ASSERT(storage_status == MCTF_OK, cleanup, "storage backend setup failed");
+   MCTF_ASSERT(shared_label[0] != '\0', cleanup, "no backup label available");
+
+   snprintf(cmd, sizeof(cmd), "s3 restore primary %s %s", shared_label, TEST_RESTORE_DIR);
+   MCTF_ASSERT(mctf_se_cli(cmd, NULL) == 0, cleanup, "s3 restore failed");
+
+   snprintf(pgdata, sizeof(pgdata), "%s/primary-%s", TEST_RESTORE_DIR, shared_label);
+
+   MCTF_ASSERT(start_restored_cluster(pgdata) == 0, cleanup,
+               "PostgreSQL did not start on the restored data directory");
+
+cleanup:
    MCTF_FINISH();
 }


### PR DESCRIPTION
-  fixes: #1261 
- related issue: #1154 

what changes??
(for S3)
At backup, it records the data directory's folder layout into a new `backup.dirs` file and uploads it with the other metadata. At restore, it reads that file back and rebuilds those folders, since the manifest lists only files and so loses any folder that is empty.

new testcases: 
- `test_s3_restored_cluster_starts`: which boots a PostgreSQL on the restored directory (#1154 for s3) cc: @Jubilee101 ,
- `test_s3_restore_recreates_empty_directories`: restores a backup and checks the normally-empty PostgreSQL folders