### PR TITLE
Bound the empty-read retry in read_complete

### DIFF
--- a/src/include/management.h
+++ b/src/include/management.h
@@ -45,6 +45,14 @@ extern "C" {
 /**
  * Management header
  */
+/**
+ * Number of 10ms retries read_complete() makes while the peer has sent
+ * nothing. 30000 is five minutes, which is long enough for a management
+ * command that takes a while to produce its outcome, and short enough that
+ * an unresponsive peer does not hold the caller forever.
+ */
+#define MANAGEMENT_READ_EMPTY_RETRIES    30000
+
 #define MANAGEMENT_COMPRESSION_UNKNOWN   -1
 #define MANAGEMENT_COMPRESSION_NONE      0
 #define MANAGEMENT_COMPRESSION_GZIP      1

--- a/src/libpgmoneta/management.c
+++ b/src/libpgmoneta/management.c
@@ -1679,10 +1679,12 @@ read_complete(SSL* ssl, int socket, void* buf, size_t size)
    size_t offset;
    size_t needs;
    int retries;
+   int empty_retries;
 
    offset = 0;
    needs = size;
    retries = 0;
+   empty_retries = 0;
 
 read:
    if (ssl == NULL)
@@ -1699,7 +1701,19 @@ read:
       if (errno == EAGAIN || errno == EWOULDBLOCK)
       {
          errno = 0;
-         goto read;
+
+         /* Nothing to read yet. Sleep before retrying, otherwise this is a
+            busy loop that spins a core for as long as the peer is quiet. */
+         SLEEP(10000000L);
+
+         if (empty_retries < MANAGEMENT_READ_EMPTY_RETRIES)
+         {
+            empty_retries++;
+            goto read;
+         }
+
+         errno = ETIMEDOUT;
+         goto error;
       }
 
       goto error;


### PR DESCRIPTION
Draft, as you suggested on #1295. The change is small; the number in it is the part worth arguing about.

`read_complete()` bounds one retry path but not the other. A short read sleeps 10ms and gives up after 100 tries. `EAGAIN` retried immediately, forever, with no counter and no sleep:

```c
if (errno == EAGAIN || errno == EWOULDBLOCK)
{
   errno = 0;
   goto read;
}
```

Against a connected but silent peer that is 5.4 million `read()` calls in 2 seconds, spinning a core until something else kills the process:

```
peer connected but silent, reading 1 byte:

  OLD: STILL SPINNING, cut off  -- 5442515 read() calls in 2.0s (busy spin, no sleep)
  NEW: returned 1 (ETIMEDOUT) after 20 retries in 0.29s
```

(The harness uses a scaled-down bound so it finishes quickly; the real one is 30000.)

## The number is the question

`read_complete()` reads the response header, and that header only arrives once the command has finished — so a backup can legitimately keep the caller waiting for minutes. Any bound here is therefore also a cap on how long a management command may take before the client gives up on it.

I picked 30000 x 10ms = five minutes as something clear of a slow command but still finite, and put it in `management.h` as `MANAGEMENT_READ_EMPTY_RETRIES` rather than burying a literal. I do not know your real upper bound for a backup on a large cluster, so this may be too low, and a per-command budget may be the better shape.

Three ways this could go, whichever you prefer:

1. **Keep the bound, change the number** — tell me what a backup can realistically take and I will set it.
2. **Sleep but do not bound.** This still fixes the CPU burn, which is unambiguous, and leaves the wait unbounded exactly as today. It would not fix a hang.
3. **Wait on the descriptor instead of polling it** — `poll()` on the socket rather than retrying `read()`. No arbitrary deadline and no spin, but a larger change to a shared path.

## On whether this is the CI hang

I do not claim it is. As I said on #1295, I have no stack trace from a hung runner and cannot reproduce the timeout locally. This is a real defect on its own — a busy loop with no exit — and fixing it is worthwhile regardless of what the CI turns out to be doing.

## Verification

Builds clean, `clang-format` quiet, `json` module passes 6/6. The `cli` module segfaults here both with and without this change, because it needs a live server that the CI containers provide and I do not have locally — so it is not evidence either way.
