### PR TITLE
[#1285] add track_commit_timestamp to setup documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ Rohan Mishra <kmrrohan29@gmail.com>
 Mostafa Mahmoud <mm1471800@gmail.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
 Krishna Lokhande <krishlokhande45@gmail.com>
+Loay Tarek <loaytareq44@gmail.com>

--- a/doc/DEVELOPERS.md
+++ b/doc/DEVELOPERS.md
@@ -231,6 +231,16 @@ i.e This is required only for PostgreSQL version 17 and above.
 summarize_wal = on
 ```
 
+#### Set track_commit_timestamp
+
+Set `track_commit_timestamp` value in `/tmp/pgsql/postgresql.conf` to be `on`
+
+``` sh
+track_commit_timestamp = on
+```
+
+pgmoneta requires `track_commit_timestamp` to be enabled for all PostgreSQL versions. If it is disabled the server is marked invalid, reported as `Online: false` in `pgmoneta-cli status details`, and backups fail.
+
 #### Start PostgreSQL
 
 ``` sh

--- a/doc/manual/en/02-installation.md
+++ b/doc/manual/en/02-installation.md
@@ -97,6 +97,7 @@ max_prepared_transactions = 100
 work_mem = 16MB
 dynamic_shared_memory_type = posix
 wal_level = replica
+track_commit_timestamp = on
 wal_log_hints = on
 max_wal_size = 16GB
 min_wal_size = 2GB

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -65,7 +65,8 @@ Ahmed Kamal <ahmedkamal200427@gmail.com>
 Rohan Mishra <kmrrohan29@gmail.com>
 Mostafa Mahmoud <mm1471800@gmail.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
-Krishna Lokhande <krishlokhande45@gmail.com> 
+Krishna Lokhande <krishlokhande45@gmail.com>
+Loay Tarek <loaytareq44@gmail.com>
 ```
 
 ## Committers


### PR DESCRIPTION
Closes #1285

Following the setup steps in doc/DEVELOPERS.md leaves track_commit_timestamp unset. 
and pgmoneta_server_info() (src/libpgmoneta/server.c) requires it unconditionally, so the server is marked invalid and backups fail with the server reported offline  with nothing pointing at the missing setting.

the changes that i have made:
-in doc/DEVELOPERS.md, i added a "Set track_commit_timestamp" step in the PostgreSQL configuration section, alongside the existing wal_level / summarize_wal steps.
-in doc/manual/en/02-installation.md, i added track_commit_timestamp = on to the postgresql.conf block.

note: the same install block is also missing summarize_wal, but i left it out because summarize_wal is PostgreSQL 17+ only and an unknown parameter is fatal at startup as i understand it, so adding it unqualified would break the PG13-16 setups the manual supports. 

maybe add it separately (commented, as the test fixtures do) if wanted.