### PR TITLE
Cross-port anonymous mmap fd fix from pgagroal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,3 +60,4 @@ Mostafa Mahmoud <mm1471800@gmail.com>
 R Sai Pranav <rajasaipranav0@gmail.com>
 Krishna Lokhande <krishlokhande45@gmail.com>
 Loay Tarek <loaytareq44@gmail.com>
+Abdulrahman Nader <a0xnader.oss@outlook.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -77,6 +77,7 @@ Haoran Zhang <andrewzhr9911@gmail.com>
 Luca Ferrari <fluca1978@gmail.com>
 Bassam Adnan <mailbassam@gmail.com>
 Tejas Tyagi <tejastyagi.tt@gmail.com>
+Abdulrahman Nader <a0xnader.oss@outlook.com>
 ```
 
 ## Contributing

--- a/src/libpgmoneta/shmem.c
+++ b/src/libpgmoneta/shmem.c
@@ -68,7 +68,7 @@ pgmoneta_create_shared_memory(size_t size, unsigned char hp, void** shmem)
    if (s == NULL)
    {
       visibility = MAP_ANONYMOUS | MAP_SHARED;
-      s = mmap(NULL, size, protection, visibility, 0, 0);
+      s = mmap(NULL, size, protection, visibility, -1, 0);
 
       if (s == (void*)-1)
       {


### PR DESCRIPTION
Use -1 instead of 0 as fd for the fallback anonymous mmap() in the shared memory creation function to match the initial call and fix portability on FreeBSD and OpenBSD, which require -1 for MAP_ANONYMOUS.

This cross-ports the fix from pgagroal PR 1044:
https://github.com/pgagroal/pgagroal/pull/1044

Update AUTHORS and doc/manual/en/97-acknowledgement.md.