### PR TITLE
Check the allocations in rfile.c

### DIFF
--- a/src/libpgmoneta/rfile.c
+++ b/src/libpgmoneta/rfile.c
@@ -117,6 +117,14 @@ pgmoneta_rfile_create(int server, char* label, char* relative_dir, char* base_fi
       goto error;
    }
    rf = (struct rfile*)malloc(sizeof(struct rfile));
+
+   if (rf == NULL)
+   {
+      pgmoneta_record_failure(failures, "rfile_create: could not allocate rfile for %s (label %s)", extracted_file_path, label);
+      fclose(fp);
+      goto error;
+   }
+
    memset(rf, 0, sizeof(struct rfile));
 
    rf->fp = fp;
@@ -221,6 +229,14 @@ pgmoneta_incremental_rfile_initialize(int server, char* label, char* relative_di
    if (rf->num_blocks > 0)
    {
       rf->relative_block_numbers = malloc(sizeof(uint32_t) * rf->num_blocks);
+
+      if (rf->relative_block_numbers == NULL)
+      {
+         pgmoneta_log_error("rfile initialize: could not allocate %u block numbers for %s%s", rf->num_blocks, relative_dir, base_file_name);
+         pgmoneta_record_failure(failures, "rfile_initialize: could not allocate block numbers for %s/%s (label %s)", relative_dir, base_file_name, label);
+         goto error;
+      }
+
       nread = fread(rf->relative_block_numbers, sizeof(uint32_t), rf->num_blocks, rf->fp);
       if (nread != rf->num_blocks)
       {


### PR DESCRIPTION
Fixes #1290.

`pgmoneta_rfile_create()` allocated the `rfile` and went straight into `memset`, and `pgmoneta_rfile_initialize()` passed an unchecked `malloc` result to `fread` as the destination.

The first one has a consequence beyond the null dereference. `fp` is an open handle by that point and only becomes owned by `rf` on the line *after* the `memset`, so the `error:` label cannot recover it — `pgmoneta_rfile_destroy()` returns immediately for a NULL `rf` and the descriptor leaks. The guard closes `fp` before taking the error path.

One thing I checked and found already correct, so it is not part of this: `rf->num_blocks` is read from the file header, but it is validated against `relsegsz` a few lines above the allocation, so a corrupt backup file cannot inflate the size. This is an ordinary allocation check, not an untrusted-size one.

Both are out-of-memory paths, so practical severity is low. Same class as #1246.

## Verification

Builds clean and `clang-format` reports no changes. I have not driven a real allocation failure through a restore, so this is verified by reading plus the compiler rather than at runtime.
