### PR TITLE
Report failure when sasl_prep cannot allocate

### DIFF
--- a/src/libpgmoneta/security.c
+++ b/src/libpgmoneta/security.c
@@ -2064,6 +2064,12 @@ sasl_prep(char* password, char** password_prep)
    }
 
    *password_prep = strdup(password);
+
+   if (*password_prep == NULL)
+   {
+      goto error;
+   }
+
    return 0;
 
 error:


### PR DESCRIPTION
Fixes #1293.

`sasl_prep()` returned 0 after `strdup` without checking it. Every other exit from that function reports failure when the output is unusable — the `error:` label sets `*password_prep = NULL` and returns 1 — so a caller that trusts the return value gets a NULL out-parameter while being told the call succeeded.

The NULL then travels three levels before anything touches it:

```
security.c:480   status = sasl_prep(password, &password_prep);
                 if (status) { goto error; }        <- status is 0, continues
security.c:548   client_proof(password_prep, ...)
security.c:2263  salted_password(password, ...)
security.c:2375  password_length = strlen(password);   <- NULL dereference
```

So an allocation failure during SCRAM authentication became a crash in `strlen` rather than a clean authentication failure.

This is an out-of-memory path, so the practical severity is low — the inconsistent contract is what makes it worth fixing rather than the likelihood.

## Verification

Builds clean and `clang-format` reports no changes. I have not driven a real allocation failure through an authentication handshake, so the call chain above is established by reading rather than at runtime.
